### PR TITLE
Enhance tab tooltips

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -17,7 +17,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   - Custom context menu reveals extension version and links to the Options page.
   - The mouse wheel scrolls the tab list even when the pointer is over the menu or search field.
   - Scroll speed can be adjusted from the Options page to make scrolling more aggressive.
-  - Hovering a tab's icon in Full View shows a tooltip with the tab title and URL.
+  - Hovering a tab's icon in Full View shows a custom tooltip with the tab title and URL.
 - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
   the Recent and Duplicates panels or the Move command.
 - The Close Button Scale adjusts the “×” size independent of the font scale.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -194,11 +194,28 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
     icon.className = 'tab-icon';
     icon.src = tab.favIconUrl;
     icon.alt = '';
-    if (document.body.classList.contains('full')) {
-      icon.title = `${tab.title || tab.url}\n${tab.url}`;
-    }
     icon.onerror = () => icon.remove();
     div.appendChild(icon);
+
+    let tooltip;
+    const showTooltip = () => {
+      if (!document.body.classList.contains('full')) return;
+      tooltip = document.createElement('div');
+      tooltip.className = 'tab-tooltip';
+      tooltip.innerHTML = `${tab.title || tab.url}<br>${tab.url}`;
+      document.body.appendChild(tooltip);
+      const rect = icon.getBoundingClientRect();
+      tooltip.style.left = `${rect.right + window.scrollX + 5}px`;
+      tooltip.style.top = `${rect.top + window.scrollY}px`;
+    };
+    const hideTooltip = () => {
+      if (tooltip) {
+        tooltip.remove();
+        tooltip = null;
+      }
+    };
+    icon.addEventListener('mouseenter', showTooltip);
+    icon.addEventListener('mouseleave', hideTooltip);
   }
 
   div.addEventListener('click', (e) => {

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -174,6 +174,24 @@ button:hover {
   background: var(--color-hover);
 }
 
+.tab-tooltip {
+  position: absolute;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  pointer-events: none;
+  z-index: 1000;
+}
+
+body[data-theme="dark"] .tab-tooltip {
+  background: var(--color-hover);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
 #bulk-actions {
   margin-top: 0.5em;
   text-align: right;


### PR DESCRIPTION
## Summary
- add `.tab-tooltip` styling with theme support
- create custom tooltip on tab icon hover in `popup.js`
- mention custom tooltip in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847f2a413788331b817cfb66d56f129