### PR TITLE
Remove MIT license references from docs

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -42,6 +42,4 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 
 To install for development, load the directory as a temporary add-on in Firefox.
 
-## License
-
-This example is provided under the MIT license.
+See LICENSE for the current project license.


### PR DESCRIPTION
## Summary
- drop the old MIT notice from `mytabs/README.md`
- note that the repository's LICENSE file contains the new terms

The MIT license notice for HyperList remains because `hyperlist.js` is still used in the extension.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68496d25cd70833185e3052c24117b92