### PR TITLE
Add context menu actions for tabs

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -30,6 +30,9 @@ body[data-theme="dark"] #context {
   background: #444;
   border-color: #555;
 }
+body[data-theme="dark"] #context div:hover {
+  background: #555;
+}
 
 #menu {
   margin-bottom: 0.5em;
@@ -92,6 +95,15 @@ button {
   border: 1px solid #ccc;
   padding: 0.2em;
   z-index: 1000;
+}
+
+#context div {
+  padding: 0.2em 0.5em;
+  cursor: pointer;
+}
+
+#context div:hover {
+  background: #ddd;
 }
 
 #bulk-actions {


### PR DESCRIPTION
## Summary
- remove per-tab action buttons
- add custom context menu for tab actions
- style context menu items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843b846f750833196284d04ebcc99e8