### PR TITLE
Refine tooltip visuals with fade

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -58,6 +58,10 @@ function clearPlaceholder() {
   }
 }
 
+function hideAllTooltips() {
+  document.querySelectorAll('.tab-tooltip').forEach(t => t.remove());
+}
+
 function showPlaceholder(target, before) {
   if (dropTarget === target &&
       target.classList.contains(before ? 'drop-before' : 'drop-after')) {
@@ -293,12 +297,14 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
     let tooltip;
     const showTooltip = () => {
       if (!document.body.classList.contains('full')) return;
+      hideAllTooltips();
       tooltip = document.createElement('div');
       tooltip.className = 'tab-tooltip';
       const safeTitle = escapeHtml(tab.title || tab.url);
       const safeUrl = escapeHtml(tab.url);
       tooltip.innerHTML = `${safeTitle}<br>${safeUrl}`;
       document.body.appendChild(tooltip);
+      requestAnimationFrame(() => tooltip.classList.add('visible'));
       const rect = icon.getBoundingClientRect();
       tooltip.style.left = `${rect.right + window.scrollX + 5}px`;
       tooltip.style.top = `${rect.top + window.scrollY}px`;
@@ -550,6 +556,7 @@ function findDuplicates(tabs) {
 }
 
 async function update() {
+  hideAllTooltips();
   const isFull = document.body.classList.contains('full');
   const prevScroll = scrollContainer
     ? isFull
@@ -718,6 +725,7 @@ async function init() {
     ? document.getElementById('tabs-wrapper')
     : container;
   scrollContainer.addEventListener('scroll', saveScroll);
+  scrollContainer.addEventListener('scroll', hideAllTooltips);
   container.addEventListener('click', onContainerClick);
   container.addEventListener('dragstart', onContainerDragStart);
   container.addEventListener('dragover', onContainerDragOver);
@@ -906,6 +914,7 @@ window.addEventListener('resize', () => {
 const context = document.getElementById('context');
 function showContextMenu(e) {
   e.preventDefault();
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   context.innerHTML = '';
 
@@ -1085,6 +1094,7 @@ async function bulkRemoveFromContainer() {
 }
 
 function onContainerClick(e) {
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   if (!tabEl || !container.contains(tabEl)) return;
   if (e.target.classList.contains('close-btn')) {
@@ -1117,6 +1127,7 @@ function onContainerClick(e) {
 }
 
 function onContainerDragStart(e) {
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   if (!tabEl) return;
   const selected = getSelectedTabIds();
@@ -1129,6 +1140,7 @@ function onContainerDragStart(e) {
 }
 
 function onContainerDragOver(e) {
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   if (!tabEl) return;
   e.preventDefault();
@@ -1138,6 +1150,7 @@ function onContainerDragOver(e) {
 }
 
 async function onContainerDrop(e) {
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   if (!tabEl) return;
   e.preventDefault();

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -265,20 +265,29 @@ button:hover {
 
 .tab-tooltip {
   position: absolute;
-  background: var(--color-bg);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-  padding: 0.2em 0.4em;
-  border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  background: linear-gradient(180deg, rgba(80, 80, 80, 0.95), rgba(60, 60, 60, 0.95));
+  color: #fff;
+  border: 1px solid #777;
+  padding: 0.4em 0.7em;
+  font-size: 0.85em;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
   pointer-events: none;
   z-index: 1000;
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.tab-tooltip.visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 body[data-theme="dark"] .tab-tooltip {
-  background: var(--color-hover);
-  color: var(--color-text);
-  border-color: var(--color-border);
+  background: linear-gradient(180deg, rgba(50, 50, 50, 0.95), rgba(30, 30, 30, 0.95));
+  color: #eee;
+  border-color: #555;
 }
 
 #bulk-actions {


### PR DESCRIPTION
## Summary
- add fade-in animation and gradient background for tooltips
- bump tooltip shadow and border radius

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850addee37083318c318f80a112c26d