### PR TITLE
fix(v1.1.1): display container dot

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -26,7 +26,8 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   - Hovering a tab's icon in the popup or Full View shows a custom tooltip with the tab title and URL, truncated for brevity.
   - The columns can extend wider than the window and a horizontal scrollbar appears when needed.
   - Tabs from each window are separated by labeled dividers with extra spacing for clarity.
-- Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
+  - Container names appear next to the colored dot in Full View so you can easily identify each tab's context.
+  - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
   the Recent and Duplicates panels or the Move command.
 - The Close Button Scale adjusts the “×” size independent of the font scale.
 - A dark theme can also be enabled from the options page.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -351,6 +351,12 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
     indicator.style.backgroundColor = ctx.colorCode;
     indicator.title = ctx.name;
     indicatorCell.appendChild(indicator);
+    if (document.body.classList.contains('full')) {
+      const label = document.createElement('span');
+      label.className = 'container-name';
+      label.textContent = ctx.name;
+      indicatorCell.appendChild(label);
+    }
   }
   row.appendChild(indicatorCell);
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -156,6 +156,16 @@ body.popup .tab {
   width: calc(10px * var(--font-scale));
   height: calc(10px * var(--font-scale));
   border-radius: 50%;
+  display: inline-block;
+  margin-right: 0.25em;
+}
+.container-name {
+  margin-left: 0.25em;
+  font-size: 0.8em;
+  white-space: nowrap;
+}
+body.popup .container-name {
+  display: none;
 }
 .tab:hover {
   background: var(--color-hover);


### PR DESCRIPTION
## Summary
- ensure the container indicator is visible by making the dot an inline block

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d11fabd48331aacaceed199ed0dd