### PR TITLE
Improve drag logic and remove Move button in full view

### DIFF
--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -15,7 +15,7 @@
     <div id="error"></div>
     <div id="tabs"></div>
     <div id="bulk-actions">
-      <button id="bulk-move">Move</button>
+      
     </div>
     <div id="context" class="hidden"></div>
 

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -244,9 +244,17 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
 
   div.addEventListener('dragover', (e) => {
     e.preventDefault();
-    // always drop after the hovered card
-    div.dataset.dropBefore = '0';
-    showPlaceholder(div, false);
+    const rect = div.getBoundingClientRect();
+    let before;
+    if (document.body.classList.contains('full')) {
+      const dx = e.clientX - (rect.left + rect.width / 2);
+      const dy = e.clientY - (rect.top + rect.height / 2);
+      before = Math.abs(dx) > Math.abs(dy) ? dx < 0 : dy < 0;
+    } else {
+      before = e.clientY < rect.top + rect.height / 2;
+    }
+    div.dataset.dropBefore = before ? '1' : '0';
+    showPlaceholder(div, before);
   });
 
   div.addEventListener('drop', async (e) => {
@@ -257,10 +265,18 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
     if (fromId !== toId) {
       const fromTab = await browser.tabs.get(fromId);
       const toTab = await browser.tabs.get(toId);
-      // always position the moved tab after the hovered card
-      let index = toTab.index + 1;
+      const rect = div.getBoundingClientRect();
+      let before;
+      if (document.body.classList.contains('full')) {
+        const dx = e.clientX - (rect.left + rect.width / 2);
+        const dy = e.clientY - (rect.top + rect.height / 2);
+        before = Math.abs(dx) > Math.abs(dy) ? dx < 0 : dy < 0;
+      } else {
+        before = e.clientY < rect.top + rect.height / 2;
+      }
+      let index = before ? toTab.index : toTab.index + 1;
       if (fromTab.windowId === toTab.windowId && fromTab.index < toTab.index) {
-        index = toTab.index;
+        index = before ? toTab.index - 1 : toTab.index;
       }
       if (index < 0) index = 0;
       await browser.tabs.move(fromId, { windowId: toTab.windowId, index });


### PR DESCRIPTION
## Summary
- remove the Move bulk-action button from `full.html`
- restore pointer-based drop logic for tab drag operations so reordering feels natural

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68459887d81083318a5d61b43ea16e2f