### PR TITLE
feat: verify container existence before bulk assign

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -913,6 +913,26 @@ async function bulkMove() {
 async function bulkAssignToContainer(containerId) {
   const errorEl = document.getElementById('error');
   if (errorEl) errorEl.textContent = '';
+  if (browser.contextualIdentities) {
+    try {
+      let identities = await browser.contextualIdentities.query({});
+      let exists = identities.some(ci => ci.cookieStoreId === containerId);
+      if (!exists) {
+        containerCache = null;
+        identities = await getContainerIdentities();
+        exists = identities.some(ci => ci.cookieStoreId === containerId);
+      }
+      if (!exists) {
+        if (errorEl) errorEl.textContent = 'Selected container does not exist';
+        return;
+      }
+    } catch (e) {
+      console.error('Contextual identities unavailable', e);
+      if (errorEl) errorEl.textContent =
+        'Container actions disabled: ' + (e.message || e);
+      return;
+    }
+  }
   const ids = getSelectedTabIds();
   if (!ids.length) return;
   if (ids.length > 10 && !confirm(`Move ${ids.length} tabs to the selected container?`)) return;


### PR DESCRIPTION
## Summary
- check chosen container id before assigning tabs
- refresh container cache if container lookup fails
- show a clear error when the container is invalid

## Testing
- `npx stylelint "**/*.css"`

------
https://chatgpt.com/codex/tasks/task_e_684a143118ec8331aef5535672030401