### PR TITLE
Add tooltip for tab icons in full view

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -17,6 +17,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   - Custom context menu reveals extension version and links to the Options page.
   - The mouse wheel scrolls the tab list even when the pointer is over the menu or search field.
   - Scroll speed can be adjusted from the Options page to make scrolling more aggressive.
+  - Hovering a tab's icon in Full View shows a tooltip with the tab title and URL.
 - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
   the Recent and Duplicates panels or the Move command.
 - The Close Button Scale adjusts the “×” size independent of the font scale.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -194,6 +194,9 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
     icon.className = 'tab-icon';
     icon.src = tab.favIconUrl;
     icon.alt = '';
+    if (document.body.classList.contains('full')) {
+      icon.title = `${tab.title || tab.url}\n${tab.url}`;
+    }
     icon.onerror = () => icon.remove();
     div.appendChild(icon);
   }


### PR DESCRIPTION
## Summary
- show a tooltip containing the tab title and URL when hovering icons in full view
- document the tooltip feature in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847dbfd8cf483319cb1d968c88e8b8c