### PR TITLE
Trim tooltip text in full view

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -23,7 +23,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   - In Full View, overflowing columns can be scrolled horizontally with the mouse wheel.
     Trackpad gestures and horizontal wheels are supported.
   - Scroll speed can be adjusted from the Options page to make scrolling more aggressive.
-  - Hovering a tab's icon in Full View shows a custom tooltip with the tab title and URL.
+  - Hovering a tab's icon in Full View shows a custom tooltip with the tab title and URL, truncated for brevity.
   - The columns can extend wider than the window and a horizontal scrollbar appears when needed.
   - Tabs from each window are separated by labeled dividers with extra spacing for clarity.
 - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -103,6 +103,10 @@ function escapeHtml(str) {
   }[c]));
 }
 
+function truncateText(str, maxLen = 80) {
+  return str.length > maxLen ? str.slice(0, maxLen - 1) + '…' : str;
+}
+
 async function loadOptions() {
   const {
     showRecent = true,
@@ -300,8 +304,10 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
       hideAllTooltips();
       tooltip = document.createElement('div');
       tooltip.className = 'tab-tooltip';
-      const safeTitle = escapeHtml(tab.title || tab.url);
-      const safeUrl = escapeHtml(tab.url);
+      const truncatedTitle = truncateText(tab.title || tab.url);
+      const truncatedUrl = truncateText(tab.url);
+      const safeTitle = escapeHtml(truncatedTitle);
+      const safeUrl = escapeHtml(truncatedUrl);
       tooltip.innerHTML = `${safeTitle}<br>${safeUrl}`;
       document.body.appendChild(tooltip);
       const rect = icon.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- shorten the tooltip title and URL to avoid oversized text
- mention truncated tooltip in documentation

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850b9b7ce488331b7343efb8a297116