### PR TITLE
fix: constrain popup list width

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -100,6 +100,9 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  overflow-x: hidden;
+  width: 100%;
+  box-sizing: border-box;
 }
 body.full #tabs {
   max-height: none;


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling in popup list by hiding overflow

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685066ff15cc833188a2827cadc63dc0