### PR TITLE
v1.0.1 - add Stylelint postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Container-related actions require Firefox's container feature and the `contextua
 
 Install dev dependencies and run Stylelint to check the stylesheet.
 Configuration is stored in `.stylelintrc.json` and uses the
-`stylelint-order` plugin. Run `npm install` before executing
-`npm run lint`.
+`stylelint-order` plugin. Before running the linter, execute
+`npm install` and then run `npm run lint`.
 
 ```bash
 npm install

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "stylelint-order": "^6.0.4"
   },
   "scripts": {
-    "lint": "stylelint mytabs/style.css"
+    "lint": "stylelint mytabs/style.css",
+    "postinstall": "npx stylelint --version"
   }
 }


### PR DESCRIPTION
## Summary
- install Stylelint in `postinstall`
- clarify how to run the linter in the README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684eb3a789bc8331a2e21be520b4a4c3