### PR TITLE
Fix tab overlap in popup

### DIFF
--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -16,7 +16,9 @@
   </div>
   <input type="text" id="search" placeholder="Search tabs" />
   <div id="error"></div>
-  <div id="tabs"></div>
+  <div id="tabs-wrapper">
+    <div id="tabs"></div>
+  </div>
     <div id="bulk-actions">
       <select id="container-target"></select>
       <button id="bulk-add-container">Add to Container</button>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -675,11 +675,8 @@ document.addEventListener('keydown', (e) => {
 });
 
 async function init() {
-  container = document.getElementById('tabs-body') ||
-              document.getElementById('tabs');
-  scrollContainer = document.body.classList.contains('full')
-    ? document.getElementById('tabs-wrapper')
-    : container;
+  container = document.getElementById('tabs');
+  scrollContainer = document.getElementById('tabs-wrapper') || container;
   scrollContainer.addEventListener('scroll', saveScroll);
   container.addEventListener('click', onContainerClick);
   container.addEventListener('dragstart', onContainerDragStart);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -92,10 +92,12 @@ body[data-theme="dark"] #context div:hover {
   box-sizing: border-box;
 }
 
+#tabs-wrapper {
+  max-height: 400px;
+  overflow-y: auto;
+}
 #tabs {
   margin-top: 0;
-  max-height: 400px;
-  overflow-y: hidden;
 }
 body.full #tabs {
   max-height: none;


### PR DESCRIPTION
## Summary
- wrap popup tab list in a scrollable container
- update popup script to use new container
- adjust stylesheet for the new wrapper

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f9e44ef288331ab8df36c71bc8fd2