### PR TITLE
Add numeric field for tile scale

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -17,7 +17,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   - Custom context menu reveals extension version and links to the Options page.
   - The mouse wheel scrolls the tab list even when the pointer is over the menu or search field.
   - Scroll speed can be adjusted from the Options page to make scrolling more aggressive.
-- Options page lets you choose theme, column count and tile width and toggle features such as
+- Options page lets you choose theme, tile width and **tile scale** with numeric values and toggle features such as
   the Recent and Duplicates panels or the Move command.
 - A dark theme can also be enabled from the options page.
 - Keyboard shortcuts open the popup, sidebar and full view.

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -10,7 +10,6 @@
       <button id="btn-all">All</button>
       <button id="btn-recent">Recent</button>
       <button id="btn-dups">Duplicates</button>
-      <input type="range" id="fullScale" min="0.5" max="2" step="0.1" />
     </div>
     <input type="text" id="search" placeholder="Search tabs" />
     <div id="error"></div>

--- a/mytabs/fullwin.js
+++ b/mytabs/fullwin.js
@@ -28,21 +28,6 @@
     document.documentElement.style.setProperty('--cols', cols);
   }
 
-  const scaleInput = document.getElementById('fullScale');
-  if (scaleInput) {
-    scaleInput.value = tileScale;
-    scaleInput.addEventListener('input', () => {
-      const scale = parseFloat(scaleInput.value) || 1;
-      const style = getComputedStyle(document.documentElement);
-      const baseWidth = (parseInt(style.getPropertyValue('--tile-width'), 10) || 250) /
-                       (parseFloat(style.getPropertyValue('--tile-scale')) || 1);
-      browser.storage.local.set({ tileScale: scale });
-      document.documentElement.style.setProperty('--tile-width',
-        (baseWidth * scale) + 'px');
-      document.documentElement.style.setProperty('--tile-scale', scale);
-      updateCols();
-    });
-  }
 
   window.addEventListener('resize', updateCols);
   updateCols();

--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -10,7 +10,7 @@
   <br>
   <label>Tile Width (px): <input type="number" id="tileWidth" min="100" max="600" value="250"></label>
   <br>
-  <label>Tile Scale: <input type="range" id="tileScale" min="0.5" max="2" step="0.1" value="1"></label>
+  <label>Tile Scale: <input type="number" id="tileScale" min="0.5" max="2" step="0.1" value="1"></label>
   <br>
   <label>Scroll Speed: <input type="number" id="scrollSpeed" min="0.5" step="0.1" value="1"></label>
   <br>


### PR DESCRIPTION
## Summary
- change Tile Scale option to a numeric input
- remove the scale slider from Full View
- update full window script and README

## Testing
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684732ec04dc8331b6b33efeb2ff1808