### PR TITLE
Adjust close button in popup

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -186,6 +186,9 @@ button:hover {
   padding: 0;
   line-height: 1;
 }
+body.popup .close-btn {
+  font-size: calc(1em * var(--close-scale) * 1.3);
+}
 .hidden {
   display: none;
 }


### PR DESCRIPTION
## Summary
- adjust popup close button size using CSS

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684fa1e9810483319190605af6027b7c