### PR TITLE
Fix shift-click deselection bug

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -126,8 +126,9 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
       if (e.shiftKey && lastSelectedIndex !== -1) {
         const start = Math.min(lastSelectedIndex, idx);
         const end = Math.max(lastSelectedIndex, idx);
+        const select = !check.checked;
         for (let i = start; i <= end; i++) {
-          updateSelection(tabs[i], true);
+          updateSelection(tabs[i], select);
         }
       } else {
         updateSelection(div, !check.checked);


### PR DESCRIPTION
## Summary
- handle deselecting ranges when using shift-click

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6843c23204f88331944c0ba95a8c700f