### PR TITLE
Ensure tab title fits tile

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -148,6 +148,8 @@ body[data-theme="dark"] .tab.drop-after {
   overflow: hidden;
   text-overflow: ellipsis;
   cursor: pointer;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .tab > div {
   padding: 0 0.2em;


### PR DESCRIPTION
## Summary
- allow tab titles to flex within their tile

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d598bf1288331b3f5ff9cc42c878b