### PR TITLE
Fix CSS wrapper and remove MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Configuration is stored in `.stylelintrc.json` and uses the
 
 ```bash
 npm install
-npx stylelint mytabs/style.css
+npm run lint
 ```

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -16,7 +16,9 @@
     </div>
     <input type="text" id="search" placeholder="Search tabs" />
     <div id="error"></div>
-    <div id="tabs"></div>
+    <div id="tabs-wrapper">
+      <div id="tabs"></div>
+    </div>
     <div id="bulk-actions">
       <select id="container-target"></select>
       <button id="bulk-add-container">Add to Container</button>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -270,7 +270,9 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
       if (!document.body.classList.contains('full')) return;
       tooltip = document.createElement('div');
       tooltip.className = 'tab-tooltip';
-      tooltip.innerHTML = `${tab.title || tab.url}<br>${tab.url}`;
+      const safeTitle = escapeHtml(tab.title || tab.url);
+      const safeUrl = escapeHtml(tab.url);
+      tooltip.innerHTML = `${safeTitle}<br>${safeUrl}`;
       document.body.appendChild(tooltip);
       const rect = icon.getBoundingClientRect();
       tooltip.style.left = `${rect.right + window.scrollX + 5}px`;

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -238,6 +238,11 @@ body.full {
   flex-direction: column;
   max-width: none;
 }
+body.full #tabs-wrapper {
+  overflow-x: auto;
+  min-width: max-content;
+  width: 100%;
+}
 body.full #tabs {
   column-width: var(--tile-width);
   column-fill: auto;

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   },
   "dependencies": {
     "stylelint-order": "^6.0.4"
+  },
+  "scripts": {
+    "lint": "stylelint mytabs/style.css"
   }
 }


### PR DESCRIPTION
## Summary
- remove MIT LICENSE file
- restore tab grid CSS and keep wrapper for scrolling
- keep tooltip HTML escaped
- update lint script in README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a7dc21838833190699711c77d7c89