### PR TITLE
Improve responsive columns in Full View

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -281,8 +281,8 @@ body.full #tabs,
   box-sizing: border-box;
 }
 .tab-grid.horizontal {
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(var(--tile-width), 1fr);
+  width: 100%;
+  grid-template-columns: repeat(auto-fit, minmax(var(--tile-width), 1fr));
 }
 body.full .tab,
 .tab-card {


### PR DESCRIPTION
## Summary
- adapt `.tab-grid.horizontal` layout to fill the window width

## Testing
- `npm run lint`
- manual check via Puppeteer script to confirm horizontal scroll

------
https://chatgpt.com/codex/tasks/task_e_684ee4a4642083318aec4fcca15b7de5