### PR TITLE
Align fullscreen grid spacing with sidebar

### DIFF
--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -16,8 +16,8 @@
     </div>
     <input type="text" id="search" placeholder="Search tabs" />
     <div id="error"></div>
-    <div id="tabs-wrapper">
-      <div id="tabs"></div>
+    <div id="tabs-wrapper" class="tab-grid-wrapper">
+      <div id="tabs" class="tab-grid"></div>
     </div>
     <div id="bulk-actions">
       <select id="container-target"></select>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -6,7 +6,7 @@ async function load(){
   ]);
   const {
     theme='light',
-    tileWidth=150,
+    tileWidth=200,
     tileScale=0.9,
     fontScale=0.8125,
     scrollSpeed=1,

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -250,7 +250,7 @@ async function getContainerIdentities() {
 function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   const row = document.createElement('div');
   const isFull = document.body.classList.contains('full');
-  row.className = 'tab';
+  row.className = 'tab tab-card';
   row.dataset.tab = tab.id;
   row.dataset.windowId = tab.windowId;
   row.tabIndex = 0;

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -1,17 +1,17 @@
 :root {
   --color-bg: #fff;
   --color-text: #333;
-  --color-border: #ccc;
+  --color-border: #ddd;
   --color-hover: #f5f5f5;
   --color-active: #eef5ff;
   --color-selected: #dceaff;
   --color-muted: #888;
   --color-visited: #f0fff0;
-  --tile-width: 150px;
+  --tile-width: 200px;
   --tile-scale: 0.9;
   --font-scale: 0.8125;
   --close-scale: 0.5;
-  --row-height: 36px;
+  --row-height: 40px;
 }
 
 /* ensure borders never add spacing */
@@ -244,19 +244,20 @@ body.full {
   flex-direction: column;
   max-width: none;
 }
-body.full #tabs-wrapper {
-  overflow-y: hidden;
+body.full #tabs-wrapper,
+.tab-grid-wrapper {
   overflow-x: auto;
-  min-width: max-content;
+  overflow-y: hidden;
   width: 100%;
   height: 100%;
   flex: 1 1 auto;
   min-height: 0;
-  min-width: 100%;
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
 }
-body.full #tabs {
+body.full #tabs,
+.tab-grid {
   display: grid;
   grid-template-rows: repeat(auto-fill, minmax(var(--row-height), 1fr));
   grid-auto-columns: var(--tile-width);
@@ -274,7 +275,8 @@ body.full #tabs {
   padding: 0;
   box-sizing: border-box;
 }
-body.full .tab {
+body.full .tab,
+.tab-card {
   padding: 0;
   margin: 0;
   border: 1px solid var(--color-border);
@@ -282,7 +284,8 @@ body.full .tab {
   border-left-width: 0;
   box-sizing: border-box;
 }
-body.full .tab-title {
+body.full .tab-title,
+.tab-card .tab-title {
   padding: 2px 4px;
 }
 body.full #counts,

--- a/mytabs/theme.js
+++ b/mytabs/theme.js
@@ -1,5 +1,5 @@
 (async function(){
-  let { theme = 'light', tileWidth = 150, tileScale = 0.9, fontScale = 0.8125, closeScale = 0.5 } =
+  let { theme = 'light', tileWidth = 200, tileScale = 0.9, fontScale = 0.8125, closeScale = 0.5 } =
     await browser.storage.local.get(['theme','tileWidth','tileScale','fontScale','closeScale']);
   if (closeScale === undefined) {
     closeScale = 0.5;


### PR DESCRIPTION
## Summary
- add grid classes to fullscreen markup
- remove excess margin and padding via new styles
- change default tile size and border color
- ensure created tab elements use `tab-card`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684bcd680af48331b45e08f7db629230