### PR TITLE
Fix sidebar auto-opening on install

### DIFF
--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -21,7 +21,8 @@
   },
   "sidebar_action": {
     "default_title": "Tabs",
-    "default_panel": "sidebar.html"
+    "default_panel": "sidebar.html",
+    "open_at_install": false
   },
   "options_ui": {
     "page": "options.html",


### PR DESCRIPTION
## Summary
- update manifest to prevent sidebar opening on installation

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684431fe22508331afca47aa9e1ccfe0