### PR TITLE
feat: adjust full view grid layout

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -18,6 +18,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Container-related actions require Firefox's container feature and the `contextualIdentities` permission. If containers are disabled, the container filter and "Add to Container" buttons will not be shown.
 - A **Full View** window shows tabs in a responsive grid that fills the entire window.
   - The number of columns adapts to the window size.
+  - The number of rows automatically adjusts to the window height and the list scrolls only horizontally.
   - Custom context menu reveals extension version and links to the Options page.
   - The mouse wheel scrolls the tab list even when the pointer is over the menu or search field.
   - In Full View, overflowing columns can be scrolled horizontally with the mouse wheel.

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -11,6 +11,7 @@
   --tile-scale: 0.9;
   --font-scale: 0.8125;
   --close-scale: 0.5;
+  --row-height: 36px;
 }
 
 html, body {
@@ -251,12 +252,15 @@ body.full #tabs-wrapper {
 body.full #tabs {
   display: grid;
   grid-template-columns: repeat(auto-fill, var(--tile-width));
-  grid-auto-flow: row;
-  grid-auto-rows: max-content;
+  grid-template-rows: repeat(auto-fit, minmax(var(--row-height), 1fr));
+  grid-auto-columns: var(--tile-width);
+  grid-auto-flow: column;
+  grid-auto-rows: minmax(var(--row-height), 1fr);
   gap: 0.2em;
   width: max-content;
   min-width: 100%;
   height: 100%;
+  align-content: start;
 }
 body.full #counts,
 body.full #menu {


### PR DESCRIPTION
## Summary
- add `--row-height` variable
- rework full view grid layout to fill screen height and scroll only horizontally
- update docs about new grid behavior

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b459b96088331b8a91f4f222845d0