### PR TITLE
Improve close button design

### DIFF
--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -14,7 +14,11 @@
   <br>
   <label>Font Scale: <input type="number" id="fontScale" min="0.25" max="2" step="0.1" value="0.8125"></label>
   <br>
-  <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="0.5"></label>
+  <label>Close Button Scale:
+    <input type="range" id="closeScale" min="0.25" max="2" step="0.1" value="0.5">
+    <button type="button" id="closePreview" class="close-btn">&times;</button>
+    <span id="closeScaleValue">0.5</span>
+  </label>
   <br>
   <label>Scroll Speed: <input type="range" id="scrollSpeed" min="0.5" max="3" step="0.1" value="1"><span id="scrollSpeedValue">1</span></label>
   <br>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -27,6 +27,9 @@ async function load(){
   document.getElementById('tileScale').value = tileScale;
   document.getElementById('fontScale').value = fontScale;
   document.getElementById('closeScale').value = closeScale;
+  document.getElementById('closeScaleValue').textContent = closeScale;
+  const preview = document.getElementById('closePreview');
+  if (preview) preview.style.fontSize = `calc(1em * ${closeScale})`;
   document.getElementById('scrollSpeed').value = scrollSpeed;
   document.getElementById('scrollSpeedValue').textContent = scrollSpeed;
   document.getElementById('opt-show-recent').checked = showRecent;
@@ -86,6 +89,9 @@ function updateCloseScale(){
   const closeScale=parseFloat(document.getElementById('closeScale').value);
   browser.storage.local.set({closeScale});
   document.documentElement.style.setProperty('--close-scale', closeScale);
+  document.getElementById('closeScaleValue').textContent = closeScale.toFixed(1);
+  const preview = document.getElementById('closePreview');
+  if (preview) preview.style.fontSize = `calc(1em * ${closeScale})`;
 }
 
 function updateScroll(){

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -203,7 +203,20 @@ button:hover {
 .close-btn {
   font-size: calc(1em * var(--close-scale));
   padding: 0;
+  margin: 0;
   line-height: 1;
+  width: 1.2em;
+  height: 1.2em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  margin-left: 0.2em;
+  border: none;
+  background: transparent;
+}
+.close-btn:hover {
+  background: var(--color-hover);
 }
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
- refine `.close-btn` style for a smaller, cleaner look
- show a close button preview next to the Close Button Scale slider
- update options script to sync preview with slider value

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68504195332083318c2e5a5a73385f2a