### PR TITLE
Improve close button layout

### DIFF
--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -14,7 +14,7 @@
   <br>
   <label>Font Scale: <input type="number" id="fontScale" min="0.25" max="2" step="0.1" value="0.8125"></label>
   <br>
-  <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="0.5"></label>
+  <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="0.5"><button class="close-btn" id="closePreview">&times;</button></label>
   <br>
   <label>Scroll Speed: <input type="range" id="scrollSpeed" min="0.5" max="3" step="0.1" value="1"><span id="scrollSpeedValue">1</span></label>
   <br>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -27,6 +27,7 @@ async function load(){
   document.getElementById('tileScale').value = tileScale;
   document.getElementById('fontScale').value = fontScale;
   document.getElementById('closeScale').value = closeScale;
+  elClosePreview.style.fontSize = `calc(1em * ${closeScale})`;
   document.getElementById('scrollSpeed').value = scrollSpeed;
   document.getElementById('scrollSpeedValue').textContent = scrollSpeed;
   document.getElementById('opt-show-recent').checked = showRecent;
@@ -86,6 +87,7 @@ function updateCloseScale(){
   const closeScale=parseFloat(document.getElementById('closeScale').value);
   browser.storage.local.set({closeScale});
   document.documentElement.style.setProperty('--close-scale', closeScale);
+  elClosePreview.style.fontSize = `calc(1em * ${closeScale})`;
 }
 
 function updateScroll(){
@@ -99,6 +101,7 @@ const elTileWidth = document.getElementById('tileWidth');
 const elTileScale = document.getElementById('tileScale');
 const elFontScale = document.getElementById('fontScale');
 const elCloseScale = document.getElementById('closeScale');
+const elClosePreview = document.getElementById('closePreview');
 const elScrollSpeed = document.getElementById('scrollSpeed');
 
 elTileWidth.addEventListener('input', updateWidth);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -204,6 +204,17 @@ button:hover {
   font-size: calc(1em * var(--close-scale));
   padding: 0;
   line-height: 1;
+  width: 1.2em;
+  height: 1.2em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+}
+.close-btn:hover {
+  background: var(--color-hover);
+  border-radius: 2px;
 }
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
- show a close button preview next to the Close Button Scale option
- refine `.close-btn` style so buttons are smaller and consistent
- update options logic to sync the preview

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68504195332083318c2e5a5a73385f2a