### PR TITLE
Improve fullscreen grid layout

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -18,7 +18,6 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Container-related actions require Firefox's container feature and the `contextualIdentities` permission. If containers are disabled, the container filter and "Add to Container" buttons will not be shown.
 - A **Full View** window shows tabs in a responsive grid that fills the entire window.
   - The number of columns adapts to the window size.
-  - Tabs can also be displayed in a horizontal grid using the `horizontal` class.
   - Custom context menu reveals extension version and links to the Options page.
   - The mouse wheel scrolls the tab list even when the pointer is over the menu or search field.
   - In Full View, overflowing columns can be scrolled horizontally with the mouse wheel.

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -17,7 +17,7 @@
     <input type="text" id="search" placeholder="Search tabs" />
     <div id="error"></div>
     <div id="tabs-wrapper" class="tab-grid-wrapper">
-      <div id="tabs" class="tab-grid horizontal"></div>
+      <div id="tabs" class="tab-grid"></div>
     </div>
     <div id="bulk-actions">
       <select id="container-target"></select>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -375,6 +375,7 @@ function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
       sample.style.visibility = 'hidden';
       container.appendChild(sample);
       rowHeight = sample.getBoundingClientRect().height || 32;
+      document.documentElement.style.setProperty('--tile-height', rowHeight + 'px');
       sample.remove();
     }
     for (const item of tabItems) {
@@ -416,6 +417,7 @@ function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
       sample.style.visibility = 'hidden';
       container.appendChild(sample);
       rowHeight = sample.getBoundingClientRect().height || 32;
+      document.documentElement.style.setProperty('--tile-height', rowHeight + 'px');
       sample.remove();
       virtualList = HyperList.create(container, {
         height: container.clientHeight || 400,

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -8,6 +8,7 @@
   --color-muted: #888;
   --color-visited: #f0fff0;
   --tile-width: 150px;
+  --tile-height: 32px;
   --tile-scale: 0.9;
   --font-scale: 0.8125;
   --close-scale: 0.5;
@@ -257,10 +258,10 @@ body.full {
 }
 body.full #tabs-wrapper,
 .tab-grid-wrapper {
-  overflow-y: hidden;
   overflow-x: auto;
-  width: 100%;
+  overflow-y: hidden;
   height: 100%;
+  width: 100%;
   flex: 1 1 auto;
   min-height: 0;
   margin: 0 !important;
@@ -269,29 +270,26 @@ body.full #tabs-wrapper,
 body.full #tabs,
 .tab-grid {
   display: grid;
-  position: relative;
+  grid-template-columns: repeat(auto-fill, var(--tile-width));
+  grid-auto-rows: var(--tile-height);
+  gap: 0;
   width: fit-content;
   min-width: 100%;
-  grid-auto-rows: max-content;
-  grid-auto-flow: column;
-  grid-auto-columns: var(--tile-width);
-  gap: 0;
   height: 100%;
   min-height: 100%;
   margin: 0 !important;
   padding: 0 !important;
   box-sizing: border-box;
 }
-.tab-grid.horizontal {
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(var(--tile-width), 1fr);
-}
 body.full .tab,
 .tab-card {
-  padding: 0 !important;
-  margin: 0 !important;
-  border-bottom: none !important;
+  margin: 0;
+  padding: 0;
+  border: none;
   box-sizing: border-box;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   width: var(--tile-width);
 }
 body.full .tab-title {


### PR DESCRIPTION
## Summary
- define `--tile-height` variable
- rework fullscreen grid CSS for automatic rows and columns
- set tile height from JavaScript when rendering
- simplify fullscreen HTML markup
- update docs about grid layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f043ab8108331a952d9d4e45b5750