### PR TITLE
fix: hide horizontal scroll in popup

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -100,6 +100,24 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  overflow-x: hidden;
+  width: 100%;
+  box-sizing: border-box;
+}
+body.popup {
+  overflow-x: hidden;
+}
+body.popup #tabs {
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+body.popup #tabs .tab {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  margin: 0 0 0.2em 0;
+  padding: 0 0.2em;
+  box-sizing: border-box;
 }
 body.full #tabs {
   max-height: none;


### PR DESCRIPTION
## Summary
- ensure popup list never scrolls horizontally
- apply compact tile styling for popup tabs

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685066ff15cc833188a2827cadc63dc0