### PR TITLE
Fix popup scroll overlap

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -95,7 +95,7 @@ body[data-theme="dark"] #context div:hover {
 #tabs {
   margin-top: 0;
   max-height: 400px;
-  overflow-y: hidden;
+  overflow-y: auto;
 }
 body.full #tabs {
   max-height: none;


### PR DESCRIPTION
## Summary
- ensure the popup tab list scrolls vertically

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f9e44ef288331ab8df36c71bc8fd2