### PR TITLE
Add color variable for visited tabs

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -6,6 +6,7 @@
   --color-active: #eef5ff;
   --color-selected: #dceaff;
   --color-muted: #888;
+  --color-visited: #f0fff0;
   --tile-width: 200px;
   --tile-scale: 0.9;
 }
@@ -30,6 +31,7 @@ body[data-theme="dark"] {
   --color-active: #335577;
   --color-selected: #224466;
   --color-muted: #aaa;
+  --color-visited: #304030;
   background: var(--color-bg);
   color: var(--color-text);
 }
@@ -193,7 +195,7 @@ button:hover {
 }
 
 .visited {
-  background: #f0fff0;
+  background: var(--color-visited);
   font-weight: bold;
 }
 


### PR DESCRIPTION
## Summary
- define `--color-visited` in `:root`
- hook `.visited` style to `--color-visited`
- assign a darker value for `--color-visited` in dark mode

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6847702f9ea0833199aa547654f81f80