### PR TITLE
Dynamic tile width for full view

### DIFF
--- a/mytabs/fullwin.js
+++ b/mytabs/fullwin.js
@@ -19,5 +19,13 @@
     browser.storage.local.set({ fullSize: data });
   });
 
+  function applyTileWidth() {
+    const width = Math.max(window.innerWidth / 5, 150);
+    document.documentElement.style.setProperty('--tile-width', width + 'px');
+  }
+
+  applyTileWidth();
+  window.addEventListener('resize', applyTileWidth);
+
   // layout now handled purely via CSS grid
 })();


### PR DESCRIPTION
## Summary
- compute `--tile-width` based on `window.innerWidth`
- update style property and recompute on resize

## Testing
- `npm install`
- `npx stylelint mytabs/style.css`


------
https://chatgpt.com/codex/tasks/task_e_6849ca6c36a083318a7acff0ba429503