### PR TITLE
Adjust default font size

### DIFF
--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -12,7 +12,7 @@
   <br>
   <label>Tile Scale: <input type="number" id="tileScale" min="0.5" max="2" step="0.1" value="0.9"></label>
   <br>
-  <label>Font Scale: <input type="number" id="fontScale" min="0.25" max="2" step="0.1" value="0.45"></label>
+  <label>Font Scale: <input type="number" id="fontScale" min="0.25" max="2" step="0.1" value="1"></label>
   <br>
   <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="0.5"></label>
   <br>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -8,7 +8,7 @@ async function load(){
     theme='light',
     tileWidth=100,
     tileScale=0.9,
-    fontScale=0.45,
+    fontScale=1,
     scrollSpeed=1,
     showRecent=true,
     showDuplicates=true,

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -9,7 +9,7 @@
   --color-visited: #f0fff0;
   --tile-width: 100px;
   --tile-scale: 0.9;
-  --font-scale: 0.45;
+  --font-scale: 1;
   --close-scale: 0.5;
 }
 

--- a/mytabs/theme.js
+++ b/mytabs/theme.js
@@ -1,5 +1,5 @@
 (async function(){
-  let { theme = 'light', tileWidth = 100, tileScale = 0.9, fontScale = 0.45, closeScale = 0.5 } =
+  let { theme = 'light', tileWidth = 100, tileScale = 0.9, fontScale = 1, closeScale = 0.5 } =
     await browser.storage.local.get(['theme','tileWidth','tileScale','fontScale','closeScale']);
   if (closeScale === undefined) {
     closeScale = 0.5;


### PR DESCRIPTION
## Summary
- increase the default `fontScale` from 0.45 to 1 for better readability

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684806de64108331b25804ab99e3573e