### PR TITLE
Wersja1: poprawa gridu w widoku pełnym

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -251,7 +251,7 @@ body.full #tabs-wrapper {
 }
 body.full #tabs {
   display: grid;
-  grid-template-rows: repeat(auto-fit, var(--row-height));
+  grid-template-rows: repeat(auto-fill, minmax(36px, 1fr));
   grid-auto-columns: var(--tile-width);
   grid-auto-flow: column;
   grid-auto-rows: var(--row-height);
@@ -259,7 +259,9 @@ body.full #tabs {
   width: max-content;
   min-width: 100%;
   height: 100%;
-  align-content: start;
+  align-content: stretch;
+  justify-items: start;
+  align-items: start;
 }
 body.full #counts,
 body.full #menu {


### PR DESCRIPTION
## Podsumowanie
- rozciągnięcie siatki w pionie dzięki `align-content: stretch`
- zastosowanie `grid-template-rows: repeat(auto-fill, minmax(36px, 1fr))`
- wyrównanie kart w komórkach do góry i lewej

## Testy
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b5a0f4efc833192905167e8f1e616