### PR TITLE
Add unloadAllTabs feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # My Tabs Helper
 
-This repository contains the source code for **My Tabs Helper**, a simple Firefox extension for managing open tabs. The add-on provides quick filtering, duplicate detection, a full grid view and optional dark theme. The popup lists tabs from the current window while the full view shows tabs from every open Firefox window. See the `mytabs` directory for the extension files.
+This repository contains the source code for **My Tabs Helper**, a simple Firefox extension for managing open tabs. The add-on provides quick filtering, duplicate detection, a full grid view and optional dark theme. The popup lists tabs from the current window while the full view shows tabs from every open Firefox window. A keyboard shortcut can unload all open tabs to free memory. See the `mytabs` directory for the extension files.

--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -9,7 +9,8 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Highlights duplicate tabs and provides a dedicated **Duplicates** view.
 - Visited tabs are highlighted so you can quickly spot new pages.
 - Double click a tab to search its page content and highlight results.
-- Perform bulk operations (close, reload, unload, move) on selected tabs.
+- Perform bulk operations (close, reload, unload, move) on selected tabs, and a
+  command to unload all tabs at once.
 - Each tab row includes a button to quickly close that tab.
 - Tabs can be reordered via drag and drop.
 - A **Full View** window shows tabs in a multi-column grid.

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -58,6 +58,15 @@ function openFullView() {
   });
 }
 
+async function unloadAllTabs() {
+  const tabs = await browser.tabs.query({});
+  for (const t of tabs) {
+    if (!t.discarded) {
+      try { await browser.tabs.discard(t.id); } catch (_) {}
+    }
+  }
+}
+
 // Open the multi-column tab manager when the icon is middle-clicked.
 browser.browserAction.onClicked.addListener((tab, info) => {
   if (info && info.button === 1) {
@@ -70,6 +79,8 @@ browser.commands.onCommand.addListener((command) => {
     browser.browserAction.openPopup();
   } else if (command === 'open-tabs-helper-full') {
     browser.tabs.create({ url: browser.runtime.getURL('full.html') });
+  } else if (command === 'unload-all-tabs') {
+    unloadAllTabs();
   }
 });
 

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -18,6 +18,7 @@
       <button id="bulk-close">Close</button>
       <button id="bulk-reload">Reload</button>
       <button id="bulk-discard">Unload</button>
+      <button id="bulk-unload-all">Unload All</button>
       <button id="bulk-move">Move</button>
     </div>
     <div id="context" class="hidden"></div>

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -36,6 +36,10 @@
     "open-tabs-helper-full": {
       "suggested_key": {"default": "Alt+Shift+F"},
       "description": "Open tab helper in full view"
+    },
+    "unload-all-tabs": {
+      "suggested_key": {"default": "Alt+Shift+U"},
+      "description": "Unload all tabs"
     }
   },
   "content_scripts": [

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -18,6 +18,7 @@
     <button id="bulk-close">Close</button>
     <button id="bulk-reload">Reload</button>
     <button id="bulk-discard">Unload</button>
+    <button id="bulk-unload-all">Unload All</button>
     <button id="bulk-move">Move</button>
   </div>
   <div id="context" class="hidden"></div>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -368,8 +368,12 @@ function showContextMenu(e) {
   }
 
   if (!tabEl && !selected.length) {
-    context.textContent = `My Tabs Helper v${browser.runtime.getManifest().version}`;
+    const info = document.createElement('div');
+    info.textContent = `My Tabs Helper v${browser.runtime.getManifest().version}`;
+    context.appendChild(info);
   }
+
+  addItem('Unload All Tabs', bulkUnloadAll);
 
   context.style.left = e.pageX + 'px';
   context.style.top = e.pageY + 'px';
@@ -404,6 +408,14 @@ async function bulkDiscard() {
   scheduleUpdate();
 }
 
+async function bulkUnloadAll() {
+  const tabs = await browser.tabs.query({});
+  for (const t of tabs) {
+    await browser.tabs.discard(t.id);
+  }
+  scheduleUpdate();
+}
+
 async function bulkMove() {
   const ids = getSelectedTabIds();
   const windows = await browser.windows.getAll({populate: false});
@@ -425,6 +437,9 @@ if (bulkReloadBtn) bulkReloadBtn.addEventListener('click', bulkReload);
 
 const bulkDiscardBtn = document.getElementById('bulk-discard');
 if (bulkDiscardBtn) bulkDiscardBtn.addEventListener('click', bulkDiscard);
+
+const bulkUnloadAllBtn = document.getElementById('bulk-unload-all');
+if (bulkUnloadAllBtn) bulkUnloadAllBtn.addEventListener('click', bulkUnloadAll);
 
 const moveBtn = document.getElementById('bulk-move');
 if (MOVE_ENABLED && moveBtn) moveBtn.addEventListener('click', bulkMove);


### PR DESCRIPTION
## Summary
- add "Unload All" buttons to popup and full views
- support new `unload-all-tabs` command in manifest and background script
- implement `bulkUnloadAll` handling in popup
- document new feature in the readmes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684511c868808331803d63b3f4b8bbff