### PR TITLE
v1: update lint instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Container-related actions require Firefox's container feature and the `contextua
 
 Install dev dependencies and run Stylelint to check the stylesheet.
 Configuration is stored in `.stylelintrc.json` and uses the
-`stylelint-order` plugin.
+`stylelint-order` plugin. Run `npm install` before executing
+`npm run lint`.
 
 ```bash
 npm install


### PR DESCRIPTION
## Summary
- clarify README that dependencies should be installed before running the linter

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684cf2b6e9048331859e91f7392b088c