### PR TITLE
fix: compact popup tiles

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -100,6 +100,20 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  overflow-x: hidden;
+  width: 100%;
+  box-sizing: border-box;
+}
+body.popup {
+  overflow-x: hidden;
+}
+body.popup #tabs {
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(var(--tile-width), 1fr));
+  grid-auto-rows: var(--tile-height);
+  row-gap: 0.25em;
 }
 body.full #tabs {
   max-height: none;
@@ -113,6 +127,14 @@ body.full #tabs {
   break-inside: avoid;
   box-sizing: border-box;
   min-width: 0;
+}
+body.popup .tab {
+  width: 100%;
+  height: var(--tile-height);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 0 0.2em;
+  background: var(--color-bg);
 }
 .tab-icon {
   width: calc(16px * var(--font-scale));


### PR DESCRIPTION
## Summary
- make popup tabs display as equal-width tiles
- keep horizontal scrolling hidden

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685066ff15cc833188a2827cadc63dc0