### PR TITLE
Implement Alt to clear selections

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -39,6 +39,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - **R** – reload selected tabs
 - **U** – unload selected tabs (Shift+U unloads all tabs)
 - **M** – move selected tabs to another window
+- **Alt** – deselect all tabs
 
 To install for development, load the directory as a temporary add-on in Firefox.
 

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -143,6 +143,14 @@ function updateSelection(row, selected) {
   }
 }
 
+function clearSelection() {
+  for (const item of tabItems) {
+    item.selected = false;
+    if (item.el) updateSelection(item.el, false);
+  }
+  lastSelectedIndex = -1;
+}
+
 const saveScroll = debounce(() => {
   if (container) {
     browser.storage.local.set({ scrollTop: container.scrollTop });
@@ -548,6 +556,12 @@ document.addEventListener('keydown', (e) => {
     requestAnimationFrame(() => { tabItems[newIdx].el?.focus(); });
     return newIdx;
   };
+
+  if (e.key === 'Alt' && !e.ctrlKey && !e.metaKey && !e.shiftKey) {
+    e.preventDefault();
+    clearSelection();
+    return;
+  }
 
   if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- add `clearSelection` helper in popup.js
- clear all selections with Alt key
- document new Alt shortcut in README

## Testing
- `npm install`
- `npx stylelint mytabs/style.css`


------
https://chatgpt.com/codex/tasks/task_e_6849fb62486c8331a13e77be818583bb