### PR TITLE
v1.3 remove more spacing

### DIFF
--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -28,7 +28,6 @@
       <button id="bulk-move">Move</button>
     </div>
   <div id="context" class="hidden"></div>
-
   <script src="theme.js"></script>
   <script src="hyperlist.js"></script>
   <script src="popup.js"></script>

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -72,10 +72,10 @@ body[data-theme="dark"] #context div:hover {
 }
 
 #menu {
-  margin-bottom: 0.5em;
+  margin-bottom: 0;
 }
 #counts {
-  margin-bottom: 0.5em;
+  margin-bottom: 0;
 }
 #menu button {
   margin-right: 0.2em;


### PR DESCRIPTION
## Summary
- remove blank line before scripts in popup.html
- remove bottom margins before the tabs for a tighter layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684bfab615c48331938ceb3d0f2c1f55