### PR TITLE
Fix: adjust full view grid width

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -266,7 +266,8 @@ body.full #tabs-wrapper,
   overscroll-behavior-x: none;
   flex: 1 1 auto;
   display: block;
-  width: 100%;
+  width: max-content;
+  min-width: 100%;
   min-height: 0;
   margin: 0 !important;
   padding: 0 !important;


### PR DESCRIPTION
## Summary
- prevent blank space at the end of the full view list by making the scroll wrapper at least 100% width but no wider than its content

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f6a31683c8331bfdd6b24afcdd8eb