### PR TITLE
Fix visited status for undiscarded tabs

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -72,6 +72,8 @@ browser.tabs.onRemoved.addListener((tabId) => {
 browser.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.discarded === true) {
     unmarkVisited(tabId);
+  } else if (changeInfo.discarded === false) {
+    markVisited(tabId);
   }
 });
 


### PR DESCRIPTION
## Summary
- ensure tabs regain 'visited' status when reloaded from discard state

## Testing
- `node --check mytabs/background.js`

------
https://chatgpt.com/codex/tasks/task_e_68473f86ef4c833180fc5c8df0580958