### PR TITLE
Add optional subtitle display for tabs

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -263,10 +263,28 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
     }
   });
 
+  const info = document.createElement('div');
+  info.className = 'tab-info';
+
   const title = document.createElement('span');
   title.textContent = tab.title || tab.url;
   title.className = 'tab-title';
-  div.appendChild(title);
+  info.appendChild(title);
+
+  let subtitle = '';
+  try {
+    subtitle = new URL(tab.url).hostname;
+  } catch (_) {
+    subtitle = tab.url;
+  }
+  if (subtitle && subtitle !== tab.title) {
+    const sub = document.createElement('div');
+    sub.className = 'subtitle';
+    sub.textContent = subtitle;
+    info.appendChild(sub);
+  }
+
+  div.appendChild(info);
 
   const closeBtn = document.createElement('button');
   closeBtn.className = 'close-btn';

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -140,6 +140,21 @@ body[data-theme="dark"] .tab.drop-after {
   text-overflow: ellipsis;
   cursor: pointer;
 }
+
+.tab-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.subtitle {
+  font-size: 0.9em;
+  color: var(--color-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .duplicate {
   background: #fff4f4;
 }


### PR DESCRIPTION
## Summary
- show a subtitle with the domain beneath each tab title when available
- style subtitles with a lighter color and smaller font

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848152771b08331bc13f5f2c906408a