### PR TITLE
Add close button scaling option

### DIFF
--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -14,6 +14,8 @@
   <br>
   <label>Font Scale: <input type="number" id="fontScale" min="0.5" max="2" step="0.1" value="0.9"></label>
   <br>
+  <label>Close Button Scale: <input type="number" id="closeScale" min="0.5" max="2" step="0.1" value="1"></label>
+  <br>
   <label>Scroll Speed: <input type="number" id="scrollSpeed" min="0.5" step="0.1" value="1"></label>
   <br>
   <label><input type="checkbox" id="opt-show-recent" checked> Show Recent panel</label>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -1,10 +1,16 @@
 async function load(){
-  const {theme='light', tileWidth=200, tileScale=0.9, fontScale=0.9, scrollSpeed=1, showRecent=true, showDuplicates=true, enableMove=true} =
-    await browser.storage.local.get(['theme','tileWidth','tileScale','fontScale','scrollSpeed','showRecent','showDuplicates','enableMove']);
+  const data = await browser.storage.local.get(['theme','tileWidth','tileScale','fontScale','closeScale','scrollSpeed','showRecent','showDuplicates','enableMove']);
+  const {theme='light', tileWidth=200, tileScale=0.9, fontScale=0.9, scrollSpeed=1, showRecent=true, showDuplicates=true, enableMove=true} = data;
+  let closeScale = data.closeScale;
+  if (closeScale === undefined) {
+    closeScale = 1;
+    browser.storage.local.set({ closeScale });
+  }
   document.getElementById('theme').value = theme;
   document.getElementById('tileWidth').value = tileWidth;
   document.getElementById('tileScale').value = tileScale;
   document.getElementById('fontScale').value = fontScale;
+  document.getElementById('closeScale').value = closeScale;
   document.getElementById('scrollSpeed').value = scrollSpeed;
   document.getElementById('opt-show-recent').checked = showRecent;
   document.getElementById('opt-show-dups').checked = showDuplicates;
@@ -12,17 +18,19 @@ async function load(){
   document.documentElement.style.setProperty('--tile-width', (tileWidth * tileScale) + 'px');
   document.documentElement.style.setProperty('--tile-scale', tileScale);
   document.documentElement.style.setProperty('--font-scale', fontScale);
+  document.documentElement.style.setProperty('--close-scale', closeScale);
 }
 async function save(){
   const theme=document.getElementById('theme').value;
   const tileWidth=parseInt(document.getElementById('tileWidth').value,10);
   const tileScale=parseFloat(document.getElementById('tileScale').value);
   const fontScale=parseFloat(document.getElementById('fontScale').value);
+  const closeScale=parseFloat(document.getElementById('closeScale').value);
   const scrollSpeed=parseFloat(document.getElementById('scrollSpeed').value);
   const showRecent=document.getElementById('opt-show-recent').checked;
   const showDuplicates=document.getElementById('opt-show-dups').checked;
   const enableMove=document.getElementById('opt-enable-move').checked;
-  await browser.storage.local.set({theme, tileWidth, tileScale, fontScale, scrollSpeed, showRecent, showDuplicates, enableMove});
+  await browser.storage.local.set({theme, tileWidth, tileScale, fontScale, closeScale, scrollSpeed, showRecent, showDuplicates, enableMove});
 }
 
 function updateWidth(){
@@ -47,6 +55,12 @@ function updateFont(){
   document.documentElement.style.setProperty('--font-scale', fontScale);
 }
 
+function updateCloseScale(){
+  const closeScale=parseFloat(document.getElementById('closeScale').value);
+  browser.storage.local.set({closeScale});
+  document.documentElement.style.setProperty('--close-scale', closeScale);
+}
+
 function updateScroll(){
   const scrollSpeed=parseFloat(document.getElementById('scrollSpeed').value);
   browser.storage.local.set({scrollSpeed});
@@ -55,6 +69,7 @@ function updateScroll(){
 const elTileWidth = document.getElementById('tileWidth');
 const elTileScale = document.getElementById('tileScale');
 const elFontScale = document.getElementById('fontScale');
+const elCloseScale = document.getElementById('closeScale');
 const elScrollSpeed = document.getElementById('scrollSpeed');
 
 elTileWidth.addEventListener('input', updateWidth);
@@ -65,6 +80,9 @@ elTileScale.addEventListener('change', updateScale);
 
 elFontScale.addEventListener('input', updateFont);
 elFontScale.addEventListener('change', updateFont);
+
+elCloseScale.addEventListener('input', updateCloseScale);
+elCloseScale.addEventListener('change', updateCloseScale);
 
 elScrollSpeed.addEventListener('input', updateScroll);
 elScrollSpeed.addEventListener('change', updateScroll);

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -237,6 +237,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
   div.appendChild(title);
 
   const closeBtn = document.createElement('button');
+  closeBtn.className = 'close-btn';
   closeBtn.textContent = '×';
   closeBtn.title = 'Close tab';
   closeBtn.addEventListener('click', async (e) => {

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -10,6 +10,7 @@
   --tile-width: 200px;
   --tile-scale: 0.9;
   --font-scale: 0.9;
+  --close-scale: 1;
 }
 
 body {
@@ -148,6 +149,9 @@ button {
 }
 button:hover {
   background: var(--color-hover);
+}
+.close-btn {
+  font-size: calc(1em * var(--close-scale));
 }
 .hidden {
   display: none;

--- a/mytabs/theme.js
+++ b/mytabs/theme.js
@@ -1,5 +1,10 @@
 (async function(){
-  let { theme = 'light', tileWidth = 200, tileScale = 0.9, fontScale = 0.9 } = await browser.storage.local.get(['theme','tileWidth','tileScale','fontScale']);
+  let { theme = 'light', tileWidth = 200, tileScale = 0.9, fontScale = 0.9, closeScale = 1 } =
+    await browser.storage.local.get(['theme','tileWidth','tileScale','fontScale','closeScale']);
+  if (closeScale === undefined) {
+    closeScale = 1;
+    browser.storage.local.set({ closeScale });
+  }
 
   function apply(){
     document.body.dataset.theme = theme;
@@ -7,6 +12,7 @@
     document.documentElement.style.setProperty('--tile-width', width + 'px');
     document.documentElement.style.setProperty('--tile-scale', tileScale);
     document.documentElement.style.setProperty('--font-scale', fontScale);
+    document.documentElement.style.setProperty('--close-scale', closeScale);
     if (document.body.classList.contains('full')) {
       document.body.style.removeProperty('width');
     }
@@ -20,6 +26,7 @@
       if (changes.tileWidth) tileWidth = changes.tileWidth.newValue;
       if (changes.tileScale) tileScale = changes.tileScale.newValue;
       if (changes.fontScale) fontScale = changes.fontScale.newValue;
+      if (changes.closeScale) closeScale = changes.closeScale.newValue;
       apply();
     }
   });


### PR DESCRIPTION
## Summary
- allow setting close button size from options
- persist `closeScale` with default 1
- apply `--close-scale` variable in themes
- style `.close-btn` and assign class in popup

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6847786859d88331a622f36904bb9965