### PR TITLE
Fix overlapping tabs after theme changes

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -826,6 +826,12 @@ if (document.readyState !== 'loading') {
 }
 window.addEventListener('unload', cleanup);
 
+// recompute item height when theme or scaling changes
+window.addEventListener('theme-applied', () => {
+  rowHeight = 0;
+  scheduleUpdate();
+});
+
 // custom context menu
 const context = document.getElementById('context');
 function showContextMenu(e) {


### PR DESCRIPTION
## Summary
- reload row heights when theme variables update

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf401fb588331ab2aa47710985189