### PR TITLE
fix: adjust popup close button spacing

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -250,7 +250,8 @@ body.full #tabs {
   display: grid;
   grid-template-columns: repeat(auto-fill, var(--tile-width));
   grid-auto-flow: row;
-  gap: 0.2em;
+  row-gap: 0;
+  column-gap: 0;
   width: max-content;
   min-width: 100%;
   min-height: 100%;

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -100,6 +100,24 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  overflow-x: hidden;
+  width: 100%;
+  box-sizing: border-box;
+}
+body.popup {
+  overflow-x: hidden;
+}
+body.popup #tabs {
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-gutter: stable;
+}
+body.popup .tab {
+  width: 100%;
+  padding-right: 0.5em;
+}
+body.popup .tab > div:last-child {
+  margin-left: auto;
 }
 body.full #tabs {
   max-height: none;


### PR DESCRIPTION
## Summary
- reserve scrollbar space for popup tab list
- keep close buttons aligned next to the scrollbar

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685066ff15cc833188a2827cadc63dc0