### PR TITLE
Responsive grid for full view

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,4 +1,5 @@
 {
+  "plugins": ["stylelint-order"],
   "rules": {
     "indentation": 2,
     "block-no-empty": true,

--- a/mytabs/fullwin.js
+++ b/mytabs/fullwin.js
@@ -1,6 +1,5 @@
 (async function(){
-  const { fullSize, tileWidth = 150, tileScale = 0.9 } =
-    await browser.storage.local.get(['fullSize', 'tileWidth', 'tileScale']);
+  const { fullSize } = await browser.storage.local.get('fullSize');
   if (fullSize && typeof fullSize.width === 'number' && typeof fullSize.height === 'number') {
     try {
       window.resizeTo(fullSize.width, fullSize.height);
@@ -20,22 +19,5 @@
     browser.storage.local.set({ fullSize: data });
   });
 
-  function updateCols() {
-    const style = getComputedStyle(document.documentElement);
-    const tile = parseInt(style.getPropertyValue('--tile-width'), 10) || 200;
-    const width = document.body.clientWidth;
-    const cols = Math.max(1, Math.floor(width / tile));
-    document.documentElement.style.setProperty('--cols', cols);
-  }
-
-  browser.storage.onChanged.addListener((changes, area) => {
-    if (area === 'local' && (changes.tileWidth || changes.tileScale)) {
-      updateCols();
-    }
-  });
-
-  window.addEventListener('theme-applied', updateCols);
-
-  window.addEventListener('resize', updateCols);
-  updateCols();
+  // layout now handled purely via CSS grid
 })();

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -239,9 +239,9 @@ body.full {
   max-width: none;
 }
 body.full #tabs {
-  column-width: var(--tile-width);
-  column-gap: 0.5em;
-  column-count: var(--cols);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--tile-width), 1fr));
+  gap: 0.5em;
   flex: 1 1 auto;
   max-height: none;
   overflow-y: auto;

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "description": "Development tooling",
   "devDependencies": {
     "stylelint": "^15.0.0"
+  },
+  "dependencies": {
+    "stylelint-order": "^6.0.4"
   }
 }


### PR DESCRIPTION
## Summary
- tweak `style.css` to use CSS grid in full window view
- simplify `fullwin.js` by dropping column calculations
- add missing `stylelint-order` plugin to config and `package.json`

## Testing
- `npm install`
- `npx stylelint mytabs/style.css`


------
https://chatgpt.com/codex/tasks/task_e_6849bd7a186c8331b0756cf91d12eaf2