### PR TITLE
Remember tab list scroll position

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1,4 +1,22 @@
 let view = 'all';
+let restored = false;
+
+function saveScroll() {
+  const container = document.getElementById('tabs');
+  if (container) {
+    browser.storage.local.set({ scrollTop: container.scrollTop });
+  }
+}
+
+async function restoreScroll() {
+  if (restored) return;
+  const { scrollTop = 0 } = await browser.storage.local.get('scrollTop');
+  const container = document.getElementById('tabs');
+  if (container) {
+    container.scrollTop = scrollTop;
+  }
+  restored = true;
+}
 
 async function getTabs() {
   const currentWin = await browser.windows.getCurrent();
@@ -216,9 +234,15 @@ document.addEventListener('keydown', (e) => {
   }
 });
 
-document.addEventListener('DOMContentLoaded', update);
+async function init() {
+  document.getElementById('tabs').addEventListener('scroll', saveScroll);
+  await update();
+  restoreScroll();
+}
+
+document.addEventListener('DOMContentLoaded', init);
 if (document.readyState !== 'loading') {
-  update();
+  init();
 }
 
 // custom context menu


### PR DESCRIPTION
## Summary
- preserve scroll position in the popup/sidebar list by storing it in browser storage

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843b8dbe144833181eb6831283c0ccf