### PR TITLE
Add grid flow to full tabs

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -241,6 +241,7 @@ body.full {
 body.full #tabs {
   display: grid;
   grid-template-columns: repeat(auto-fill, var(--tile-width));
+  grid-auto-flow: column;
   gap: 0.5em;
   flex: 1 1 auto;
   max-height: none;


### PR DESCRIPTION
## Summary
- ensure full view tabs fill top-to-bottom by setting `grid-auto-flow: column`

## Testing
- `npm install`
- `npx stylelint mytabs/style.css`


------
https://chatgpt.com/codex/tasks/task_e_6849e09f71488331b99503b229aba76b