### PR TITLE
Fix popup width scaling

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -29,7 +29,6 @@ body {
   margin: 0;
   padding: 0.5em;
   width: 100%;
-  max-width: 450px;
   box-sizing: border-box;
   background: var(--color-bg);
   color: var(--color-text);


### PR DESCRIPTION
## Summary
- remove 450px width cap so popup can expand fully

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685066ff15cc833188a2827cadc63dc0