### PR TITLE
Enhance close button

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -12,6 +12,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   command to unload all tabs at once. The keyboard shortcut for this command can
   be configured on the Options page.
 - Each tab row includes a button to quickly close that tab.
+- The close button uses an inline SVG icon and appears when hovering a tab.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.
 - Bulk assign selected tabs to any Firefox container or move them back to the default container.
 - Pinned and active tabs retain their state and original order when moved between windows or containers.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -336,8 +336,13 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   const closeCell = document.createElement('div');
   const closeBtn = document.createElement('button');
   closeBtn.className = 'close-btn';
-  closeBtn.textContent = '×';
+  closeBtn.innerHTML =
+    '<svg viewBox="0 0 12 12" aria-hidden="true" focusable="false">' +
+    '<path d="M2 2 L10 10 M10 2 L2 10" ' +
+    'stroke="currentColor" stroke-width="2" stroke-linecap="round"/>' +
+    '</svg>';
   closeBtn.title = 'Close tab';
+  closeBtn.setAttribute('aria-label', 'Close tab');
   closeCell.appendChild(closeBtn);
   row.appendChild(closeCell);
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -112,6 +112,8 @@ body.popup #tabs {
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-gutter: stable;
+  width: 100%;
+  box-sizing: border-box;
 }
 body.popup .tab {
   width: 100%;
@@ -120,16 +122,6 @@ body.popup .tab {
 body.popup .tab > div:last-child {
   margin-left: auto;
   margin-right: 0.5em;
-=======
-  width: 100%;
-  box-sizing: border-box;
-}
-body.popup #tabs {
-  overflow-y: auto;
-  overflow-x: hidden;
-  width: 100%;
-  box-sizing: border-box;
-
 }
 body.full #tabs {
   max-height: none;
@@ -234,9 +226,28 @@ button:hover {
   background: var(--color-hover);
 }
 .close-btn {
-  font-size: calc(1em * var(--close-scale));
+  width: calc(1em * var(--close-scale));
+  height: calc(1em * var(--close-scale));
   padding: 0;
   line-height: 1;
+  border: none;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.close-btn svg {
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.tab .close-btn {
+  visibility: hidden;
+}
+.tab:hover .close-btn,
+.tab.active .close-btn,
+.tab.selected .close-btn {
+  visibility: visible;
 }
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
- polish up pop-up tab styling
- show a SVG close button on hover and active rows

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850a70d41ec8331b76c30eb930f24fe