### PR TITLE
v1.2.0 add window headers

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -24,6 +24,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
     Trackpad gestures and horizontal wheels are supported.
   - Scroll speed can be adjusted from the Options page to make scrolling more aggressive.
   - Hovering a tab's icon in Full View shows a custom tooltip with the tab title and URL.
+  - Window headers clearly separate tabs from different windows.
   - The columns can extend wider than the window and a horizontal scrollbar appears when needed.
 - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
   the Recent and Duplicates panels or the Move command.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -344,6 +344,13 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   return row;
 }
 
+function createWindowHeader(winNum) {
+  const header = document.createElement('div');
+  header.className = 'window-header';
+  header.textContent = `Window ${winNum}`;
+  return header;
+}
+
 function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
   if (!container) return;
   currentDupIds = dupIds;
@@ -385,7 +392,14 @@ function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
       document.documentElement.style.setProperty('--tile-height', rowHeight + 'px');
       sample.remove();
     }
+    let prevWin = null;
     for (const item of tabItems) {
+      const winId = item.tab.windowId;
+      if (winMap && winMap.size > 1 && winId !== prevWin) {
+        const header = createWindowHeader(winMap.get(winId) ?? winId);
+        container.appendChild(header);
+        prevWin = winId;
+      }
       const el = createTabRow(
         item.tab,
         dupIds.has(item.tab.id),

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -7,6 +7,7 @@
   --color-selected: #dceaff;
   --color-muted: #888;
   --color-visited: #f0fff0;
+  --color-window-header: #eee;
   --tile-width: 150px;
   --tile-height: 32px;
   --tile-scale: 0.9;
@@ -44,6 +45,7 @@ body[data-theme="dark"] {
   --color-selected: #224466;
   --color-muted: #aaa;
   --color-visited: #304030;
+  --color-window-header: #444;
   background: var(--color-bg);
   color: var(--color-text);
 }
@@ -298,6 +300,15 @@ body.full #tabs,
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.window-header {
+  grid-column: 1 / -1;
+  background: var(--color-window-header);
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  padding: 0 0.2em;
+  border-top: 1px solid var(--color-border);
 }
 body.full .tab-title {
   padding: 2px 0;


### PR DESCRIPTION
## Summary
- show visible window headers in full view
- style separators with new color variable
- document the new feature

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fa2578b60833182cf15b6c50dfe4f