### PR TITLE
Fix undefined containerCache

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -12,6 +12,7 @@ let container; // tabs container cached after DOM load
 let dropTarget = null;
 let containerMap = new Map();
 let filterContainerId = '';
+let containerCache;
 let targetSelect;
 let visitedIds = new Set();
 


### PR DESCRIPTION
## Summary
- declare `containerCache` in popup.js to cache container identities

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848bf25a6508331a354f96b4d08e549