### PR TITLE
Add minimal Firefox tabs helper extension

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -1,0 +1,18 @@
+# My Tabs Helper
+
+This is a minimal open source Firefox add-on inspired by the features of **All Tabs Helper**.
+
+## Features
+
+- Displays a list of all open tabs.
+- Search tabs by title or URL.
+- Activate, unload or close tabs from the list.
+- Move a tab to another open window if available.
+- Highlights duplicate tabs (tabs with the same URL).
+- Keyboard shortcut `Alt+Shift+H` to open the helper popup.
+
+To install for development, load the directory as a temporary add-on in Firefox.
+
+## License
+
+This example is provided under the MIT license.

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -1,0 +1,5 @@
+chrome.commands.onCommand.addListener((command) => {
+  if (command === 'open-tabs-helper') {
+    chrome.browserAction.openPopup();
+  }
+});

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 2,
+  "name": "My Tabs Helper",
+  "version": "0.1",
+  "description": "A simple tab management tool inspired by All Tabs Helper",
+  "permissions": [
+    "tabs",
+    "tabHide",
+    "storage",
+    "commands"
+  ],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
+  "browser_action": {
+    "default_title": "Tabs Helper",
+    "default_popup": "popup.html"
+  },
+  "commands": {
+    "open-tabs-helper": {
+      "suggested_key": {"default": "Alt+Shift+H"},
+      "description": "Open tab helper popup"
+    }
+  }
+}

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    body { font-family: sans-serif; margin: 0; padding: 0.5em; }
+    #search { width: 100%; }
+    #tabs { margin-top: 0.5em; max-height: 400px; overflow-y: auto; }
+    .tab { display: flex; align-items: center; margin-bottom: 0.2em; }
+    .tab-title { flex: 1; }
+    button { margin-left: 0.2em; }
+  </style>
+</head>
+<body>
+  <input type="text" id="search" placeholder="Search tabs" />
+  <div id="tabs"></div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1,0 +1,90 @@
+async function getTabs() {
+  const tabs = await browser.tabs.query({});
+  return tabs;
+}
+
+function createTabRow(tab, isDuplicate) {
+  const div = document.createElement('div');
+  div.className = 'tab';
+  if (isDuplicate) {
+    div.style.backgroundColor = '#fdd';
+  }
+
+  const title = document.createElement('span');
+  title.textContent = tab.title || tab.url;
+  title.className = 'tab-title';
+  div.appendChild(title);
+
+  const btnActivate = document.createElement('button');
+  btnActivate.textContent = 'Activate';
+  btnActivate.onclick = () => browser.tabs.update(tab.id, {active: true});
+  div.appendChild(btnActivate);
+
+  const btnUnload = document.createElement('button');
+  btnUnload.textContent = 'Unload';
+  btnUnload.onclick = () => browser.tabs.discard(tab.id);
+  div.appendChild(btnUnload);
+
+  const btnClose = document.createElement('button');
+  btnClose.textContent = 'Close';
+  btnClose.onclick = () => browser.tabs.remove(tab.id);
+  div.appendChild(btnClose);
+
+  const btnMove = document.createElement('button');
+  btnMove.textContent = 'Move';
+  btnMove.onclick = async () => {
+    const windows = await browser.windows.getAll({populate: false});
+    const other = windows.find(w => w.id !== tab.windowId);
+    if (other) {
+      await browser.tabs.move(tab.id, {windowId: other.id, index: -1});
+    }
+  };
+  div.appendChild(btnMove);
+
+  return div;
+}
+
+function renderTabs(tabs) {
+  const duplicates = findDuplicates(tabs);
+  const dupIds = new Set(duplicates.map(t => t.id));
+
+  const container = document.getElementById('tabs');
+  container.innerHTML = '';
+  for (const tab of tabs) {
+    const row = createTabRow(tab, dupIds.has(tab.id));
+    container.appendChild(row);
+  }
+}
+
+function filterTabs(tabs, query) {
+  const q = query.toLowerCase();
+  return tabs.filter(t => (t.title && t.title.toLowerCase().includes(q)) ||
+                         (t.url && t.url.toLowerCase().includes(q)));
+}
+
+function findDuplicates(tabs) {
+  const map = new Map();
+  const duplicates = [];
+  for (const tab of tabs) {
+    if (map.has(tab.url)) {
+      duplicates.push(tab);
+    } else {
+      map.set(tab.url, tab);
+    }
+  }
+  return duplicates;
+}
+
+async function update() {
+  let tabs = await getTabs();
+  const searchInput = document.getElementById('search');
+  const query = searchInput.value.trim();
+  if (query) {
+    tabs = filterTabs(tabs, query);
+  }
+  renderTabs(tabs);
+}
+
+document.getElementById('search').addEventListener('input', update);
+
+document.addEventListener('DOMContentLoaded', update);


### PR DESCRIPTION
## Summary
- add example Firefox extension named *My Tabs Helper*
- list tabs, search by text, activate, unload, close, move, and highlight duplicates
- include keyboard shortcut for quick access
- document usage and features

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843646bae348331944bcfcdc1f6a533