### PR TITLE
fix(popup): improve drag reliability

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -271,6 +271,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   row.dataset.windowId = tab.windowId;
   row.tabIndex = 0;
   row.draggable = true;
+  row.setAttribute('draggable', 'true');
   if (item) row._item = item;
   if (tab.id === activeId) {
     row.classList.add('active');
@@ -362,6 +363,12 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   closeBtn.title = 'Close tab';
   closeCell.appendChild(closeBtn);
   row.appendChild(closeCell);
+
+  // ensure dragging works from any cell in popup mode
+  row.querySelectorAll('*').forEach(el => {
+    el.draggable = true;
+    el.setAttribute('draggable', 'true');
+  });
 
   // click and drag events handled via delegation
 
@@ -1152,6 +1159,7 @@ function onContainerDragStart(e) {
   } else {
     e.dataTransfer.setData('text/plain', tabEl.dataset.tab);
   }
+  e.dataTransfer.effectAllowed = 'move';
   clearPlaceholder();
 }
 
@@ -1160,6 +1168,7 @@ function onContainerDragOver(e) {
   const tabEl = e.target.closest('.tab');
   if (!tabEl) return;
   e.preventDefault();
+  e.dataTransfer.dropEffect = 'move';
   const rect = tabEl.getBoundingClientRect();
   const before = e.clientY < rect.top + rect.height / 2;
   showPlaceholder(tabEl, before);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -137,6 +137,13 @@ body.full #tabs {
   break-inside: avoid;
   box-sizing: border-box;
   min-width: 0;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+  cursor: grab;
+}
+.tab:active {
+  cursor: grabbing;
 }
 body.popup .tab {
   width: 100%;


### PR DESCRIPTION
## Summary
- explicitly mark popup rows and child elements as draggable
- hint drag effect during dragstart/over
- avoid text selection across browsers and show grab cursor

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850b9ed736083318dda71eb1c9d4956