### PR TITLE
Add tab counters in popup

### DIFF
--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -5,6 +5,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <div id="counts">Total: <span id="total-count">0</span> | Active: <span id="active-count">0</span></div>
   <div id="menu">
     <button id="btn-all">All</button>
     <button id="btn-recent">Recent</button>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -176,6 +176,9 @@ function findDuplicates(tabs) {
 
 async function update() {
   const allTabs = await browser.tabs.query({ currentWindow: true });
+  document.getElementById('total-count').textContent = allTabs.length;
+  const activeCount = allTabs.filter(t => !t.discarded).length;
+  document.getElementById('active-count').textContent = activeCount;
   let tabs = await getTabs();
   const dupIds = new Set(findDuplicates(allTabs).map(t => t.id));
   const current = await browser.tabs.query({ currentWindow: true, active: true });

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -34,6 +34,9 @@ body[data-theme="dark"] #context {
 #menu {
   margin-bottom: 0.5em;
 }
+#counts {
+  margin-bottom: 0.5em;
+}
 #menu button {
   margin-right: 0.2em;
 }


### PR DESCRIPTION
## Summary
- show total and active tab counts above the filter buttons
- style new counts section
- update counts whenever popup UI refreshes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843b7cedfd88331a1de09bbbd0b3eff