### PR TITLE
Improve close button style

### DIFF
--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -14,7 +14,7 @@
   <br>
   <label>Font Scale: <input type="number" id="fontScale" min="0.25" max="2" step="0.1" value="0.8125"></label>
   <br>
-  <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="0.5"></label>
+  <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="0.8"></label>
   <br>
   <label>Scroll Speed: <input type="range" id="scrollSpeed" min="0.5" max="3" step="0.1" value="1"><span id="scrollSpeedValue">1</span></label>
   <br>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -19,7 +19,7 @@ async function load(){
   } = data;
   let closeScale = data.closeScale;
   if (closeScale === undefined) {
-    closeScale = 0.5;
+    closeScale = 0.8;
     browser.storage.local.set({ closeScale });
   }
   document.getElementById('theme').value = theme;

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -12,7 +12,7 @@
   --tile-scale: 0.9;
   --tile-height: calc(32px * var(--tile-scale));
   --font-scale: 0.8125;
-  --close-scale: 0.5;
+  --close-scale: 0.8;
 }
 
 *, *::before, *::after {
@@ -202,8 +202,20 @@ button:hover {
 }
 .close-btn {
   font-size: calc(1em * var(--close-scale));
+  width: calc(1.4em * var(--close-scale));
+  height: calc(1.4em * var(--close-scale));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 0;
   line-height: 1;
+  margin-right: 0.4em;
+  border: none;
+  background: transparent;
+  border-radius: 50%;
+}
+.close-btn:hover {
+  background: var(--color-hover);
 }
 .hidden {
   display: none;

--- a/mytabs/theme.js
+++ b/mytabs/theme.js
@@ -1,8 +1,8 @@
 (async function(){
-  let { theme = 'light', tileWidth = 150, tileScale = 0.9, fontScale = 0.8125, closeScale = 0.5 } =
+  let { theme = 'light', tileWidth = 150, tileScale = 0.9, fontScale = 0.8125, closeScale = 0.8 } =
     await browser.storage.local.get(['theme','tileWidth','tileScale','fontScale','closeScale']);
   if (closeScale === undefined) {
-    closeScale = 0.5;
+    closeScale = 0.8;
     browser.storage.local.set({ closeScale });
   }
 


### PR DESCRIPTION
## Summary
- enlarge close button defaults
- add extra space on right side

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68501ef712c883318cd931e889b9742b