### PR TITLE
Add bulk container management

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -14,6 +14,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   be configured on the Options page.
 - Each tab row includes a button to quickly close that tab.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.
+- Bulk assign selected tabs to any Firefox container or move them back to the default container.
 - A **Full View** window shows tabs in multiple columns filled top-to-bottom.
   - Custom context menu reveals extension version and links to the Options page.
   - The mouse wheel scrolls the tab list even when the pointer is over the menu or search field.

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -18,7 +18,14 @@
     <div id="error"></div>
     <div id="tabs"></div>
     <div id="bulk-actions">
-      
+      <select id="container-target"></select>
+      <button id="bulk-add-container">Add to Container</button>
+      <button id="bulk-remove-container">Remove from Container</button>
+      <button id="bulk-close">Close</button>
+      <button id="bulk-reload">Reload</button>
+      <button id="bulk-discard">Unload</button>
+      <button id="bulk-unload-all">Unload All</button>
+      <button id="bulk-move">Move</button>
     </div>
     <div id="context" class="hidden"></div>
 

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -17,13 +17,16 @@
   <input type="text" id="search" placeholder="Search tabs" />
   <div id="error"></div>
   <div id="tabs"></div>
-  <div id="bulk-actions">
-    <button id="bulk-close">Close</button>
-    <button id="bulk-reload">Reload</button>
-    <button id="bulk-discard">Unload</button>
-    <button id="bulk-unload-all">Unload All</button>
-    <button id="bulk-move">Move</button>
-  </div>
+    <div id="bulk-actions">
+      <select id="container-target"></select>
+      <button id="bulk-add-container">Add to Container</button>
+      <button id="bulk-remove-container">Remove from Container</button>
+      <button id="bulk-close">Close</button>
+      <button id="bulk-reload">Reload</button>
+      <button id="bulk-discard">Unload</button>
+      <button id="bulk-unload-all">Unload All</button>
+      <button id="bulk-move">Move</button>
+    </div>
   <div id="context" class="hidden"></div>
 
   <script src="theme.js"></script>


### PR DESCRIPTION
## Summary
- support assigning/removing selected tabs to/from containers
- add container controls to popup and full view
- wire up new buttons and context menu entries
- document the new feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68480ed55aac8331b8be90071f12f3b5