### PR TITLE
fix whitespace scroll issue

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -278,7 +278,6 @@ body.full #tabs,
   grid-auto-flow: column;
   gap: 0;
   width: fit-content;
-  min-width: 100%;
   height: 100%;
   min-height: 100%;
   margin: 0 !important;


### PR DESCRIPTION
## Summary
- remove extra min-width from the grid container to prevent empty space when scrolling horizontally

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f5ea778888331a77b20afbe09f70f