### PR TITLE
Add ESLint integration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended"],
+  "globals": {
+    "browser": "readonly"
+  },
+  "plugins": ["import"],
+  "rules": {}
+}

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Container-related actions require Firefox's container feature and the `contextua
 
 ## Development
 
-Install dev dependencies and run Stylelint to check the stylesheet.
-Configuration is stored in `.stylelintrc.json` and uses the
-`stylelint-order` plugin. Run `npm install` before executing
+Install dev dependencies and run the linter to check both the
+stylesheet and JavaScript files. Stylelint configuration is stored in
+`.stylelintrc.json` and uses the `stylelint-order` plugin. ESLint is
+configured in `.eslintrc.json`. Run `npm install` before executing
 `npm run lint`.
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "1.0.0",
   "description": "Development tooling",
   "devDependencies": {
+    "eslint": "^9.29.0",
+    "eslint-plugin-import": "^2.31.0",
     "stylelint": "^15.0.0"
   },
   "dependencies": {
     "stylelint-order": "^6.0.4"
   },
   "scripts": {
-    "lint": "stylelint mytabs/style.css"
+    "lint": "stylelint mytabs/style.css && npm run lint:js",
+    "lint:js": "ESLINT_USE_FLAT_CONFIG=false eslint mytabs/*.js"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint and eslint-plugin-import
- configure ESLint with `eslint:recommended`
- add `lint:js` npm script and run it from `lint`
- document the lint workflow in README

## Testing
- `npm run lint` *(fails: 30 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684df15fbca48331aa66fd9e07a71aa4