### PR TITLE
Fix card title layout

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -143,6 +143,7 @@ body[data-theme="dark"] .tab.drop-after {
   box-shadow: inset 0 -2px 0 #9af;
 }
 .tab-title {
+  display: block;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -151,6 +152,10 @@ body[data-theme="dark"] .tab.drop-after {
 .tab > div {
   padding: 0 0.2em;
   vertical-align: middle;
+}
+.tab > div:nth-child(2) {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .duplicate {
   background: #fff4f4;


### PR DESCRIPTION
## Summary
- expand tab title flexbox to prevent overlap
- ensure `.tab-title` is a block element

## Testing
- `npm run lint`
- `npx web-ext build -s mytabs -a dist --overwrite-dest`

------
https://chatgpt.com/codex/tasks/task_e_684d581b3ba48331844b12781c556b4f