### PR TITLE
Add horizontal grid layout

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -18,6 +18,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Container-related actions require Firefox's container feature and the `contextualIdentities` permission. If containers are disabled, the container filter and "Add to Container" buttons will not be shown.
 - A **Full View** window shows tabs in a responsive grid that fills the entire window.
   - The number of columns adapts to the window size.
+  - Tabs can also be displayed in a horizontal grid using the `horizontal` class.
   - Custom context menu reveals extension version and links to the Options page.
   - The mouse wheel scrolls the tab list even when the pointer is over the menu or search field.
   - In Full View, overflowing columns can be scrolled horizontally with the mouse wheel.

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -17,7 +17,7 @@
     <input type="text" id="search" placeholder="Search tabs" />
     <div id="error"></div>
     <div id="tabs-wrapper" class="tab-grid-wrapper">
-      <div id="tabs" class="tab-grid"></div>
+      <div id="tabs" class="tab-grid horizontal"></div>
     </div>
     <div id="bulk-actions">
       <select id="container-target"></select>

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -279,6 +279,10 @@ body.full #tabs,
   padding: 0 !important;
   box-sizing: border-box;
 }
+.tab-grid.horizontal {
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(var(--tile-width), 1fr);
+}
 body.full .tab,
 .tab-card {
   padding: 0 !important;


### PR DESCRIPTION
## Summary
- add `.tab-grid.horizontal` CSS rule for column flow
- assign horizontal grid class in `full.html`
- document horizontal mode in Full View section

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684eb3912198833199a8e98a1c64db10