### PR TITLE
docs: add setup script v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Container-related actions require Firefox's container feature and the `contextua
 Install dev dependencies and run Stylelint to check the stylesheet.
 Configuration is stored in `.stylelintrc.json` and uses the
 `stylelint-order` plugin. Run `npm install` before executing
-`npm run lint`.
+`npm run lint` or simply execute `scripts/setup.sh`.
 
 ```bash
 npm install
 npm run lint
+# or
+./scripts/setup.sh
 ```

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Install npm dependencies and run lint
+npm install
+npm run lint


### PR DESCRIPTION
## Summary
- add setup script for installing dependencies and running lint
- mention setup script in README

## Testing
- `npm install`
- `npm run lint`
- `./scripts/setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d9fd040708331b15991b94790827d