### PR TITLE
Fix overlapping titles in full view

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -106,6 +106,7 @@ body.full #tabs {
   border-bottom: none;
   break-inside: avoid;
   box-sizing: border-box;
+  min-width: 0;
 }
 .tab-icon {
   width: calc(16px * var(--font-scale));


### PR DESCRIPTION
## Summary
- ensure `.tab` items can shrink in grid layout to keep titles within their column

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d60149c5c8331a9da190b819cc740