### PR TITLE
Enhance full view behavior

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -47,15 +47,23 @@ browser.runtime.onMessage.addListener((msg) => {
   }
 });
 
-function openFullView() {
-  browser.windows.create({
+async function openFullView() {
+  const { fullSize } = await browser.storage.local.get('fullSize');
+  const createData = {
     url: browser.runtime.getURL('full.html'),
     type: 'popup'
-  }).then(win => {
-    if (win && win.id) {
-      browser.windows.update(win.id, { state: 'maximized' });
+  };
+  if (fullSize) {
+    if (typeof fullSize.width === 'number' && typeof fullSize.height === 'number') {
+      createData.width = fullSize.width;
+      createData.height = fullSize.height;
     }
-  });
+    if (typeof fullSize.left === 'number' && typeof fullSize.top === 'number') {
+      createData.left = fullSize.left;
+      createData.top = fullSize.top;
+    }
+  }
+  await browser.windows.create(createData);
 }
 
 async function unloadAllTabs() {

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -21,6 +21,7 @@
 
     <script src="theme.js"></script>
     <script src="popup.js"></script>
+    <script src="fullwin.js"></script>
     <!-- grid layout now handled purely via CSS -->
   </body>
 </html>

--- a/mytabs/fullwin.js
+++ b/mytabs/fullwin.js
@@ -1,0 +1,21 @@
+(async function(){
+  const { fullSize } = await browser.storage.local.get('fullSize');
+  if (fullSize && typeof fullSize.width === 'number' && typeof fullSize.height === 'number') {
+    try {
+      window.resizeTo(fullSize.width, fullSize.height);
+      if (typeof fullSize.left === 'number' && typeof fullSize.top === 'number') {
+        window.moveTo(fullSize.left, fullSize.top);
+      }
+    } catch (_) {}
+  }
+
+  window.addEventListener('unload', () => {
+    const data = {
+      width: window.outerWidth,
+      height: window.outerHeight,
+      left: window.screenX,
+      top: window.screenY
+    };
+    browser.storage.local.set({ fullSize: data });
+  });
+})();

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -183,8 +183,13 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
     const fromId = parseInt(e.dataTransfer.getData('text/plain'), 10);
     const toId = parseInt(div.dataset.tab, 10);
     if (fromId !== toId) {
+      const fromTab = await browser.tabs.get(fromId);
       const toTab = await browser.tabs.get(toId);
-      await browser.tabs.move(fromId, {windowId: toTab.windowId, index: toTab.index});
+      let index = toTab.index + 1;
+      if (fromTab.windowId === toTab.windowId && fromTab.index < toTab.index) {
+        index = toTab.index;
+      }
+      await browser.tabs.move(fromId, { windowId: toTab.windowId, index });
       scheduleUpdate();
     }
   });


### PR DESCRIPTION
## Summary
- store last window bounds when closing full view
- restore stored size when opening the full view popup
- tweak drag-drop logic so tabs drop below the target

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68458f6c3a9083318f36195fae9132ae