### PR TITLE
fix: adjust button padding

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -157,7 +157,7 @@ body[data-theme="dark"] .tab.drop-after {
 }
 button {
   padding: 0.3em 0.6em;
-  margin-left: 0.2em;
+  margin-left: 0;
   border: 1px solid var(--color-border);
   border-radius: 4px;
   background: var(--color-bg);
@@ -261,7 +261,7 @@ body.full #tabs-wrapper,
 body.full #tabs,
 .tab-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(var(--tile-width), 1fr));
+  grid-template-columns: repeat(auto-fill, var(--tile-width));
   grid-auto-rows: auto;
   gap: 0;
   row-gap: 0;
@@ -283,7 +283,7 @@ body.full .tab,
   box-sizing: border-box;
 }
 body.full .tab-title {
-  padding: 2px 4px;
+  padding: 2px 0;
 }
 body.full #counts,
 body.full #menu {


### PR DESCRIPTION
## Summary
- no left margin for buttons
- remove horizontal padding from tab titles in fullscreen
- use fixed tile width in grid

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684cec78f1288331a60ba4ac7d7882ea