### PR TITLE
v1.1 restore row grid layout

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -249,8 +249,10 @@ body.full #tabs-wrapper {
 body.full #tabs {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(var(--tile-width), 1fr));
+  grid-auto-flow: row;
   gap: 0.5em;
-  width: 100%;
+  width: max-content;
+  min-width: 100%;
   min-height: 100%;
   max-height: none;
 }


### PR DESCRIPTION
## Summary
- revert `grid-auto-flow` to row layout
- use `width: max-content; min-width: 100%` for overflow scrolling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ab65302d88331930afbf61bcd718f