### PR TITLE
fix: truncate popup titles

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -100,6 +100,12 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  overflow-x: hidden;
+  width: 100%;
+  box-sizing: border-box;
+}
+body.popup #tabs {
+  overflow-y: auto;
 }
 body.full #tabs {
   max-height: none;

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -34,6 +34,9 @@ body {
   background: var(--color-bg);
   color: var(--color-text);
 }
+body.popup {
+  max-width: 100%;
+}
 
 body[data-theme="dark"] {
   --color-bg: #222;


### PR DESCRIPTION
## Summary
- enable vertical scroll in popup without horizontal scroll

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685066ff15cc833188a2827cadc63dc0