### PR TITLE
Improve drag placeholder

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -8,25 +8,23 @@ let MOVE_ENABLED = true;
 
 let lastSelectedIndex = -1;
 let container; // tabs container cached after DOM load
-let placeholder = null;
+let dropTarget = null;
 
 function clearPlaceholder() {
-  if (placeholder && placeholder.parentNode) {
-    placeholder.parentNode.removeChild(placeholder);
+  if (dropTarget) {
+    dropTarget.classList.remove('drop-before', 'drop-after');
+    dropTarget = null;
   }
-  placeholder = null;
 }
 
 function showPlaceholder(target, before) {
-  if (!placeholder) {
-    placeholder = document.createElement("div");
-    placeholder.className = "drop-placeholder";
+  if (dropTarget === target &&
+      target.classList.contains(before ? 'drop-before' : 'drop-after')) {
+    return;
   }
-  if (before) {
-    target.parentNode.insertBefore(placeholder, target);
-  } else {
-    target.parentNode.insertBefore(placeholder, target.nextSibling);
-  }
+  clearPlaceholder();
+  dropTarget = target;
+  dropTarget.classList.add(before ? 'drop-before' : 'drop-after');
 }
 
 function throttle(fn) {
@@ -238,8 +236,6 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
   div.addEventListener('dragstart', (e) => {
     e.dataTransfer.setData('text/plain', tab.id);
     clearPlaceholder();
-    placeholder = document.createElement('div');
-    placeholder.className = 'drop-placeholder';
   });
 
   div.addEventListener('dragover', (e) => {
@@ -253,7 +249,6 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
     } else {
       before = e.clientY < rect.top + rect.height / 2;
     }
-    div.dataset.dropBefore = before ? '1' : '0';
     showPlaceholder(div, before);
   });
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -84,13 +84,17 @@ body[data-theme="dark"] #context div:hover {
   outline: 1px solid #888;
 }
 
-.drop-placeholder {
-  border-top: 2px solid #39f;
-  margin: 0 0.2em;
+.tab.drop-before {
+  box-shadow: inset 0 2px 0 #39f;
 }
-
-body[data-theme="dark"] .drop-placeholder {
-  border-color: #9af;
+.tab.drop-after {
+  box-shadow: inset 0 -2px 0 #39f;
+}
+body[data-theme="dark"] .tab.drop-before {
+  box-shadow: inset 0 2px 0 #9af;
+}
+body[data-theme="dark"] .tab.drop-after {
+  box-shadow: inset 0 -2px 0 #9af;
 }
 .tab-title {
   flex: 1;


### PR DESCRIPTION
## Summary
- polish drag/drop behaviour in popup
- show visual lines instead of placeholder elements

## Testing
- `node --check mytabs/popup.js`


------
https://chatgpt.com/codex/tasks/task_e_684599b0b87c83319312d5b1f3a04c72