### PR TITLE
Adjust grid layout for multi-row tab view

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -249,22 +249,17 @@ body[data-theme="dark"] .tab-tooltip {
 
 /* Layout tweaks for full view */
 body.full {
-  width: 100%;
-  height: 100%;
   padding: 0;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  max-width: none;
+  margin: 0;
+  height: 100vh;
+  overflow: hidden;
 }
 body.full #tabs-wrapper,
 .tab-grid-wrapper {
   overflow-x: auto;
   overflow-y: hidden;
   height: 100vh;
-  width: 100%;
-  flex: 1 1 auto;
-  min-height: 0;
+  display: block;
   margin: 0 !important;
   padding: 0 !important;
 }
@@ -273,14 +268,11 @@ body.full #tabs,
   display: grid;
   grid-template-columns: repeat(auto-fill, var(--tile-width));
   grid-auto-rows: var(--tile-height);
-  gap: 0;
   width: fit-content;
   min-width: 100%;
   height: 100vh;
   min-height: 100%;
-  margin: 0 !important;
-  padding: 0 !important;
-  box-sizing: border-box;
+  gap: 0;
 }
 .tab-card,
 .tab {


### PR DESCRIPTION
## Summary
- tweak `.tab-grid-wrapper` and `.tab-grid` so tabs wrap horizontally
- keep the body from scrolling vertically in full view

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f17b772e483319c609934e63745de