### PR TITLE
dynamic-columns-v3

### DIFF
--- a/mytabs/fullwin.js
+++ b/mytabs/fullwin.js
@@ -19,13 +19,7 @@
     browser.storage.local.set({ fullSize: data });
   });
 
-  function applyTileWidth() {
-    const width = Math.max(window.innerWidth / 5, 150);
-    document.documentElement.style.setProperty('--tile-width', width + 'px');
-  }
-
-  applyTileWidth();
-  window.addEventListener('resize', applyTileWidth);
+  // tile width based on theme settings only
 
   // layout now handled purely via CSS grid
 })();

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -240,7 +240,7 @@ body.full {
 }
 body.full #tabs {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(var(--tile-width), 1fr));
+  grid-template-columns: repeat(auto-fill, var(--tile-width));
   gap: 0.5em;
   flex: 1 1 auto;
   max-height: none;


### PR DESCRIPTION
## Summary
- keep full-window tabs in fixed-width columns
- rely on theme settings for tile width instead of window scaling

## Testing
- `npm install`
- `npx stylelint mytabs/style.css`


------
https://chatgpt.com/codex/tasks/task_e_6849c9f9cac48331a073ae0488eba20f