### PR TITLE
Add context menu with version info

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -43,3 +43,11 @@ browser.commands.onCommand.addListener((command) => {
     browser.tabs.create({ url: browser.runtime.getURL('full.html') });
   }
 });
+
+browser.runtime.onInstalled.addListener(() => {
+  browser.contextMenus.create({
+    id: 'show-version',
+    title: `My Tabs Helper v${browser.runtime.getManifest().version}`,
+    contexts: ['browser_action']
+  });
+});

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -6,7 +6,8 @@
   "permissions": [
     "tabs",
     "tabHide",
-    "storage"
+    "storage",
+    "contextMenus"
   ],
   "background": {
     "scripts": [


### PR DESCRIPTION
## Summary
- add `contextMenus` permission
- create context menu on extension icon that shows extension version

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b0dfe6e8833186ec5b984e98ea9b