### PR TITLE
Reduce grid gap

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -87,7 +87,7 @@ body[data-theme="dark"] #context div:hover {
 }
 
 #tabs {
-  margin-top: 0.5em;
+  margin-top: 0.2em;
   max-height: 400px;
   overflow-y: auto;
 }
@@ -95,8 +95,8 @@ body[data-theme="dark"] #context div:hover {
 .tab {
   display: flex;
   align-items: center;
-  gap: 0.4em;
-  padding: 0.2em;
+  gap: 0.2em;
+  padding: 0.1em;
   border-bottom: 1px solid var(--color-border);
   break-inside: avoid;
   width: 100%;
@@ -250,7 +250,7 @@ body.full #tabs {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(var(--tile-width), 1fr));
   grid-auto-flow: row;
-  gap: 0.5em;
+  gap: 0.2em;
   width: max-content;
   min-width: 100%;
   min-height: 100%;


### PR DESCRIPTION
## Summary
- minimize margins and padding around the tab grid
- shrink internal spacing in each tab
- tighten the full view grid gap

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684abb6d67f083319b19265ed040c00d