### PR TITLE
Improve close button design

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -100,6 +100,7 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  padding-right: 0.5em; /* spacing for scrollbar */
 }
 body.full #tabs {
   max-height: none;
@@ -202,8 +203,19 @@ button:hover {
 }
 .close-btn {
   font-size: calc(1em * var(--close-scale));
-  padding: 0;
+  padding: 0 0.2em;
   line-height: 1;
+  background: transparent;
+  border: none;
+  margin-left: auto;
+  color: var(--color-muted);
+  cursor: pointer;
+}
+.tab:hover .close-btn {
+  color: #d33;
+}
+.close-btn:focus {
+  outline: 1px solid var(--color-border);
 }
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
- tweak #tabs padding to prevent overlap with scrollbar
- style the close button for better appearance and alignment

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68501ef712c883318cd931e889b9742b