### PR TITLE
Fix scroll reset in full view

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -512,6 +512,12 @@ function findDuplicates(tabs) {
 }
 
 async function update() {
+  const isFull = document.body.classList.contains('full');
+  const prevScroll = scrollContainer
+    ? isFull
+      ? scrollContainer.scrollLeft
+      : scrollContainer.scrollTop
+    : 0;
   try {
     const allWins = document.body.classList.contains('full');
     const queryOpts = allWins ? {} : { currentWindow: true };
@@ -551,6 +557,13 @@ async function update() {
     console.error('Update failed', e);
     document.getElementById('error').textContent =
       'Error updating tabs: ' + (e.message || e);
+  }
+  if (scrollContainer) {
+    if (isFull) {
+      scrollContainer.scrollLeft = prevScroll;
+    } else {
+      scrollContainer.scrollTop = prevScroll;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- preserve scroll offset when tab list refreshes

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f5d53d1c4833198c317b46f410654