### PR TITLE
v1.1 remove card spacing in full view

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -278,6 +278,7 @@ body.full .tab,
 .tab-card {
   padding: 0 !important;
   margin: 0 !important;
+  border-bottom: none !important;
   box-sizing: border-box;
 }
 body.full .tab-title {


### PR DESCRIPTION
## Summary
- remove tab bottom border in full view

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684bf654fe14833187a34d4db8a5c9fd