### PR TITLE
Use debounce for popup updates

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -473,7 +473,7 @@ async function update() {
   renderTabs(list, activeId, dupIds, visitedIds, winMap, query);
 }
 
-const scheduleUpdate = throttle(update);
+const scheduleUpdate = debounce(update, 200);
 
 document.getElementById('search').addEventListener('input', scheduleUpdate);
 document.getElementById('btn-all').addEventListener('click', () => { view = 'all'; scheduleUpdate(); });


### PR DESCRIPTION
## Summary
- call `debounce` instead of `throttle` when scheduling tab list updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848b9f27fe48331a8d871ecb5d8a73d