### PR TITLE
Fix default container move

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -913,6 +913,60 @@ async function bulkMove() {
 async function bulkAssignToContainer(containerId) {
   const errorEl = document.getElementById('error');
   if (errorEl) errorEl.textContent = '';
+
+  async function performMove() {
+    const ids = getSelectedTabIds();
+    if (!ids.length) return;
+    if (ids.length > 10 &&
+        !confirm(`Move ${ids.length} tabs to the selected container?`)) {
+      return;
+    }
+    let tabs = await Promise.all(ids.map(id => browser.tabs.get(id)));
+    tabs.sort((a, b) =>
+      a.windowId === b.windowId ? a.index - b.index : a.windowId - b.windowId);
+    const failed = [];
+    for (const tab of tabs) {
+      try {
+        if (/^(about:|moz-extension:|chrome:|file:|view-source:)/.test(tab.url)) {
+          failed.push(tab.title || tab.url);
+          continue;
+        }
+        const newTab = await browser.tabs.create({
+          url: tab.url,
+          cookieStoreId: containerId,
+          index: tab.index,
+          windowId: tab.windowId,
+          pinned: tab.pinned,
+          active: tab.active
+        });
+        try {
+          await browser.tabs.remove(tab.id);
+        } catch (e) {
+          console.error('Failed to remove tab', e);
+          failed.push(tab.title || tab.url);
+          if (newTab && newTab.id) {
+            await browser.tabs.remove(newTab.id);
+          }
+        }
+      } catch (e) {
+        console.error('Failed to move tab', e);
+        failed.push(tab.title || tab.url);
+      }
+    }
+    scheduleUpdate();
+    if (failed.length) {
+      if (errorEl) {
+        errorEl.textContent =
+          `Some tabs could not be moved: ${failed.join(', ')}`;
+      }
+    }
+  }
+
+  if (containerId === 'firefox-default') {
+    // default container always exists
+    return await performMove();
+  }
+
   if (browser.contextualIdentities) {
     try {
       let identities = await browser.contextualIdentities.query({});
@@ -928,49 +982,14 @@ async function bulkAssignToContainer(containerId) {
       }
     } catch (e) {
       console.error('Contextual identities unavailable', e);
-      if (errorEl) errorEl.textContent =
-        'Container actions disabled: ' + (e.message || e);
+      if (errorEl) {
+        errorEl.textContent =
+          'Container actions disabled: ' + (e.message || e);
+      }
       return;
     }
   }
-  const ids = getSelectedTabIds();
-  if (!ids.length) return;
-  if (ids.length > 10 && !confirm(`Move ${ids.length} tabs to the selected container?`)) return;
-  let tabs = await Promise.all(ids.map(id => browser.tabs.get(id)));
-  tabs.sort((a, b) => a.windowId === b.windowId ? a.index - b.index : a.windowId - b.windowId);
-  const failed = [];
-  for (const tab of tabs) {
-    try {
-      if (/^(about:|moz-extension:|chrome:|file:|view-source:)/.test(tab.url)) {
-        failed.push(tab.title || tab.url);
-        continue;
-      }
-      const newTab = await browser.tabs.create({
-        url: tab.url,
-        cookieStoreId: containerId,
-        index: tab.index,
-        windowId: tab.windowId,
-        pinned: tab.pinned,
-        active: tab.active
-      });
-      try {
-        await browser.tabs.remove(tab.id);
-      } catch (e) {
-        console.error('Failed to remove tab', e);
-        failed.push(tab.title || tab.url);
-        if (newTab && newTab.id) {
-          await browser.tabs.remove(newTab.id);
-        }
-      }
-    } catch (e) {
-      console.error('Failed to move tab', e);
-      failed.push(tab.title || tab.url);
-    }
-  }
-  scheduleUpdate();
-  if (failed.length) {
-    if (errorEl) errorEl.textContent = `Some tabs could not be moved: ${failed.join(', ')}`;
-  }
+  return await performMove();
 }
 
 async function bulkRemoveFromContainer() {


### PR DESCRIPTION
## Summary
- fix container existence check when assigning tabs to containers
- skip identity queries for the default container

## Testing
- `npm install`
- `npx stylelint mytabs/style.css`

------
https://chatgpt.com/codex/tasks/task_e_684a1d9495d88331b6d61620120f493e