### PR TITLE
Remove redundant permission

### DIFF
--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -6,8 +6,7 @@
   "permissions": [
     "tabs",
     "tabHide",
-    "storage",
-    "commands"
+    "storage"
   ],
   "background": {
     "scripts": ["background.js"],


### PR DESCRIPTION
## Summary
- remove `commands` from `permissions` array in extension manifest

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843aa921c0c8331a8fed7f726c70f0c