### PR TITLE
Enhance popup close button design

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -28,6 +28,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
   the Recent and Duplicates panels or the Move command.
 - The Close Button Scale adjusts the “×” size independent of the font scale.
+- The popup close button is larger and styled with red and black colors.
 - A dark theme can also be enabled from the options page.
 - Keyboard shortcuts open the popup, sidebar and full view and can be changed from the Options page.
 - Default shortcuts:

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -96,6 +96,7 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  padding-right: 0.5em;
 }
 body.full #tabs {
   max-height: none;
@@ -104,7 +105,7 @@ body.full #tabs {
 .tab {
   display: flex;
   align-items: center;
-  padding: 0;
+  padding: 0 0.3em 0 0;
   border-bottom: none;
   break-inside: avoid;
   box-sizing: border-box;
@@ -182,9 +183,24 @@ button:hover {
   background: var(--color-hover);
 }
 .close-btn {
-  font-size: calc(1em * var(--close-scale));
+  font-size: calc(1.2em * var(--close-scale));
+  width: calc(1.5em * var(--close-scale));
+  height: calc(1.5em * var(--close-scale));
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0;
   line-height: 1;
+  margin-right: 0.2em;
+  color: #fff;
+  background: #c00;
+  border: 1px solid #000;
+  border-radius: 3px;
+}
+
+body[data-theme="dark"] .close-btn {
+  background: #900;
+  color: #fff;
 }
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
- enlarge close button in popup mode
- style close button with red/black colors
- add padding so scrollbar no longer covers the button
- document new button appearance

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fa3593dd88331bc51a5d418eb79b2