### PR TITLE
Improve close button styling

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -101,6 +101,9 @@ body[data-theme="dark"] #context div:hover {
   max-height: 400px;
   overflow-y: hidden;
 }
+body.popup #tabs {
+  padding-right: 0.4em;
+}
 body.full #tabs {
   max-height: none;
 }
@@ -202,8 +205,24 @@ button:hover {
 }
 .close-btn {
   font-size: calc(1em * var(--close-scale));
-  padding: 0;
+  width: 1.2em;
+  height: 1.2em;
   line-height: 1;
+  border: none;
+  background: transparent;
+  color: var(--color-muted);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 2px;
+  padding: 0;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+.close-btn:hover {
+  background: var(--color-hover);
+  color: var(--color-text);
 }
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
- redesign the close buttons for tabs
- add padding in popup view to keep buttons clear of the scrollbar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68504ea23c1883318552d4c55df80976