### PR TITLE
Enhance full view with multi-column layout

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -10,6 +10,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Visited tabs are highlighted so you can quickly spot new pages.
 - Double click a tab to search its page content and highlight results.
 - Perform bulk operations (close, reload, unload, move) on selected tabs.
+- Each tab row includes a button to quickly close that tab.
 - Tabs can be reordered via drag and drop.
 - A **Full View** window shows tabs in a multi-column grid.
 - Custom context menu reveals extension version.

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -4,10 +4,26 @@
   <meta charset="utf-8" />
   <link rel="stylesheet" href="style.css" />
 </head>
-  <body>
-    <div id="grid"></div>
+  <body class="full">
+    <div id="counts">Total: <span id="total-count">0</span> | Active: <span id="active-count">0</span></div>
+    <div id="menu">
+      <button id="btn-all">All</button>
+      <button id="btn-recent">Recent</button>
+      <button id="btn-dups">Duplicates</button>
+    </div>
+    <input type="text" id="search" placeholder="Search tabs" />
+    <div id="error"></div>
+    <div id="tabs"></div>
+    <div id="bulk-actions">
+      <button id="bulk-close">Close</button>
+      <button id="bulk-reload">Reload</button>
+      <button id="bulk-discard">Unload</button>
+      <button id="bulk-move">Move</button>
+    </div>
+    <div id="context" class="hidden"></div>
 
     <script src="theme.js"></script>
+    <script src="popup.js"></script>
     <script src="full.js"></script>
   </body>
 </html>

--- a/mytabs/full.js
+++ b/mytabs/full.js
@@ -1,15 +1,5 @@
-async function load(){
-  const {cols=3} = await browser.storage.local.get('cols');
+async function load() {
+  const { cols = 3 } = await browser.storage.local.get('cols');
   document.documentElement.style.setProperty('--cols', cols);
-  // Query tabs across all open windows
-  const tabs = await browser.tabs.query({});
-  const grid = document.getElementById('grid');
-  for(const t of tabs){
-    const c=document.createElement('div');
-    c.className='cell';
-    c.textContent=t.title||t.url;
-    c.onclick=()=>browser.tabs.update(t.id,{active:true});
-    grid.appendChild(c);
-  }
 }
 load();

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -152,6 +152,16 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
   title.className = 'tab-title';
   div.appendChild(title);
 
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = '×';
+  closeBtn.title = 'Close tab';
+  closeBtn.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    await browser.tabs.remove(tab.id);
+    scheduleUpdate();
+  });
+  div.appendChild(closeBtn);
+
 
   div.addEventListener('dragstart', (e) => {
     e.dataTransfer.setData('text/plain', tab.id);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -151,3 +151,25 @@ button {
   color: #888;
   margin-top: 1em;
 }
+
+/* Layout tweaks for full view */
+body.full {
+  width: auto;
+}
+body.full #tabs {
+  display: grid;
+  grid-template-columns: repeat(var(--cols, 3), 1fr);
+  gap: 0.5em;
+  max-height: 80vh;
+  overflow: auto;
+}
+body.full #counts,
+body.full #menu {
+  position: sticky;
+  top: 0;
+  background: inherit;
+  z-index: 1;
+}
+body.full .tab {
+  border: 1px solid #ddd;
+}


### PR DESCRIPTION
## Summary
- overhaul `full.html` to reuse popup layout
- update `full.js` to just apply column settings
- add close button to each tab row
- style full view grid layout and sticky header
- document new close button feature

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844b749a0648331ad3529f1906c41ae