### PR TITLE
Improve multi-select keyboard support

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -129,7 +129,11 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
 
   div.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') {
-      activateTab(tab.id);
+      if (!e.ctrlKey && !e.metaKey && !e.shiftKey) {
+        activateTab(tab.id);
+      } else {
+        e.preventDefault();
+      }
     }
   });
 
@@ -234,17 +238,39 @@ document.addEventListener('keydown', (e) => {
   const tabs = Array.from(document.querySelectorAll('.tab'));
   if (!tabs.length) return;
   if (document.activeElement.tagName === 'INPUT') return;
-  let idx = tabs.indexOf(document.activeElement);
-  if (e.key === 'ArrowDown') {
+  const focused = document.activeElement;
+  const isTab = focused.classList.contains('tab');
+  let idx = tabs.indexOf(focused);
+
+  const moveFocus = (delta) => {
+    const newIdx = Math.min(Math.max(idx + delta, 0), tabs.length - 1);
+    tabs[newIdx].focus();
+    idx = newIdx;
+    return newIdx;
+  };
+
+  if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
     e.preventDefault();
-    idx = (idx + 1) % tabs.length;
-    tabs[idx].focus();
-  } else if (e.key === 'ArrowUp') {
+    const oldIdx = idx;
+    const newIdx = moveFocus(e.key === 'ArrowDown' ? 1 : -1);
+    if (e.shiftKey && isTab) {
+      if (lastSelectedIndex === -1) lastSelectedIndex = oldIdx;
+      const start = Math.min(lastSelectedIndex, newIdx);
+      const end = Math.max(lastSelectedIndex, newIdx);
+      tabs.forEach((t, i) => updateSelection(t, i >= start && i <= end));
+    } else if (!e.ctrlKey && !e.metaKey) {
+      tabs.forEach(t => updateSelection(t, false));
+      updateSelection(tabs[newIdx], true);
+      lastSelectedIndex = newIdx;
+    } else {
+      lastSelectedIndex = newIdx;
+    }
+  } else if (e.key === ' ' && isTab) {
     e.preventDefault();
-    idx = (idx - 1 + tabs.length) % tabs.length;
-    tabs[idx].focus();
-  } else if (e.key === 'Enter' && document.activeElement.classList.contains('tab')) {
-    document.activeElement.click();
+    updateSelection(focused, !focused.querySelector('.sel').checked);
+    lastSelectedIndex = tabs.indexOf(focused);
+  } else if (e.key === 'Enter' && isTab && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+    focused.click();
   }
 });
 


### PR DESCRIPTION
## Summary
- support selecting rows with keyboard navigation
- prevent tab activation when Enter is pressed with modifier keys

## Testing
- `node -c mytabs/popup.js`


------
https://chatgpt.com/codex/tasks/task_e_6843be439a1083318984c988adba6cdc