### PR TITLE
Fix popup drag issue

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -291,6 +291,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
     icon.className = 'tab-icon';
     icon.src = tab.favIconUrl;
     icon.alt = '';
+    icon.draggable = false;
     icon.onerror = () => icon.remove();
     iconCell.appendChild(icon);
   
@@ -360,6 +361,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   closeBtn.className = 'close-btn';
   closeBtn.textContent = '×';
   closeBtn.title = 'Close tab';
+  closeBtn.draggable = false;
   closeCell.appendChild(closeBtn);
   row.appendChild(closeCell);
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -137,6 +137,7 @@ body.full #tabs {
   break-inside: avoid;
   box-sizing: border-box;
   min-width: 0;
+  user-select: none;
 }
 body.popup .tab {
   width: 100%;


### PR DESCRIPTION
## Summary
- prevent image and button drag interference
- disable text selection to improve drag start reliability

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850b9ed736083318dda71eb1c9d4956