### PR TITLE
Enable horizontal tab scrolling

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -244,8 +244,8 @@ body.full {
 }
 body.full #tabs-wrapper,
 .tab-grid-wrapper {
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow-y: hidden;
+  overflow-x: auto;
   width: 100%;
   height: 100%;
   flex: 1 1 auto;
@@ -256,13 +256,16 @@ body.full #tabs-wrapper,
 body.full #tabs,
 .tab-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(var(--tile-width), 1fr));
+  grid-auto-columns: var(--tile-width);
+  grid-auto-flow: column;
   grid-auto-rows: auto;
   gap: 0;
   row-gap: 0;
   column-gap: 0;
-  width: 100%;
+  width: max-content;
+  min-width: 100%;
   height: 100%;
+  min-height: 100%;
   align-content: start;
   justify-items: start;
   align-items: start;


### PR DESCRIPTION
## Summary
- adjust CSS so cards fill the full window and scroll horizontally

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c772bb96c8331ac2f603f606e69a5