### PR TITLE
v1.1.0 fix horizontal scrolling

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -270,10 +270,10 @@ body.full #tabs,
 .tab-grid {
   display: grid;
   position: relative;
-  width: 100%;
+  width: max-content;
   grid-auto-rows: max-content;
   gap: 0.4em;
-  grid-template-columns: repeat(auto-fill, minmax(var(--tile-width), 1fr));
+  grid-template-columns: repeat(auto-fill, var(--tile-width));
   height: 100%;
   margin: 0 !important;
   padding: 0 !important;


### PR DESCRIPTION
## Summary
- make tab grid width wrap content so overflow scrolls horizontally
- fix grid template columns to use fixed tile width

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684df4d8bee48331843781f59fd504a6