### PR TITLE
fix: enable vertical scroll in popup

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -99,7 +99,10 @@ body[data-theme="dark"] #context div:hover {
 #tabs {
   margin-top: 0;
   max-height: 400px;
-  overflow-y: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
+  width: 100%;
+  box-sizing: border-box;
 }
 body.full #tabs {
   max-height: none;


### PR DESCRIPTION
## Summary
- allow vertical scrolling for tab list while keeping horizontal overflow hidden

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685066ff15cc833188a2827cadc63dc0