### PR TITLE
Add options shortcut in context menu

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -14,7 +14,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Each tab row includes a button to quickly close that tab.
 - Tabs can be reordered via drag and drop.
 - A **Full View** window shows tabs in a multi-column grid.
-- Custom context menu reveals extension version.
+ - Custom context menu reveals extension version and links to the Options page.
 - Options page lets you choose theme, grid columns and toggle features such as
   the Recent and Duplicates panels or the Move command.
 - A dark theme can also be enabled from the options page.

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -98,4 +98,15 @@ browser.runtime.onInstalled.addListener(() => {
     title: `My Tabs Helper v${browser.runtime.getManifest().version}`,
     contexts: ['browser_action']
   });
+  browser.contextMenus.create({
+    id: 'open-options',
+    title: 'Options',
+    contexts: ['browser_action']
+  });
+});
+
+browser.contextMenus.onClicked.addListener((info) => {
+  if (info.menuItemId === 'open-options') {
+    browser.runtime.openOptionsPage();
+  }
 });


### PR DESCRIPTION
## Summary
- add `open-options` item to the extension context menu
- explain new context menu feature in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684598a3015c83318357e02169fc62ec