### PR TITLE
v1.2 remove margin before tabs

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -91,7 +91,7 @@ body[data-theme="dark"] #context div:hover {
 }
 
 #tabs {
-  margin-top: 0.2em;
+  margin-top: 0;
   max-height: 400px;
   overflow-y: auto;
 }


### PR DESCRIPTION
## Summary
- remove top margin from tabs list so cards are flush in full view

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684bf8f9bb208331a3103d21c2b5b9ca