### PR TITLE
Fix drag reorder handling in grid view

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -241,14 +241,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
   div.addEventListener('dragover', (e) => {
     e.preventDefault();
     const rect = div.getBoundingClientRect();
-    let before;
-    if (document.body.classList.contains('full')) {
-      const dx = e.clientX - (rect.left + rect.width / 2);
-      const dy = e.clientY - (rect.top + rect.height / 2);
-      before = Math.abs(dx) > Math.abs(dy) ? dx < 0 : dy < 0;
-    } else {
-      before = e.clientY < rect.top + rect.height / 2;
-    }
+    const before = e.clientY < rect.top + rect.height / 2;
     showPlaceholder(div, before);
   });
 
@@ -261,14 +254,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
       const fromTab = await browser.tabs.get(fromId);
       const toTab = await browser.tabs.get(toId);
       const rect = div.getBoundingClientRect();
-      let before;
-      if (document.body.classList.contains('full')) {
-        const dx = e.clientX - (rect.left + rect.width / 2);
-        const dy = e.clientY - (rect.top + rect.height / 2);
-        before = Math.abs(dx) > Math.abs(dy) ? dx < 0 : dy < 0;
-      } else {
-        before = e.clientY < rect.top + rect.height / 2;
-      }
+      const before = e.clientY < rect.top + rect.height / 2;
       let index = before ? toTab.index : toTab.index + 1;
       if (fromTab.windowId === toTab.windowId && fromTab.index < toTab.index) {
         index = before ? toTab.index - 1 : toTab.index;


### PR DESCRIPTION
## Summary
- simplify drag position detection when reordering tabs

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845e87887008331a62f24c13937fad1