### PR TITLE
Update extension to MV3

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -95,7 +95,7 @@ async function unloadAllTabs() {
 }
 
 // Open the multi-column tab manager when the icon is middle-clicked.
-browser.browserAction.onClicked.addListener((tab, info) => {
+browser.action.onClicked.addListener((tab, info) => {
   if (info && info.button === 1) {
     openFullView();
   }
@@ -103,7 +103,7 @@ browser.browserAction.onClicked.addListener((tab, info) => {
 
 browser.commands.onCommand.addListener((command) => {
   if (command === 'open-tabs-helper') {
-    browser.browserAction.openPopup();
+    browser.action.openPopup();
   } else if (command === 'open-tabs-helper-full') {
     browser.tabs.create({ url: browser.runtime.getURL('full.html') });
   } else if (command === 'unload-all-tabs') {
@@ -111,16 +111,16 @@ browser.commands.onCommand.addListener((command) => {
   }
 });
 
-browser.runtime.onInstalled.addListener(() => {
-  browser.contextMenus.create({
+browser.runtime.onInstalled.addListener(async () => {
+  await browser.contextMenus.create({
     id: 'show-version',
     title: `KepiTAB v${browser.runtime.getManifest().version}`,
-    contexts: ['browser_action']
+    contexts: ['action']
   });
-  browser.contextMenus.create({
+  await browser.contextMenus.create({
     id: 'open-options',
     title: 'Options',
-    contexts: ['browser_action']
+    contexts: ['action']
   });
 });
 

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "KepiTAB",
   "version": "0.2",
   "description": "A simple tab management tool inspired by All Tabs Helper",
@@ -10,12 +10,9 @@
     "contextMenus"
   ],
   "background": {
-    "scripts": [
-      "background.js"
-    ],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "browser_action": {
+  "action": {
     "default_title": "KepiTAB",
     "default_popup": "popup.html"
   },


### PR DESCRIPTION
## Summary
- migrate to manifest_version 3 and use a service worker
- replace browserAction with action API
- update context menu registration for MV3

## Testing
- `web-ext lint --boring` *(fails: Manifest field unsupported and extension ID required)*
- `web-ext build --overwrite-dest --artifacts-dir ../build`

------
https://chatgpt.com/codex/tasks/task_e_68473e53268083318929953617810255