### PR TITLE
fix: enable popup vertical scroll

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -100,6 +100,12 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  overflow-x: hidden;
+  width: 100%;
+  box-sizing: border-box;
+}
+body.popup #tabs {
+  overflow-y: auto;
 }
 body.full #tabs {
   max-height: none;


### PR DESCRIPTION
## Summary
- add `overflow-y: auto` for popup tab list to allow vertical scrolling

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685066ff15cc833188a2827cadc63dc0