### PR TITLE
fix tab title grid overlap

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -156,7 +156,7 @@ body[data-theme="dark"] .tab.drop-after {
   padding: 0 0.2em;
   vertical-align: middle;
 }
-.tab > div:nth-child(2) {
+.tab > div:nth-child(3) {
   flex: 1 1 auto;
   min-width: 0;
 }


### PR DESCRIPTION
## Summary
- keep tab titles truncated but prevent overlap by making the title cell flexible

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d7c78dbfc8331978b97f57a4d67e1