### PR TITLE
Disable text selection on tabs

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -137,6 +137,8 @@ body.full #tabs {
   break-inside: avoid;
   box-sizing: border-box;
   min-width: 0;
+  user-select: none;
+  -moz-user-select: none;
 }
 body.popup .tab {
   width: 100%;


### PR DESCRIPTION
## Summary
- prevent text selection on tab items to improve drag reliability

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850b9ed736083318dda71eb1c9d4956