### PR TITLE
Add hover highlight for tabs

### DIFF
--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -10,6 +10,7 @@
     .tab-title { flex: 1; }
     .tab.active { background-color: #eef; font-weight: bold; }
     .tab:focus { outline: 1px solid #888; }
+    .tab:hover { background-color: #ffd; }
     #error { color: red; }
     button { margin-left: 0.2em; }
   </style>

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -10,6 +10,7 @@
     .tab-title { flex: 1; }
     .tab.active { background-color: #eef; font-weight: bold; }
     .tab:focus { outline: 1px solid #888; }
+    .tab:hover { background-color: #ffd; }
     #error { color: red; }
     button { margin-left: 0.2em; }
   </style>

--- a/mytabs/sidebar.html
+++ b/mytabs/sidebar.html
@@ -10,6 +10,7 @@
     .tab-title { flex: 1; }
     .tab.active { background-color: #eef; font-weight: bold; }
     .tab:focus { outline: 1px solid #888; }
+    .tab:hover { background-color: #ffd; }
     #error { color: red; }
     button { margin-left: 0.2em; }
   </style>


### PR DESCRIPTION
## Summary
- highlight tab rows when hovered

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6843b1ac85608331b979962653c9c42b