### PR TITLE
Initialize container cache

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -12,6 +12,7 @@ let container; // tabs container cached after DOM load
 let dropTarget = null;
 let containerMap = new Map();
 let filterContainerId = '';
+let containerCache = null;
 let targetSelect;
 let visitedIds = new Set();
 
@@ -200,7 +201,7 @@ async function getContainerIdentities() {
   return containerCache;
 }
 
-function createTabRow(tab, isDuplicate, activeId, isVisited) {
+function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   const div = document.createElement('div');
   div.className = 'tab';
   div.dataset.tab = tab.id;


### PR DESCRIPTION
## Summary
- initialize `containerCache` to avoid ReferenceError when fetching container identities

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848bf25a6508331a354f96b4d08e549