### PR TITLE
Fix full view grid responsiveness

### DIFF
--- a/mytabs/full.js
+++ b/mytabs/full.js
@@ -1,7 +1,8 @@
 async function setColumns() {
-  const { cols = 3 } = await browser.storage.local.get('cols');
+  // Determine columns purely from window width so the grid
+  // automatically expands to fill the available space.
   const minWidth = 250;
-  const computed = Math.max(1, Math.min(cols, Math.floor(window.innerWidth / minWidth)));
+  const computed = Math.max(1, Math.floor(window.innerWidth / minWidth));
   document.documentElement.style.setProperty('--cols', computed);
 }
 


### PR DESCRIPTION
## Summary
- adjust column calculation in `full.js` so the grid auto-expands with the window

## Testing
- `node -e "require('./tab/mytabs/full.js')"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6845110f69888331be0ec686345fd93c