### PR TITLE
Implement scrollable grid layout

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -554,8 +554,11 @@ document.addEventListener('keydown', (e) => {
   const moveFocus = (delta) => {
     const newIdx = Math.min(Math.max(idx + delta, 0), tabItems.length - 1);
     idx = newIdx;
-    container.scrollTop = newIdx * rowHeight;
-    requestAnimationFrame(() => { tabItems[newIdx].el?.focus(); });
+    const el = tabItems[newIdx].el;
+    requestAnimationFrame(() => {
+      el?.focus();
+      el?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    });
     return newIdx;
   };
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -244,13 +244,15 @@ body.full #tabs-wrapper {
   width: 100%;
 }
 body.full #tabs {
-  column-width: var(--tile-width);
-  column-fill: auto;
-  column-gap: 0.5em;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: var(--tile-width);
+  grid-auto-rows: max-content;
+  gap: 0.5em;
   flex: 1 1 auto;
   max-height: none;
   overflow-y: auto;
-  overflow-x: auto;
+  overflow-x: hidden;
   width: max-content;
 }
 body.full #counts,


### PR DESCRIPTION
## Summary
- restore multi-column grid layout for tab cards
- keep arrow navigation working with scrollIntoView

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a81b469708331b9d10fb169401be1