### PR TITLE
Fix recent tab filtering

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -122,7 +122,7 @@ async function getTabs(allTabs) {
     const result = [];
     let currentWin = null;
     if (!document.body.classList.contains('full')) {
-      currentWin = await browser.windows.getCurrent();
+      currentWin = await browser.windows.getLastFocused({windowTypes: ['normal']});
     }
     for (const id of recent) {
       try {


### PR DESCRIPTION
## Summary
- fix fetching current Firefox window when listing recent tabs

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684733e12a4c8331b8d906d758092475