### PR TITLE
fix(v2): improve popup drag start

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -363,6 +363,11 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   closeCell.appendChild(closeBtn);
   row.appendChild(closeCell);
 
+  // ensure dragging works from any cell in popup mode
+  row.querySelectorAll('*').forEach(el => {
+    el.draggable = true;
+  });
+
   // click and drag events handled via delegation
 
   return row;
@@ -1146,12 +1151,15 @@ function onContainerDragStart(e) {
   hideAllTooltips();
   const tabEl = e.target.closest('.tab');
   if (!tabEl) return;
+  e.dataTransfer.effectAllowed = 'move';
+  e.dataTransfer.dropEffect = 'move';
   const selected = getSelectedTabIds();
   if (selected.length > 1 && tabEl.classList.contains('selected')) {
     e.dataTransfer.setData('text/plain', selected.join(','));
   } else {
     e.dataTransfer.setData('text/plain', tabEl.dataset.tab);
   }
+  e.dataTransfer.setDragImage(tabEl, 0, 0);
   clearPlaceholder();
 }
 
@@ -1160,6 +1168,7 @@ function onContainerDragOver(e) {
   const tabEl = e.target.closest('.tab');
   if (!tabEl) return;
   e.preventDefault();
+  e.dataTransfer.dropEffect = 'move';
   const rect = tabEl.getBoundingClientRect();
   const before = e.clientY < rect.top + rect.height / 2;
   showPlaceholder(tabEl, before);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -137,6 +137,7 @@ body.full #tabs {
   break-inside: avoid;
   box-sizing: border-box;
   min-width: 0;
+  user-select: none;
 }
 body.popup .tab {
   width: 100%;


### PR DESCRIPTION
## Summary
- adjust drag events to explicitly set effectAllowed and dropEffect
- use the dragged element as the drag image

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850b9ed736083318dda71eb1c9d4956