### PR TITLE
Fix overscroll in full view

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -263,6 +263,7 @@ body.full #tabs-wrapper,
 .tab-grid-wrapper {
   overflow-x: auto;
   overflow-y: hidden;
+  overscroll-behavior-x: contain;
   flex: 1 1 auto;
   display: block;
   width: 100%;


### PR DESCRIPTION
## Summary
- prevent scrolling past the last tab in full view by containing overscroll

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f61ec1f3083319a8a956e8bb6ebf6