### PR TITLE
fix: truncate popup titles

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -100,6 +100,9 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  overflow-x: hidden;
+  width: 100%;
+  box-sizing: border-box;
 }
 body.full #tabs {
   max-height: none;

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -99,10 +99,12 @@ body[data-theme="dark"] #context div:hover {
 #tabs {
   margin-top: 0;
   max-height: 400px;
-  overflow-y: hidden;
-  overflow-x: hidden;
   width: 100%;
   box-sizing: border-box;
+}
+body.popup #tabs {
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 body.full #tabs {
   max-height: none;


### PR DESCRIPTION
## Summary
- prevent horizontal scroll in popup list and clip titles to window width

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685066ff15cc833188a2827cadc63dc0