### PR TITLE
fix(tab grid): enforce multi-row layout

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -250,8 +250,10 @@ body[data-theme="dark"] .tab-tooltip {
 /* Layout tweaks for full view */
 body.full {
   width: 100%;
-  height: 100%;
+  height: 100vh;
   padding: 0;
+  margin: 0;
+  overflow: hidden;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -262,6 +264,7 @@ body.full #tabs-wrapper,
   overflow-x: auto;
   overflow-y: hidden;
   height: 100vh;
+  display: block;
   width: 100%;
   flex: 1 1 auto;
   min-height: 0;


### PR DESCRIPTION
## Summary
- keep the grid wrapper from overflowing vertically
- prevent vertical scrolling and allow horizontal scroll only

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f17b772e483319c609934e63745de