### PR TITLE
v1 - Fix fullscreen grid gaps

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,7 +1,6 @@
 {
   "plugins": ["stylelint-order"],
   "rules": {
-    "indentation": 2,
     "block-no-empty": true,
     "order/properties-order": null
   }

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -236,7 +236,7 @@ body[data-theme="dark"] .tab-tooltip {
 body.full {
   width: 100%;
   height: 100%;
-  padding: 0.5em;
+  padding: 0;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -278,9 +278,6 @@ body.full .tab,
 .tab-card {
   padding: 0 !important;
   margin: 0 !important;
-  border: 1px solid #ddd;
-  border-top-width: 0;
-  border-left-width: 0;
   box-sizing: border-box;
 }
 body.full .tab-title {


### PR DESCRIPTION
## Summary
- remove padding in `body.full`
- drop borders from `.tab-card`
- clean up deprecated `indentation` rule

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684bdb20bbec8331888e2680f3e00118