### PR TITLE
Remove double click search

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -8,7 +8,6 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Shows a **Recent** panel using an LRU buffer.
 - Highlights duplicate tabs and provides a dedicated **Duplicates** view.
 - Visited tabs appear in **bold** while unvisited tabs are dimmed, making new pages easy to spot.
-- Double click a tab to search its page content and highlight results.
 - Perform bulk operations (close, reload, unload, move) on selected tabs, and a
   command to unload all tabs at once. The keyboard shortcut for this command can
   be configured on the Options page.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -327,14 +327,6 @@ function createTabRow(tab, isDuplicate, activeId, isVisited) {
 
   div.addEventListener('dragend', clearPlaceholder);
 
-  div.addEventListener('dblclick', async () => {
-    const query = prompt('Search text');
-    if (query) {
-      await browser.tabs.sendMessage(tab.id, { type: 'highlight', query });
-      browser.tabs.update(tab.id, { active: true });
-    }
-  });
-
   return div;
 }
 


### PR DESCRIPTION
## Summary
- remove double click content search handler
- drop documentation mentioning double click search

## Testing
- `node --check mytabs/popup.js`
- `cd mytabs && for f in *.js; do node --check "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_6848155734dc8331b3f75176752eff00