### PR TITLE
Improve popup close button styling

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -28,6 +28,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
   the Recent and Duplicates panels or the Move command.
 - The Close Button Scale adjusts the “×” size independent of the font scale.
+- The popup close button now sports a bold red and black circular design.
 - A dark theme can also be enabled from the options page.
 - Keyboard shortcuts open the popup, sidebar and full view and can be changed from the Options page.
 - Default shortcuts:

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -12,7 +12,7 @@
   --tile-scale: 0.9;
   --tile-height: calc(32px * var(--tile-scale));
   --font-scale: 0.8125;
-  --close-scale: 0.5;
+  --close-scale: 0.65;
 }
 
 *, *::before, *::after {
@@ -96,6 +96,7 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  padding-right: 0.8em;
 }
 body.full #tabs {
   max-height: none;
@@ -104,7 +105,7 @@ body.full #tabs {
 .tab {
   display: flex;
   align-items: center;
-  padding: 0;
+  padding: 0 0.3em 0 0;
   border-bottom: none;
   break-inside: avoid;
   box-sizing: border-box;
@@ -183,8 +184,34 @@ button:hover {
 }
 .close-btn {
   font-size: calc(1em * var(--close-scale));
+  width: calc(1.6em * var(--close-scale));
+  height: calc(1.6em * var(--close-scale));
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0;
   line-height: 1;
+  margin-right: 0.3em;
+  color: #fff;
+  background: linear-gradient(#ff4444, #660000);
+  border: 1px solid #330000;
+  border-radius: 50%;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.35);
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.close-btn:hover {
+  background: linear-gradient(#ff6666, #880000);
+  box-shadow: 0 3px 5px rgba(0,0,0,0.5);
+}
+
+body[data-theme="dark"] .close-btn {
+  background: linear-gradient(#880000, #330000);
+  border-color: #220000;
+}
+
+body[data-theme="dark"] .close-btn:hover {
+  background: linear-gradient(#aa0000, #550000);
 }
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
- enlarge `--close-scale` for more prominent close icon
- tweak `#tabs` padding to avoid scrollbar overlap
- restyle `.close-btn` with red/black gradient and circular shape
- document updated button appearance

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fa3593dd88331bc51a5d418eb79b2