### PR TITLE
v1.1.0 Use CSS grid for tab layout

### DIFF
--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -17,9 +17,7 @@
     <input type="text" id="search" placeholder="Search tabs" />
     <div id="error"></div>
     <div id="tabs-wrapper" class="tab-grid-wrapper">
-      <table id="tabs" class="tab-grid">
-        <tbody id="tabs-body"></tbody>
-      </table>
+      <div id="tabs" class="tab-grid"></div>
     </div>
     <div id="bulk-actions">
       <select id="container-target"></select>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -248,7 +248,7 @@ async function getContainerIdentities() {
 }
 
 function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
-  const row = document.createElement('tr');
+  const row = document.createElement('div');
   const isFull = document.body.classList.contains('full');
   row.className = 'tab';
   row.dataset.tab = tab.id;
@@ -269,7 +269,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   }
 
 
-  const iconCell = document.createElement('td');
+  const iconCell = document.createElement('div');
   if (tab.favIconUrl) {
     const icon = document.createElement('img');
     icon.className = 'tab-icon';
@@ -302,7 +302,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   }
   row.appendChild(iconCell);
 
-  const indicatorCell = document.createElement('td');
+  const indicatorCell = document.createElement('div');
   const ctx = containerMap.get(tab.cookieStoreId);
   if (ctx) {
     const indicator = document.createElement('span');
@@ -314,14 +314,14 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   row.appendChild(indicatorCell);
 
 
-  const titleCell = document.createElement('td');
+  const titleCell = document.createElement('div');
   const title = document.createElement('span');
   title.textContent = tab.title || tab.url;
   title.className = 'tab-title';
   titleCell.appendChild(title);
   row.appendChild(titleCell);
 
-  const closeCell = document.createElement('td');
+  const closeCell = document.createElement('div');
   const closeBtn = document.createElement('button');
   closeBtn.className = 'close-btn';
   closeBtn.textContent = '×';

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -100,7 +100,8 @@ body.full #tabs {
 }
 
 .tab {
-  display: table-row;
+  display: flex;
+  align-items: center;
   padding: 0;
   border-bottom: none;
   break-inside: avoid;
@@ -147,7 +148,7 @@ body[data-theme="dark"] .tab.drop-after {
   text-overflow: ellipsis;
   cursor: pointer;
 }
-.tab td {
+.tab > div {
   padding: 0 0.2em;
   vertical-align: middle;
 }
@@ -259,10 +260,10 @@ body.full #tabs-wrapper,
 }
 body.full #tabs,
 .tab-grid {
-  display: table;
+  display: grid;
   position: relative;
   width: 100%;
-  border-collapse: collapse;
+  grid-template-columns: repeat(auto-fill, minmax(var(--tile-width), 1fr));
   height: 100%;
   margin: 0 !important;
   padding: 0 !important;


### PR DESCRIPTION
## Summary
- switch `.tab-grid` to CSS grid
- create tab elements using `div` nodes
- update full view markup

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684cf2a741588331a69dc580b7feeb74