### PR TITLE
Fix tab width layout

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -99,7 +99,7 @@ body[data-theme="dark"] #context div:hover {
   padding: 0.2em;
   border-bottom: 1px solid var(--color-border);
   break-inside: avoid;
-  width: var(--tile-width);
+  width: 100%;
   box-sizing: border-box;
 }
 .tab-icon {


### PR DESCRIPTION
## Summary
- make `.tab` fill available width in popup views while preserving column width in full view

## Testing
- `npx stylelint mytabs/style.css` *(fails: Unknown rule order/properties-order)*

------
https://chatgpt.com/codex/tasks/task_e_6849bd4228508331aec18294f1c4bf98