### PR TITLE
Fix tooltip clipping

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -305,8 +305,17 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
       tooltip.innerHTML = `${safeTitle}<br>${safeUrl}`;
       document.body.appendChild(tooltip);
       const rect = icon.getBoundingClientRect();
-      tooltip.style.left = `${rect.right + window.scrollX + 5}px`;
-      tooltip.style.top = `${rect.top + window.scrollY}px`;
+      let left = rect.right + window.scrollX + 5;
+      const top = rect.top + window.scrollY;
+      const width = tooltip.offsetWidth;
+      if (left + width > window.innerWidth - 5) {
+        left = rect.left + window.scrollX - width - 5;
+        tooltip.classList.add('left');
+      } else {
+        tooltip.classList.remove('left');
+      }
+      tooltip.style.left = `${left}px`;
+      tooltip.style.top = `${top}px`;
       requestAnimationFrame(() => {
         tooltip.classList.add('visible');
       });
@@ -316,7 +325,10 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
         tooltip.classList.remove('visible');
         const el = tooltip;
         tooltip = null;
-        setTimeout(() => el.remove(), 150);
+        setTimeout(() => {
+          el.classList.remove('left');
+          el.remove();
+        }, 150);
       }
     };
     icon.addEventListener('mouseenter', showTooltip);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -271,8 +271,6 @@ button:hover {
   padding: 0.3em 0.6em;
   font-size: 0.85em;
   border-radius: 4px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
-=======
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
   pointer-events: none;
   z-index: 1000;
@@ -297,6 +295,12 @@ button:hover {
   border-color: transparent rgba(60, 60, 60, 0.95) transparent transparent;
 }
 
+.tab-tooltip.left::after {
+  left: auto;
+  right: -5px;
+  border-color: transparent transparent transparent rgba(60, 60, 60, 0.95);
+}
+
 body[data-theme="dark"] .tab-tooltip {
   background: rgba(40, 40, 40, 0.95);
   color: #eee;
@@ -305,7 +309,10 @@ body[data-theme="dark"] .tab-tooltip {
 
 body[data-theme="dark"] .tab-tooltip::after {
   border-color: transparent rgba(40, 40, 40, 0.95) transparent transparent;
-=======
+}
+
+body[data-theme="dark"] .tab-tooltip.left::after {
+  border-color: transparent transparent transparent rgba(40, 40, 40, 0.95);
 }
 
 #bulk-actions {


### PR DESCRIPTION
## Summary
- improve tooltip placement logic
- fix leftover conflict markers in stylesheet
- add flipped pointer style for tooltips on the left

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850b6b52b7483318bb749bb338f2991