### PR TITLE
v1.4 remove full view tab gaps

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -256,10 +256,10 @@ body.full #tabs-wrapper,
 body.full #tabs,
 .tab-grid {
   display: grid;
-  grid-template-rows: repeat(auto-fill, minmax(40px, auto));
+  grid-template-rows: repeat(auto-fill, minmax(0, auto));
   grid-auto-columns: 200px;
   grid-auto-flow: column;
-  grid-auto-rows: minmax(40px, auto);
+  grid-auto-rows: auto;
   gap: 0;
   row-gap: 0;
   column-gap: 0;


### PR DESCRIPTION
## Summary
- tweak grid rows so tab cards sit flush without extra spacing

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c633651288331ac4617b3c43db582