### PR TITLE
feat(full): window separators

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -344,6 +344,13 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   return row;
 }
 
+function createSeparator(num) {
+  const sep = document.createElement('div');
+  sep.className = 'window-separator';
+  sep.textContent = `Window ${num}`;
+  return sep;
+}
+
 function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
   if (!container) return;
   currentDupIds = dupIds;
@@ -385,7 +392,13 @@ function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
       document.documentElement.style.setProperty('--tile-height', rowHeight + 'px');
       sample.remove();
     }
+    let lastWin = -1;
     for (const item of tabItems) {
+      if (winMap && item.tab.windowId !== lastWin) {
+        lastWin = item.tab.windowId;
+        const num = winMap.get(lastWin) ?? 0;
+        container.appendChild(createSeparator(num));
+      }
       const el = createTabRow(
         item.tab,
         dupIds.has(item.tab.id),

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -168,6 +168,14 @@ body.popup .tab > div {
 .duplicate {
   background: #fff4f4;
 }
+.window-separator {
+  grid-column: 1 / -1;
+  border-top: 2px solid var(--color-border);
+  background: var(--color-hover);
+  font-weight: bold;
+  text-align: center;
+  line-height: var(--tile-height);
+}
 button {
   padding: 0.3em 0.6em;
   margin-left: 0;


### PR DESCRIPTION
## Summary
- add CSS style for window separators
- create window separator elements in JS when rendering tabs

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fa2578b60833182cf15b6c50dfe4f