### PR TITLE
Implement horizontal scroll speed slider

### DIFF
--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -16,7 +16,7 @@
   <br>
   <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="0.5"></label>
   <br>
-  <label>Scroll Speed: <input type="number" id="scrollSpeed" min="0.5" step="0.1" value="1"></label>
+  <label>Scroll Speed: <input type="range" id="scrollSpeed" min="0.5" max="3" step="0.1" value="1"><span id="scrollSpeedValue">1</span></label>
   <br>
   <label><input type="checkbox" id="opt-show-recent" checked> Show Recent panel</label>
   <br>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -28,6 +28,7 @@ async function load(){
   document.getElementById('fontScale').value = fontScale;
   document.getElementById('closeScale').value = closeScale;
   document.getElementById('scrollSpeed').value = scrollSpeed;
+  document.getElementById('scrollSpeedValue').textContent = scrollSpeed;
   document.getElementById('opt-show-recent').checked = showRecent;
   document.getElementById('opt-show-dups').checked = showDuplicates;
   document.getElementById('opt-enable-move').checked = enableMove;
@@ -88,8 +89,10 @@ function updateCloseScale(){
 }
 
 function updateScroll(){
-  const scrollSpeed=parseFloat(document.getElementById('scrollSpeed').value);
+  const el = document.getElementById('scrollSpeed');
+  const scrollSpeed = parseFloat(el.value);
   browser.storage.local.set({scrollSpeed});
+  document.getElementById('scrollSpeedValue').textContent = scrollSpeed.toFixed(1);
 }
 
 const elTileWidth = document.getElementById('tileWidth');


### PR DESCRIPTION
## Summary
- add a range slider to control scroll speed
- update options logic to display slider value

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c83d7b870833190e760411f248284