### PR TITLE
Fix popup tab width

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -99,6 +99,8 @@ body[data-theme="dark"] #context div:hover {
   padding: 0.2em;
   border-bottom: 1px solid var(--color-border);
   break-inside: avoid;
+  width: var(--tile-width);
+  box-sizing: border-box;
 }
 .tab-icon {
   width: calc(16px * var(--font-scale));


### PR DESCRIPTION
## Summary
- keep tile width consistent in popup and full views by applying `width: var(--tile-width)` to `.tab`
- use `box-sizing: border-box` for `.tab` so borders don't change width

## Testing
- `npx stylelint mytabs/style.css` *(fails: `npm error canceled`)*

------
https://chatgpt.com/codex/tasks/task_e_6849823affb48331846e573fbd9a5af2