### PR TITLE
Improve tooltip visuals v2

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -58,6 +58,10 @@ function clearPlaceholder() {
   }
 }
 
+function hideAllTooltips() {
+  document.querySelectorAll('.tab-tooltip').forEach(t => t.remove());
+}
+
 function showPlaceholder(target, before) {
   if (dropTarget === target &&
       target.classList.contains(before ? 'drop-before' : 'drop-after')) {
@@ -293,6 +297,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
     let tooltip;
     const showTooltip = () => {
       if (!document.body.classList.contains('full')) return;
+      hideAllTooltips();
       tooltip = document.createElement('div');
       tooltip.className = 'tab-tooltip';
       const safeTitle = escapeHtml(tab.title || tab.url);
@@ -302,11 +307,15 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
       const rect = icon.getBoundingClientRect();
       tooltip.style.left = `${rect.right + window.scrollX + 5}px`;
       tooltip.style.top = `${rect.top + window.scrollY}px`;
+      tooltip.getBoundingClientRect();
+      tooltip.classList.add('show');
     };
     const hideTooltip = () => {
       if (tooltip) {
-        tooltip.remove();
+        const t = tooltip;
         tooltip = null;
+        t.classList.remove('show');
+        t.addEventListener('transitionend', () => t.remove(), { once: true });
       }
     };
     icon.addEventListener('mouseenter', showTooltip);
@@ -550,6 +559,7 @@ function findDuplicates(tabs) {
 }
 
 async function update() {
+  hideAllTooltips();
   const isFull = document.body.classList.contains('full');
   const prevScroll = scrollContainer
     ? isFull
@@ -718,6 +728,7 @@ async function init() {
     ? document.getElementById('tabs-wrapper')
     : container;
   scrollContainer.addEventListener('scroll', saveScroll);
+  scrollContainer.addEventListener('scroll', hideAllTooltips);
   container.addEventListener('click', onContainerClick);
   container.addEventListener('dragstart', onContainerDragStart);
   container.addEventListener('dragover', onContainerDragOver);
@@ -906,6 +917,7 @@ window.addEventListener('resize', () => {
 const context = document.getElementById('context');
 function showContextMenu(e) {
   e.preventDefault();
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   context.innerHTML = '';
 
@@ -1085,6 +1097,7 @@ async function bulkRemoveFromContainer() {
 }
 
 function onContainerClick(e) {
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   if (!tabEl || !container.contains(tabEl)) return;
   if (e.target.classList.contains('close-btn')) {
@@ -1117,6 +1130,7 @@ function onContainerClick(e) {
 }
 
 function onContainerDragStart(e) {
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   if (!tabEl) return;
   const selected = getSelectedTabIds();
@@ -1129,6 +1143,7 @@ function onContainerDragStart(e) {
 }
 
 function onContainerDragOver(e) {
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   if (!tabEl) return;
   e.preventDefault();
@@ -1138,6 +1153,7 @@ function onContainerDragOver(e) {
 }
 
 async function onContainerDrop(e) {
+  hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   if (!tabEl) return;
   e.preventDefault();

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -265,20 +265,43 @@ button:hover {
 
 .tab-tooltip {
   position: absolute;
-  background: var(--color-bg);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-  padding: 0.2em 0.4em;
+  background: rgba(60, 60, 60, 0.95);
+  color: #fff;
+  border: 1px solid #666;
+  padding: 0.3em 0.6em;
+  font-size: 0.85em;
   border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
   pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
   z-index: 1000;
 }
 
+.tab-tooltip.show {
+  opacity: 1;
+}
+
+.tab-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 10px;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 5px 5px 0 5px;
+  border-color: rgba(60, 60, 60, 0.95) transparent transparent transparent;
+}
+
 body[data-theme="dark"] .tab-tooltip {
-  background: var(--color-hover);
-  color: var(--color-text);
-  border-color: var(--color-border);
+  background: rgba(40, 40, 40, 0.95);
+  color: #eee;
+  border-color: #555;
+}
+
+body[data-theme="dark"] .tab-tooltip::after {
+  border-color: rgba(40, 40, 40, 0.95) transparent transparent transparent;
 }
 
 #bulk-actions {


### PR DESCRIPTION
## Summary
- add fade transition and arrow to tooltips
- show/hide tooltip smoothly in popup.js

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850addee37083318c318f80a112c26d