### PR TITLE
Ulepszenie wyglądu kart w pełnym widoku

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -88,7 +88,7 @@ body[data-theme="dark"] #context div:hover {
 }
 
 #tabs {
-  margin-top: 0.2em;
+  margin-top: 0;
   max-height: 400px;
   overflow-y: auto;
 }
@@ -233,7 +233,7 @@ body[data-theme="dark"] .tab-tooltip {
 body.full {
   width: 100%;
   height: 100%;
-  padding: 0.5em;
+  padding: 0;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -255,7 +255,7 @@ body.full #tabs {
   grid-auto-columns: var(--tile-width);
   grid-auto-flow: column;
   grid-auto-rows: minmax(var(--row-height), 1fr);
-  gap: 0.2em;
+  gap: 1px;
   width: max-content;
   min-width: 100%;
   height: 100%;
@@ -263,6 +263,11 @@ body.full #tabs {
   align-content: stretch;
   justify-items: start;
   align-items: start;
+}
+body.full .tab {
+  padding: 0;
+  margin: 0;
+  border: 1px solid var(--color-border);
 }
 body.full #counts,
 body.full #menu {


### PR DESCRIPTION
## Podsumowanie
- zmieniono `gap` w siatce kart na 1px
- usunięto margines nad kontenerem kart
- karty w pełnym widoku pozbawiono paddingu i otrzymały obramowanie
- zredukowano padding dla `body.full`

## Testy
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b6205d5cc833191231c52b26dcd24