### PR TITLE
fix(popup): disable text selection

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -363,6 +363,11 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   closeCell.appendChild(closeBtn);
   row.appendChild(closeCell);
 
+  // ensure dragging works from any cell in popup mode
+  row.querySelectorAll('*').forEach(el => {
+    el.draggable = true;
+  });
+
   // click and drag events handled via delegation
 
   return row;

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -137,6 +137,7 @@ body.full #tabs {
   break-inside: avoid;
   box-sizing: border-box;
   min-width: 0;
+  user-select: none;
 }
 body.popup .tab {
   width: 100%;


### PR DESCRIPTION
## Summary
- prevent text selection on tab rows to help dragging

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850b9ed736083318dda71eb1c9d4956