### PR TITLE
Tooltip cleanup and style v2

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -58,6 +58,10 @@ function clearPlaceholder() {
   }
 }
 
+function hideAllTooltips() {
+  document.querySelectorAll('.tab-tooltip').forEach(t => t.remove());
+}
+
 function showPlaceholder(target, before) {
   if (dropTarget === target &&
       target.classList.contains(before ? 'drop-before' : 'drop-after')) {
@@ -550,6 +554,7 @@ function findDuplicates(tabs) {
 }
 
 async function update() {
+  hideAllTooltips();
   const isFull = document.body.classList.contains('full');
   const prevScroll = scrollContainer
     ? isFull
@@ -718,6 +723,7 @@ async function init() {
     ? document.getElementById('tabs-wrapper')
     : container;
   scrollContainer.addEventListener('scroll', saveScroll);
+  scrollContainer.addEventListener('scroll', hideAllTooltips);
   container.addEventListener('click', onContainerClick);
   container.addEventListener('dragstart', onContainerDragStart);
   container.addEventListener('dragover', onContainerDragOver);
@@ -906,6 +912,7 @@ window.addEventListener('resize', () => {
 const context = document.getElementById('context');
 function showContextMenu(e) {
   e.preventDefault();
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   context.innerHTML = '';
 
@@ -1085,6 +1092,7 @@ async function bulkRemoveFromContainer() {
 }
 
 function onContainerClick(e) {
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   if (!tabEl || !container.contains(tabEl)) return;
   if (e.target.classList.contains('close-btn')) {
@@ -1117,6 +1125,7 @@ function onContainerClick(e) {
 }
 
 function onContainerDragStart(e) {
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   if (!tabEl) return;
   const selected = getSelectedTabIds();
@@ -1129,6 +1138,7 @@ function onContainerDragStart(e) {
 }
 
 function onContainerDragOver(e) {
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   if (!tabEl) return;
   e.preventDefault();
@@ -1138,6 +1148,7 @@ function onContainerDragOver(e) {
 }
 
 async function onContainerDrop(e) {
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   if (!tabEl) return;
   e.preventDefault();

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -265,20 +265,21 @@ button:hover {
 
 .tab-tooltip {
   position: absolute;
-  background: var(--color-bg);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-  padding: 0.2em 0.4em;
+  background: rgba(48, 48, 48, 0.95);
+  color: #fff;
+  padding: 0.3em 0.6em;
   border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  font-size: 0.75rem;
+  line-height: 1.2;
+  white-space: nowrap;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.3);
   pointer-events: none;
   z-index: 1000;
 }
 
 body[data-theme="dark"] .tab-tooltip {
-  background: var(--color-hover);
-  color: var(--color-text);
-  border-color: var(--color-border);
+  background: rgba(48, 48, 48, 0.95);
+  color: #fff;
 }
 
 #bulk-actions {


### PR DESCRIPTION
## Summary
- remove lingering tooltip elements when content updates or scroll events occur
- update tooltip styling with darker background and lighter text

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850addee37083318c318f80a112c26d