### PR TITLE
Implement middle-click full view

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -16,6 +16,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Options page lets you choose theme and grid columns.
 - A dark theme can be enabled from the options page.
 - Keyboard shortcuts open the popup, sidebar and full view.
+- Middle-clicking the toolbar icon opens the multi-column Full View window.
 
 To install for development, load the directory as a temporary add-on in Firefox.
 

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -54,6 +54,13 @@ function openFullView() {
   });
 }
 
+// Open the multi-column tab manager when the icon is middle-clicked.
+browser.browserAction.onClicked.addListener((tab, info) => {
+  if (info && info.button === 1) {
+    openFullView();
+  }
+});
+
 browser.commands.onCommand.addListener((command) => {
   if (command === 'open-tabs-helper') {
     browser.browserAction.openPopup();


### PR DESCRIPTION
## Summary
- open full view window when extension icon is middle-clicked
- document the new behavior in the extension README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68443c4286c0833189fd27bc12f36513