### PR TITLE
Reduce default tile size

### DIFF
--- a/mytabs/fullwin.js
+++ b/mytabs/fullwin.js
@@ -1,5 +1,5 @@
 (async function(){
-  const { fullSize, tileWidth = 200, tileScale = 0.9 } =
+  const { fullSize, tileWidth = 100, tileScale = 0.9 } =
     await browser.storage.local.get(['fullSize', 'tileWidth', 'tileScale']);
   if (fullSize && typeof fullSize.width === 'number' && typeof fullSize.height === 'number') {
     try {

--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -8,13 +8,13 @@
   <h1>Options</h1>
   <label>Theme: <select id="theme"><option value="light">Light</option><option value="dark">Dark</option></select></label>
   <br>
-  <label>Tile Width (px): <input type="number" id="tileWidth" min="100" max="600" value="200"></label>
+  <label>Tile Width (px): <input type="number" id="tileWidth" min="50" max="600" value="100"></label>
   <br>
   <label>Tile Scale: <input type="number" id="tileScale" min="0.5" max="2" step="0.1" value="0.9"></label>
   <br>
-  <label>Font Scale: <input type="number" id="fontScale" min="0.5" max="2" step="0.1" value="0.9"></label>
+  <label>Font Scale: <input type="number" id="fontScale" min="0.25" max="2" step="0.1" value="0.45"></label>
   <br>
-  <label>Close Button Scale: <input type="number" id="closeScale" min="0.5" max="2" step="0.1" value="1"></label>
+  <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="0.5"></label>
   <br>
   <label>Scroll Speed: <input type="number" id="scrollSpeed" min="0.5" step="0.1" value="1"></label>
   <br>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -1,9 +1,9 @@
 async function load(){
   const data = await browser.storage.local.get(['theme','tileWidth','tileScale','fontScale','closeScale','scrollSpeed','showRecent','showDuplicates','enableMove']);
-  const {theme='light', tileWidth=200, tileScale=0.9, fontScale=0.9, scrollSpeed=1, showRecent=true, showDuplicates=true, enableMove=true} = data;
+  const {theme='light', tileWidth=100, tileScale=0.9, fontScale=0.45, scrollSpeed=1, showRecent=true, showDuplicates=true, enableMove=true} = data;
   let closeScale = data.closeScale;
   if (closeScale === undefined) {
-    closeScale = 1;
+    closeScale = 0.5;
     browser.storage.local.set({ closeScale });
   }
   document.getElementById('theme').value = theme;

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -7,10 +7,10 @@
   --color-selected: #dceaff;
   --color-muted: #888;
   --color-visited: #f0fff0;
-  --tile-width: 200px;
+  --tile-width: 100px;
   --tile-scale: 0.9;
-  --font-scale: 0.9;
-  --close-scale: 1;
+  --font-scale: 0.45;
+  --close-scale: 0.5;
 }
 
 body {

--- a/mytabs/theme.js
+++ b/mytabs/theme.js
@@ -1,8 +1,8 @@
 (async function(){
-  let { theme = 'light', tileWidth = 200, tileScale = 0.9, fontScale = 0.9, closeScale = 1 } =
+  let { theme = 'light', tileWidth = 100, tileScale = 0.9, fontScale = 0.45, closeScale = 0.5 } =
     await browser.storage.local.get(['theme','tileWidth','tileScale','fontScale','closeScale']);
   if (closeScale === undefined) {
-    closeScale = 1;
+    closeScale = 0.5;
     browser.storage.local.set({ closeScale });
   }
 


### PR DESCRIPTION
## Summary
- shrink default tile width, font scale and close button size
- adjust default option values

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6847ca370ec883318911f35eb5da0aa0