### PR TITLE
Fix grid overflow handling

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -258,7 +258,7 @@ body.full {
 body.full #tabs-wrapper,
 .tab-grid-wrapper {
   overflow-y: auto;
-  overflow-x: auto;
+  overflow-x: hidden;
   width: 100%;
   height: 100%;
   flex: 1 1 auto;
@@ -271,6 +271,8 @@ body.full #tabs,
   display: grid;
   position: relative;
   width: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
   grid-auto-rows: max-content;
   gap: 0.4em;
   grid-template-columns: repeat(auto-fill, minmax(var(--tile-width), 1fr));


### PR DESCRIPTION
## Summary
- keep `.tab-grid-wrapper` from scrolling horizontally
- ensure `.tab-grid` hides horizontal overflow

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ea6b43d2c83319fa94cd0c42b2bec