### PR TITLE
v1.1.3-restore-card-grid-order

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -250,8 +250,8 @@ body.full #tabs-wrapper {
 }
 body.full #tabs {
   display: grid;
-  grid-template-columns: repeat(auto-fill, var(--tile-width));
   grid-auto-flow: row;
+  grid-auto-columns: var(--tile-width);
   grid-auto-rows: max-content;
   gap: 0.2em;
   width: max-content;


### PR DESCRIPTION
## Summary
- restore row-based grid flow so cards appear in the correct order

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ad18947f88331805a1564d5bb0b01