### PR TITLE
Improved close button design

### DIFF
--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -16,7 +16,12 @@
   <br>
   <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="0.5"></label>
   <br>
-  <label>Scroll Speed: <input type="range" id="scrollSpeed" min="0.5" max="3" step="0.1" value="1"><span id="scrollSpeedValue">1</span></label>
+  <div class="slider-row">
+    <label for="scrollSpeed">Scroll Speed:</label>
+    <input type="range" id="scrollSpeed" min="0.5" max="3" step="0.1" value="1">
+    <span id="scrollSpeedValue">1</span>
+    <button id="save">Save</button>
+  </div>
   <br>
   <label><input type="checkbox" id="opt-show-recent" checked> Show Recent panel</label>
   <br>
@@ -30,7 +35,6 @@
   <br>
   <label>Unload All Shortcut: <input type="text" id="key-unload-all" placeholder="Alt+Shift+U"></label>
   <br>
-  <button id="save">Save</button>
   <script src="theme.js"></script>
   <script src="options.js"></script>
 </body>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -336,8 +336,8 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   const closeCell = document.createElement('div');
   const closeBtn = document.createElement('button');
   closeBtn.className = 'close-btn';
-  closeBtn.textContent = '×';
   closeBtn.title = 'Close tab';
+  closeBtn.innerHTML = '<svg viewBox="0 0 10 10" aria-hidden="true"><path d="M1 1 L9 9 M9 1 L1 9" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg>';
   closeCell.appendChild(closeBtn);
   row.appendChild(closeCell);
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -204,6 +204,33 @@ button:hover {
   font-size: calc(1em * var(--close-scale));
   padding: 0;
   line-height: 1;
+  width: calc(16px * var(--close-scale));
+  height: calc(16px * var(--close-scale));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--color-muted);
+  border-radius: 50%;
+  margin-left: 0.2em;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+.close-btn:hover {
+  background: var(--color-hover);
+  color: var(--color-text);
+}
+.slider-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+}
+.slider-row input[type="range"] {
+  flex: 1;
+}
+.slider-row button {
+  margin-left: 0.4em;
 }
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
- restyle close buttons to be small circular icons
- place Save button next to the scroll speed slider
- create SVG based close icon for each tab row

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68504195332083318c2e5a5a73385f2a