### PR TITLE
Add global border-box rule

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -13,6 +13,10 @@
   --close-scale: 0.5;
 }
 
+* {
+  box-sizing: border-box;
+}
+
 html, body {
   height: 100%;
 }


### PR DESCRIPTION
## Summary
- apply universal `box-sizing: border-box` to prevent layout shifts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684bd4b7408483319674fc99a273d2f6