### PR TITLE
Reduce full view tile spacing

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -248,6 +248,8 @@ body.full #tabs-wrapper {
   flex: 1 1 auto;
   min-height: 0;
   min-width: 100%;
+  margin: 0;
+  padding: 0;
 }
 body.full #tabs {
   display: grid;
@@ -255,7 +257,7 @@ body.full #tabs {
   grid-auto-columns: var(--tile-width);
   grid-auto-flow: column;
   grid-auto-rows: minmax(var(--row-height), 1fr);
-  gap: 1px;
+  gap: 0;
   width: max-content;
   min-width: 100%;
   height: 100%;
@@ -263,6 +265,8 @@ body.full #tabs {
   align-content: stretch;
   justify-items: start;
   align-items: start;
+  margin: 0;
+  padding: 0;
 }
 body.full .tab {
   padding: 0;


### PR DESCRIPTION
## Summary
- avoid margins and padding around the full view grid
- set the grid gap to 0 so tiles match sidebar spacing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b63fd6ad48331bb9a1b127a01033b