### PR TITLE
Add container filtering feature

### DIFF
--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -10,6 +10,9 @@
       <button id="btn-all">All</button>
       <button id="btn-recent">Recent</button>
       <button id="btn-dups">Duplicates</button>
+      <select id="container-filter">
+        <option value="">All Containers</option>
+      </select>
     </div>
     <input type="text" id="search" placeholder="Search tabs" />
     <div id="error"></div>

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -3,12 +3,13 @@
   "name": "KepiTAB",
   "version": "0.2",
   "description": "A simple tab management tool inspired by All Tabs Helper",
-  "permissions": [
-    "tabs",
-    "tabHide",
-    "storage",
-    "contextMenus"
-  ],
+    "permissions": [
+      "tabs",
+      "tabHide",
+      "storage",
+      "contextMenus",
+      "contextualIdentities"
+    ],
   "background": { "scripts": ["background.js"] },
   "browser_action": {
     "default_title": "KepiTAB",

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -10,6 +10,9 @@
     <button id="btn-all">All</button>
     <button id="btn-recent">Recent</button>
     <button id="btn-dups">Duplicates</button>
+    <select id="container-filter">
+      <option value="">All Containers</option>
+    </select>
   </div>
   <input type="text" id="search" placeholder="Search tabs" />
   <div id="error"></div>

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -73,6 +73,9 @@ body[data-theme="dark"] #context div:hover {
 #menu button {
   margin-right: 0.2em;
 }
+#container-filter {
+  margin-left: 0.2em;
+}
 
 #search {
   width: 100%;
@@ -97,6 +100,12 @@ body[data-theme="dark"] #context div:hover {
 .tab-icon {
   width: calc(16px * var(--font-scale));
   height: calc(16px * var(--font-scale));
+}
+.container-indicator {
+  width: calc(10px * var(--font-scale));
+  height: calc(10px * var(--font-scale));
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 .tab:hover {
   background: var(--color-hover);


### PR DESCRIPTION
## Summary
- add contextualIdentities permission
- provide container filter dropdown in popup and full view
- fetch container data and filter by cookieStoreId
- show container color marker next to each tab
- style dropdown and container indicator

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684807382098833199d119e7361e6e9e