### PR TITLE
v0.2.1: fix tooltip clipping

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -24,6 +24,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
     Trackpad gestures and horizontal wheels are supported.
   - Scroll speed can be adjusted from the Options page to make scrolling more aggressive.
   - Hovering a tab's icon in Full View shows a custom tooltip with the tab title and URL.
+  - Tooltips near the edge now flip to the left to stay fully visible.
   - The columns can extend wider than the window and a horizontal scrollbar appears when needed.
   - Tabs from each window are separated by labeled dividers with extra spacing for clarity.
 - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "KepiTAB",
-  "version": "0.2",
+  "version": "0.2.1",
   "description": "A simple tab management tool inspired by All Tabs Helper",
     "permissions": [
       "tabs",

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -307,6 +307,10 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
       const rect = icon.getBoundingClientRect();
       tooltip.style.left = `${rect.right + window.scrollX + 5}px`;
       tooltip.style.top = `${rect.top + window.scrollY}px`;
+      if (rect.right + tooltip.offsetWidth + 5 > window.innerWidth) {
+        tooltip.classList.add('left');
+        tooltip.style.left = `${rect.left + window.scrollX - tooltip.offsetWidth - 5}px`;
+      }
       requestAnimationFrame(() => {
         tooltip.classList.add('visible');
       });

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -271,8 +271,6 @@ button:hover {
   padding: 0.3em 0.6em;
   font-size: 0.85em;
   border-radius: 4px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
-=======
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
   pointer-events: none;
   z-index: 1000;
@@ -297,6 +295,12 @@ button:hover {
   border-color: transparent rgba(60, 60, 60, 0.95) transparent transparent;
 }
 
+.tab-tooltip.left::after {
+  left: auto;
+  right: -5px;
+  border-color: transparent transparent transparent rgba(60, 60, 60, 0.95);
+}
+
 body[data-theme="dark"] .tab-tooltip {
   background: rgba(40, 40, 40, 0.95);
   color: #eee;
@@ -305,7 +309,10 @@ body[data-theme="dark"] .tab-tooltip {
 
 body[data-theme="dark"] .tab-tooltip::after {
   border-color: transparent rgba(40, 40, 40, 0.95) transparent transparent;
-=======
+}
+
+body[data-theme="dark"] .tab-tooltip.left::after {
+  border-color: transparent transparent transparent rgba(40, 40, 40, 0.95);
 }
 
 #bulk-actions {


### PR DESCRIPTION
## Summary
- improve tooltip placement to avoid clipping on the last column
- add CSS for left-aligned tooltip arrow
- document the fix and update version to 0.2.1

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850b6b52b7483318bb749bb338f2991