### PR TITLE
Enhance popup close button design

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -28,6 +28,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
   the Recent and Duplicates panels or the Move command.
 - The Close Button Scale adjusts the “×” size independent of the font scale.
+- The popup close button uses an enlarged circular red-and-black design.
 - A dark theme can also be enabled from the options page.
 - Keyboard shortcuts open the popup, sidebar and full view and can be changed from the Options page.
 - Default shortcuts:

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -96,6 +96,7 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  padding-right: 0.5em;
 }
 body.full #tabs {
   max-height: none;
@@ -104,7 +105,7 @@ body.full #tabs {
 .tab {
   display: flex;
   align-items: center;
-  padding: 0;
+  padding: 0 0.3em 0 0;
   border-bottom: none;
   break-inside: avoid;
   box-sizing: border-box;
@@ -182,9 +183,35 @@ button:hover {
   background: var(--color-hover);
 }
 .close-btn {
-  font-size: calc(1em * var(--close-scale));
+  font-size: calc(1.2em * var(--close-scale));
+  width: calc(1.6em * var(--close-scale));
+  height: calc(1.6em * var(--close-scale));
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0;
   line-height: 1;
+  margin-right: 0.2em;
+  color: #fff;
+  background: radial-gradient(circle at 30% 30%, #f44, #400);
+  border: 1px solid #000;
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.close-btn:hover {
+  background: radial-gradient(circle at 30% 30%, #ff6666, #600);
+  box-shadow: 0 2px 5px rgba(0,0,0,0.5);
+}
+
+body[data-theme="dark"] .close-btn {
+  background: radial-gradient(circle at 30% 30%, #800, #200);
+  border-color: #000;
+}
+
+body[data-theme="dark"] .close-btn:hover {
+  background: radial-gradient(circle at 30% 30%, #b00, #500);
 }
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
- refine popup close button style with larger circular red-black gradient
- note updated button design in documentation

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fa3593dd88331bc51a5d418eb79b2