### PR TITLE
fix: truncate popup tab titles

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -100,6 +100,26 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  overflow-x: hidden;
+  width: 100%;
+  box-sizing: border-box;
+}
+body.popup {
+  overflow-x: hidden;
+}
+body.popup #tabs {
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+body.popup .tab {
+  width: 100%;
+  overflow: hidden;
+}
+body.popup .tab > div:nth-child(3) {
+  overflow: hidden;
+}
+body.popup .tab-title {
+  max-width: 100%;
 }
 body.full #tabs {
   max-height: none;


### PR DESCRIPTION
## Summary
- keep popup tabs within window width
- ensure long titles are truncated with ellipsis

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685066ff15cc833188a2827cadc63dc0