### PR TITLE
Fix row spacing by trimming close button padding

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -170,6 +170,8 @@ button:hover {
 }
 .close-btn {
   font-size: calc(1em * var(--close-scale));
+  padding: 0;
+  line-height: 1;
 }
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
- refine `.close-btn` to remove extra padding
- set `line-height` for the close button so each tab row is tighter

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ce723247c83319ce46f350171a87e