### PR TITLE
Switch to manifest v2 API

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -116,7 +116,7 @@ async function unloadAllTabs() {
 }
 
 // Open the multi-column tab manager when the icon is middle-clicked.
-browser.action.onClicked.addListener((tab, info) => {
+browser.browserAction.onClicked.addListener((tab, info) => {
   if (info && info.button === 1) {
     openFullView();
   }
@@ -124,7 +124,7 @@ browser.action.onClicked.addListener((tab, info) => {
 
 browser.commands.onCommand.addListener((command) => {
   if (command === 'open-tabs-helper') {
-    browser.action.openPopup();
+    browser.browserAction.openPopup();
   } else if (command === 'open-tabs-helper-full') {
     browser.tabs.create({ url: browser.runtime.getURL('full.html') });
   } else if (command === 'unload-all-tabs') {
@@ -136,12 +136,12 @@ browser.runtime.onInstalled.addListener(async () => {
   await browser.contextMenus.create({
     id: 'show-version',
     title: `KepiTAB v${browser.runtime.getManifest().version}`,
-    contexts: ['action']
+    contexts: ['browser_action']
   });
   await browser.contextMenus.create({
     id: 'open-options',
     title: 'Options',
-    contexts: ['action']
+    contexts: ['browser_action']
   });
 });
 

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "KepiTAB",
   "version": "0.2",
   "description": "A simple tab management tool inspired by All Tabs Helper",
@@ -9,10 +9,8 @@
     "storage",
     "contextMenus"
   ],
-  "background": {
-    "service_worker": "background.js"
-  },
-  "action": {
+  "background": { "scripts": ["background.js"] },
+  "browser_action": {
     "default_title": "KepiTAB",
     "default_popup": "popup.html"
   },


### PR DESCRIPTION
## Summary
- update manifest to version 2
- move service worker to background script
- rename `action` to `browser_action`
- update background script API calls

## Testing
- `web-ext lint`
- `web-ext run --firefox=firefox --no-input --args="--headless"` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68474265e36083318d1186eccfbe4341