### PR TITLE
fix: hide horizontal scroll in popup

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -100,6 +100,14 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
+  width: 100%;
+  box-sizing: border-box;
+}
+body.popup #tabs {
+  overflow-y: auto;
+  overflow-x: hidden;
+  width: 100%;
+  box-sizing: border-box;
 }
 body.full #tabs {
   max-height: none;
@@ -113,6 +121,9 @@ body.full #tabs {
   break-inside: avoid;
   box-sizing: border-box;
   min-width: 0;
+}
+body.popup .tab {
+  width: 100%;
 }
 .tab-icon {
   width: calc(16px * var(--font-scale));


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling in popup view
- ensure popup tabs span full width

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685066ff15cc833188a2827cadc63dc0