### PR TITLE
Add tooltip support in popup view

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -23,7 +23,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   - In Full View, overflowing columns can be scrolled horizontally with the mouse wheel.
     Trackpad gestures and horizontal wheels are supported.
   - Scroll speed can be adjusted from the Options page to make scrolling more aggressive.
-  - Hovering a tab's icon in Full View shows a custom tooltip with the tab title and URL, truncated for brevity.
+  - Hovering a tab's icon in the popup or Full View shows a custom tooltip with the tab title and URL, truncated for brevity.
   - The columns can extend wider than the window and a horizontal scrollbar appears when needed.
   - Tabs from each window are separated by labeled dividers with extra spacing for clarity.
 - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -300,7 +300,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   
     let tooltip;
     const showTooltip = () => {
-      if (!document.body.classList.contains('full')) return;
+      // Allow tooltips in both popup and full views
       hideAllTooltips();
       tooltip = document.createElement('div');
       tooltip.className = 'tab-tooltip';


### PR DESCRIPTION
## Summary
- show tab icon tooltips when hovering icons in popup view as well as full view
- update documentation to reflect popup tooltip feature

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850bbb3d2408331b04d2730db080eba