### PR TITLE
Remove unused cols setting

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -8,7 +8,6 @@
   --color-muted: #888;
   --tile-width: 250px;
   --tile-scale: 1;
-  --cols: 3;
 }
 
 body {

--- a/mytabs/theme.js
+++ b/mytabs/theme.js
@@ -1,12 +1,11 @@
 (async function(){
-  let { theme = 'light', tileWidth = 250, tileScale = 1, cols = 3 } = await browser.storage.local.get(['theme','tileWidth','tileScale','cols']);
+  let { theme = 'light', tileWidth = 250, tileScale = 1 } = await browser.storage.local.get(['theme','tileWidth','tileScale']);
 
   function apply(){
     document.body.dataset.theme = theme;
     const width = tileWidth * tileScale;
     document.documentElement.style.setProperty('--tile-width', width + 'px');
     document.documentElement.style.setProperty('--tile-scale', tileScale);
-    document.documentElement.style.setProperty('--cols', cols);
     if (document.body.classList.contains('full')) {
       document.body.style.removeProperty('width');
     }
@@ -19,7 +18,6 @@
       if (changes.theme) theme = changes.theme.newValue;
       if (changes.tileWidth) tileWidth = changes.tileWidth.newValue;
       if (changes.tileScale) tileScale = changes.tileScale.newValue;
-      if (changes.cols) cols = changes.cols.newValue;
       apply();
     }
   });


### PR DESCRIPTION
## Summary
- drop `cols` setting from the theme script
- remove default `--cols` CSS variable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847350e20bc8331b829e58d18707f63