### PR TITLE
Refine popup close button size

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -28,6 +28,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
   the Recent and Duplicates panels or the Move command.
 - The Close Button Scale adjusts the “×” size independent of the font scale.
+- The popup close button uses a compact red-and-black circular design.
 - A dark theme can also be enabled from the options page.
 - Keyboard shortcuts open the popup, sidebar and full view and can be changed from the Options page.
 - Default shortcuts:

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -96,6 +96,7 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  padding-right: 0.5em;
 }
 body.full #tabs {
   max-height: none;
@@ -104,7 +105,7 @@ body.full #tabs {
 .tab {
   display: flex;
   align-items: center;
-  padding: 0;
+  padding: 0 0.3em 0 0;
   border-bottom: none;
   break-inside: avoid;
   box-sizing: border-box;
@@ -183,8 +184,34 @@ button:hover {
 }
 .close-btn {
   font-size: calc(1em * var(--close-scale));
+  width: calc(1.4em * var(--close-scale));
+  height: calc(1.4em * var(--close-scale));
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 0;
   line-height: 1;
+  margin-right: 0.2em;
+  color: #fff;
+  background: radial-gradient(circle at 30% 30%, #f55, #300);
+  border: 1px solid #000;
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.close-btn:hover {
+  background: radial-gradient(circle at 30% 30%, #ff7777, #500);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+}
+
+body[data-theme="dark"] .close-btn {
+  background: radial-gradient(circle at 30% 30%, #a00, #100);
+  border-color: #000;
+}
+
+body[data-theme="dark"] .close-btn:hover {
+  background: radial-gradient(circle at 30% 30%, #c00, #300);
 }
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
- shrink popup close button and soften gradient
- update docs with compact button description

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fa3593dd88331bc51a5d418eb79b2