### PR TITLE
Fix horizontal scrolling in full view

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -264,7 +264,7 @@ body.full #tabs,
   gap: 0;
   row-gap: 0;
   column-gap: 0;
-  width: 100%;
+  width: max-content;
   height: auto;
   align-content: start;
   justify-items: start;


### PR DESCRIPTION
## Summary
- enable horizontal scrollbar for the tab grid by using `width: max-content`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c856009248331b8f4124b8df900fe