### PR TITLE
Fix card layout in full view

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -256,10 +256,10 @@ body.full #tabs-wrapper,
 body.full #tabs,
 .tab-grid {
   display: grid;
-  grid-template-rows: repeat(auto-fill, minmax(0, auto));
+  grid-template-rows: repeat(auto-fill, minmax(40px, auto));
   grid-auto-columns: 200px;
   grid-auto-flow: column;
-  grid-auto-rows: auto;
+  grid-auto-rows: minmax(40px, auto);
   gap: 0;
   row-gap: 0;
   column-gap: 0;


### PR DESCRIPTION
## Summary
- restore default tile row height in full view grid

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c656a42a88331b3eb541a1b591a90