### PR TITLE
feat(popup): improve drag handling

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -363,6 +363,11 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   closeCell.appendChild(closeBtn);
   row.appendChild(closeCell);
 
+  // ensure dragging works from any cell in popup mode
+  row.querySelectorAll('*').forEach(el => {
+    el.draggable = true;
+  });
+
   // click and drag events handled via delegation
 
   return row;


### PR DESCRIPTION
## Summary
- set `draggable` on all tab row children so dragging is reliable in popup mode

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850b9ed736083318dda71eb1c9d4956