### PR TITLE
Fix fullscreen grid max height

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -252,6 +252,7 @@ body.full #tabs {
   gap: 0.5em;
   width: 100%;
   min-height: 100%;
+  max-height: none;
 }
 body.full #counts,
 body.full #menu {


### PR DESCRIPTION
## Summary
- allow the `#tabs` grid to expand fully in fullscreen view

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ab32de79c833191be4d4435122050