### PR TITLE
Update column layout on option change

### DIFF
--- a/mytabs/fullwin.js
+++ b/mytabs/fullwin.js
@@ -28,6 +28,11 @@
     document.documentElement.style.setProperty('--cols', cols);
   }
 
+  browser.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local' && (changes.tileWidth || changes.tileScale)) {
+      updateCols();
+    }
+  });
 
   window.addEventListener('resize', updateCols);
   updateCols();


### PR DESCRIPTION
## Summary
- listen for storage changes in `fullwin.js`
- recalc columns when tile width or scale changes

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6847704f92e08331aa7b90197dc52d54