### PR TITLE
Update full view grid

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -14,6 +14,11 @@
   --row-height: 36px;
 }
 
+/* ensure borders never add spacing */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 html, body {
   height: 100%;
 }
@@ -257,7 +262,7 @@ body.full #tabs {
   grid-auto-columns: var(--tile-width);
   grid-auto-flow: column;
   grid-auto-rows: minmax(var(--row-height), 1fr);
-  gap: 0;
+  gap: 0px;
   width: max-content;
   min-width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- apply global border-box sizing to remove layout gaps
- explicitly set `gap:0px` for the fullscreen grid

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684b6b64d4a88331918d6121a2aeab0a