### PR TITLE
Reduce tile gap for full view

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -250,7 +250,7 @@ body.full #tabs {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(var(--tile-width), 1fr));
   grid-auto-flow: row;
-  gap: 0.5em;
+  gap: 0.25em;
   width: max-content;
   min-width: 100%;
   min-height: 100%;


### PR DESCRIPTION
## Summary
- tweak tile gap spacing in `mytabs/style.css`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684aba0e62508331bf6d6b82acde1b3d