### PR TITLE
feat: use auto-fill grid in full view

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -250,8 +250,8 @@ body.full #tabs-wrapper {
 }
 body.full #tabs {
   display: grid;
-  grid-auto-columns: var(--tile-width);
-  grid-auto-flow: column;
+  grid-template-columns: repeat(auto-fill, var(--tile-width));
+  grid-auto-flow: row;
   grid-auto-rows: max-content;
   gap: 0.2em;
   width: max-content;


### PR DESCRIPTION
## Summary
- layout full view cards in rows and columns
- revert full view grid to auto-fill columns

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b444916ac8331b87abd7ff413b5b1