### PR TITLE
Fix horizontal grid

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -239,8 +239,8 @@ body.full {
   max-width: none;
 }
 body.full #tabs-wrapper {
-  overflow-y: auto;
   overflow-x: auto;
+  min-width: max-content;
   width: 100%;
   height: 100%;
   flex: 1 1 auto;
@@ -248,8 +248,9 @@ body.full #tabs-wrapper {
 }
 body.full #tabs {
   display: grid;
-  grid-template-columns: repeat(auto-fill, var(--tile-width));
-  grid-auto-flow: row;
+  grid-auto-flow: column;
+  grid-auto-columns: var(--tile-width);
+  grid-auto-rows: max-content;
   gap: 0.2em;
   width: max-content;
   min-width: 100%;


### PR DESCRIPTION
## Summary
- restore column-based grid with horizontal scroll to show cards top-to-bottom

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ac26d9fb88331bac2b4088a397e7e