### PR TITLE
v1.0.1 init container fallback

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -648,7 +648,8 @@ document.addEventListener('keydown', (e) => {
 });
 
 async function init() {
-  container = document.getElementById('tabs-body');
+  container = document.getElementById('tabs-body') ||
+              document.getElementById('tabs');
   scrollContainer = document.body.classList.contains('full')
     ? document.getElementById('tabs-wrapper')
     : container;


### PR DESCRIPTION
## Summary
- allow popup initialization to fall back to `#tabs` when `#tabs-body` is missing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684cf07b15a48331832ef02e30708662