### PR TITLE
Disable vertical scroll in full view

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Container-related actions require Firefox's container feature and the `contextua
 Install dev dependencies and run Stylelint to check the stylesheet.
 Configuration is stored in `.stylelintrc.json` and uses the
 `stylelint-order` plugin. Run `npm install` before executing
-`npm run lint`.
+`npm run lint` or simply execute `scripts/setup.sh`.
 
 ```bash
 npm install
 npm run lint
+# or
+./scripts/setup.sh
 ```

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -257,7 +257,7 @@ body.full {
 }
 body.full #tabs-wrapper,
 .tab-grid-wrapper {
-  overflow-y: hidden;
+  overflow-y: auto;
   overflow-x: auto;
   width: 100%;
   height: 100%;
@@ -302,11 +302,4 @@ body.full #menu {
 }
 body.full #menu button {
   flex: 1 1 auto;
-}
-
-body.full .tab-grid {
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(var(--tile-width), 1fr);
-  overflow-y: hidden;
-  overflow-x: auto;
 }

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -257,7 +257,7 @@ body.full {
 }
 body.full #tabs-wrapper,
 .tab-grid-wrapper {
-  overflow-y: auto;
+  overflow-y: hidden;
   overflow-x: auto;
   width: 100%;
   height: 100%;
@@ -270,10 +270,10 @@ body.full #tabs,
 .tab-grid {
   display: grid;
   position: relative;
-  width: 100%;
+  width: max-content;
   grid-auto-rows: max-content;
   gap: 0.4em;
-  grid-template-columns: repeat(auto-fill, minmax(var(--tile-width), 1fr));
+  grid-template-columns: repeat(auto-fill, var(--tile-width));
   height: 100%;
   margin: 0 !important;
   padding: 0 !important;

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -257,7 +257,7 @@ body.full {
 }
 body.full #tabs-wrapper,
 .tab-grid-wrapper {
-  overflow-y: auto;
+  overflow-y: hidden;
   overflow-x: auto;
   width: 100%;
   height: 100%;
@@ -302,4 +302,11 @@ body.full #menu {
 }
 body.full #menu button {
   flex: 1 1 auto;
+}
+
+body.full .tab-grid {
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(var(--tile-width), 1fr);
+  overflow-y: hidden;
+  overflow-x: auto;
 }

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -257,7 +257,7 @@ body.full {
 }
 body.full #tabs-wrapper,
 .tab-grid-wrapper {
-  overflow-y: hidden;
+  overflow-y: auto;
   overflow-x: auto;
   width: 100%;
   height: 100%;
@@ -270,10 +270,10 @@ body.full #tabs,
 .tab-grid {
   display: grid;
   position: relative;
-  width: max-content;
+  width: 100%;
   grid-auto-rows: max-content;
   gap: 0.4em;
-  grid-template-columns: repeat(auto-fill, var(--tile-width));
+  grid-template-columns: repeat(auto-fill, minmax(var(--tile-width), 1fr));
   height: 100%;
   margin: 0 !important;
   padding: 0 !important;

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -257,7 +257,7 @@ body.full {
 }
 body.full #tabs-wrapper,
 .tab-grid-wrapper {
-  overflow-y: auto;
+  overflow-y: hidden;
   overflow-x: auto;
   width: 100%;
   height: 100%;

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Install npm dependencies and run lint
+npm install
+npm run lint


### PR DESCRIPTION
## Summary
- prevent vertical scrolling on `tabs-wrapper` in Full View so the mouse wheel only scrolls horizontally

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684da167bcc8833194716ac275789c0c