### PR TITLE
fix: clamp popup tab titles

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -99,7 +99,10 @@ body[data-theme="dark"] #context div:hover {
 #tabs {
   margin-top: 0;
   max-height: 400px;
-  overflow-y: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
+  width: 100%;
+  box-sizing: border-box;
 }
 body.full #tabs {
   max-height: none;


### PR DESCRIPTION
## Summary
- keep popup tab list within popup width by hiding horizontal overflow

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685066ff15cc833188a2827cadc63dc0