### PR TITLE
v1.1.1 prevent horizontal overscroll

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -263,6 +263,7 @@ body.full #tabs-wrapper,
 .tab-grid-wrapper {
   overflow-x: auto;
   overflow-y: hidden;
+  overscroll-behavior-x: none;
   flex: 1 1 auto;
   display: block;
   width: 100%;


### PR DESCRIPTION
## Summary
- stop overscroll bounce effect in full view

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f61ec1f3083319a8a956e8bb6ebf6