### PR TITLE
Enhance popup close button layout

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -28,6 +28,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
   the Recent and Duplicates panels or the Move command.
 - The Close Button Scale adjusts the “×” size independent of the font scale.
+- The popup close button is larger, styled with a red-to-black gradient and spaced away from the scrollbar.
 - A dark theme can also be enabled from the options page.
 - Keyboard shortcuts open the popup, sidebar and full view and can be changed from the Options page.
 - Default shortcuts:

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -96,6 +96,7 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  padding-right: 1em;
 }
 body.full #tabs {
   max-height: none;
@@ -104,7 +105,7 @@ body.full #tabs {
 .tab {
   display: flex;
   align-items: center;
-  padding: 0;
+  padding: 0 0.5em 0 0;
   border-bottom: none;
   break-inside: avoid;
   box-sizing: border-box;
@@ -183,8 +184,34 @@ button:hover {
 }
 .close-btn {
   font-size: calc(1em * var(--close-scale));
+  width: calc(1.6em * var(--close-scale));
+  height: calc(1.6em * var(--close-scale));
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0;
   line-height: 1;
+  margin-right: 0.3em;
+  color: #fff;
+  background: linear-gradient(#e00, #000);
+  border: 1px solid #000;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.5);
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.close-btn:hover {
+  background: linear-gradient(#ff4444, #222);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.6);
+}
+
+body[data-theme="dark"] .close-btn {
+  background: linear-gradient(#600, #000);
+  border-color: #000;
+}
+
+body[data-theme="dark"] .close-btn:hover {
+  background: linear-gradient(#c33, #222);
 }
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
- enlarge the popup tab close button and style it with a red-to-black gradient
- add extra padding so the close button no longer overlaps the scrollbar
- document the improved design

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fa3593dd88331bc51a5d418eb79b2