### PR TITLE
Fix vertical stacking in full view

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -240,8 +240,8 @@ body.full {
 }
 body.full #tabs {
   display: grid;
-  grid-template-columns: repeat(auto-fill, var(--tile-width));
-  grid-auto-flow: column;
+  grid-template-columns: 1fr;
+  grid-auto-flow: row;
   gap: 0.5em;
   flex: 1 1 auto;
   max-height: none;
@@ -265,7 +265,7 @@ body.full #menu button {
 body.full .tab {
   border: 1px solid var(--color-border);
   border-radius: 4px;
-  width: var(--tile-width);
+  width: 100%;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- adjust `body.full #tabs` rules for single-column layout
- make full view tab width span full container

## Testing
- `npx stylelint "**/*.css"`


------
https://chatgpt.com/codex/tasks/task_e_6849e5a661688331b9ff9e4a0b8c4904