### PR TITLE
Fix spacing in popup list

### DIFF
--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -10,7 +10,7 @@
   <br>
   <label>Tile Width (px): <input type="number" id="tileWidth" min="50" max="600" value="150"></label>
   <br>
-  <label>Tile Scale: <input type="number" id="tileScale" min="0.5" max="2" step="0.1" value="0.9"></label>
+  <label>Tile Scale: <input type="number" id="tileScale" min="0.5" max="2" step="0.1" value="0.75"></label>
   <br>
   <label>Font Scale: <input type="number" id="fontScale" min="0.25" max="2" step="0.1" value="0.8125"></label>
   <br>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -7,7 +7,7 @@ async function load(){
   const {
     theme='light',
     tileWidth=150,
-    tileScale=0.9,
+    tileScale=0.75,
     fontScale=0.8125,
     scrollSpeed=1,
     showRecent=true,

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -9,7 +9,7 @@
   --color-visited: #f0fff0;
   --tile-width: 150px;
   --tile-height: 32px;
-  --tile-scale: 0.9;
+  --tile-scale: 0.75;
   --tile-height: calc(32px * var(--tile-scale));
   --font-scale: 0.8125;
   --close-scale: 0.5;

--- a/mytabs/theme.js
+++ b/mytabs/theme.js
@@ -1,5 +1,5 @@
 (async function(){
-  let { theme = 'light', tileWidth = 150, tileScale = 0.9, fontScale = 0.8125, closeScale = 0.5 } =
+  let { theme = 'light', tileWidth = 150, tileScale = 0.75, fontScale = 0.8125, closeScale = 0.5 } =
     await browser.storage.local.get(['theme','tileWidth','tileScale','fontScale','closeScale']);
   if (closeScale === undefined) {
     closeScale = 0.5;


### PR DESCRIPTION
## Summary
- adjust `--tile-scale` default to tighten popup list

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f9491578c83319f764d4503be66fa