### PR TITLE
Move filter buttons to left

### DIFF
--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -5,11 +5,13 @@
   <link rel="stylesheet" href="style.css" />
 </head>
   <body class="full">
-    <div id="counts">Total: <span id="total-count">0</span> | Active: <span id="active-count">0</span></div>
-    <div id="menu">
-      <button id="btn-all">All</button>
-      <button id="btn-recent">Recent</button>
-      <button id="btn-dups">Duplicates</button>
+    <div id="top-bar">
+      <div id="menu">
+        <button id="btn-all">All</button>
+        <button id="btn-recent">Recent</button>
+        <button id="btn-dups">Duplicates</button>
+      </div>
+      <div id="counts">Total: <span id="total-count">0</span> | Active: <span id="active-count">0</span></div>
     </div>
     <input type="text" id="search" placeholder="Search tabs" />
     <div id="error"></div>

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -219,19 +219,28 @@ body.full #tabs {
   max-height: none;
   overflow-y: auto;
 }
-body.full #counts,
-body.full #menu {
+body.full #top-bar {
   position: sticky;
   top: 0;
   background: inherit;
   z-index: 1;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   padding: 0.3em 0;
+  gap: 1em;
+}
+body.full #counts {
+  margin: 0;
+  font-weight: bold;
+}
+body.full #menu {
+  display: flex;
+  gap: 0.5em;
+  padding: 0;
 }
 body.full #menu button {
-  flex: 1 1 auto;
+  flex: none;
 }
 body.full .tab {
   border: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary
- reorder counts and buttons so filters are on the left
- tweak CSS so the top bar contents stay left-aligned

## Testing
- `npm test` *(fails: ENOENT because package.json is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846c7560bf883318d4a331a65baee4c