### PR TITLE
Fix overlapping tab titles in full view grid

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -271,7 +271,7 @@ body.full #tabs,
   display: grid;
   position: relative;
   width: 100%;
-  grid-auto-rows: max-content;
+  grid-auto-rows: minmax(45px, auto);
   gap: 0.4em;
   grid-template-columns: repeat(auto-fill, minmax(var(--tile-width), 1fr));
   height: 100%;
@@ -285,6 +285,11 @@ body.full .tab,
   margin: 0 !important;
   border-bottom: none !important;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+.tab-card .title {
+  text-overflow: ellipsis;
 }
 body.full .tab-title {
   padding: 2px 0;


### PR DESCRIPTION
## Summary
- fix `.tab-grid` auto row size for better layout
- make `.tab-card` flex column to stop content overlap
- truncate long titles within cards

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d6b8a1b84833199de4fdad06c1209