### PR TITLE
Poprawa pełnego widoku - dopasowanie siatki kart do wysokości okna

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -251,14 +251,15 @@ body.full #tabs-wrapper {
 }
 body.full #tabs {
   display: grid;
-  grid-template-rows: repeat(auto-fill, minmax(36px, 1fr));
+  grid-template-rows: repeat(auto-fill, minmax(var(--row-height), 1fr));
   grid-auto-columns: var(--tile-width);
   grid-auto-flow: column;
-  grid-auto-rows: var(--row-height);
+  grid-auto-rows: minmax(var(--row-height), 1fr);
   gap: 0.2em;
   width: max-content;
   min-width: 100%;
   height: 100%;
+  min-height: 100%;
   align-content: stretch;
   justify-items: start;
   align-items: start;


### PR DESCRIPTION
## Podsumowanie
- siatka kart w `full.html` ma zawsze wysokość całego okna
- wiersze `#tabs` rozciągają się dzięki `minmax(var(--row-height), 1fr)`

## Testy
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b5b2c1d4083319e798265fff7a092