### PR TITLE
Adjust drag behavior to always drop after card

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -201,17 +201,9 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
 
   div.addEventListener('dragover', (e) => {
     e.preventDefault();
-    const rect = div.getBoundingClientRect();
-    let before;
-    if (document.body.classList.contains('full')) {
-      const dx = e.clientX - (rect.left + rect.width / 2);
-      const dy = e.clientY - (rect.top + rect.height / 2);
-      before = Math.abs(dx) > Math.abs(dy) ? dx < 0 : dy < 0;
-    } else {
-      before = e.clientY < rect.top + rect.height / 2;
-    }
-    div.dataset.dropBefore = before ? '1' : '0';
-    showPlaceholder(div, before);
+    // always drop after the hovered card
+    div.dataset.dropBefore = '0';
+    showPlaceholder(div, false);
   });
 
   div.addEventListener('drop', async (e) => {
@@ -222,18 +214,10 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
     if (fromId !== toId) {
       const fromTab = await browser.tabs.get(fromId);
       const toTab = await browser.tabs.get(toId);
-      const rect = div.getBoundingClientRect();
-      let before;
-      if (document.body.classList.contains('full')) {
-        const dx = e.clientX - (rect.left + rect.width / 2);
-        const dy = e.clientY - (rect.top + rect.height / 2);
-        before = Math.abs(dx) > Math.abs(dy) ? dx < 0 : dy < 0;
-      } else {
-        before = e.clientY < rect.top + rect.height / 2;
-      }
-      let index = before ? toTab.index : toTab.index + 1;
+      // always position the moved tab after the hovered card
+      let index = toTab.index + 1;
       if (fromTab.windowId === toTab.windowId && fromTab.index < toTab.index) {
-        index = before ? toTab.index - 1 : toTab.index;
+        index = toTab.index;
       }
       if (index < 0) index = 0;
       await browser.tabs.move(fromId, { windowId: toTab.windowId, index });


### PR DESCRIPTION
## Summary
- fix dragover handling so cards always drop under the hovered tab
- simplify drop handler to insert the dragged tab after the target

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684596858b1c83318a41b812dab07760