### PR TITLE
fix(v1.1): display container indicator correctly

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -26,7 +26,8 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   - Hovering a tab's icon in the popup or Full View shows a custom tooltip with the tab title and URL, truncated for brevity.
   - The columns can extend wider than the window and a horizontal scrollbar appears when needed.
   - Tabs from each window are separated by labeled dividers with extra spacing for clarity.
-- Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
+  - A colored dot indicates the tab's container. Container names appear next to the dot in Full View so you can easily identify each tab's context.
+  - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
   the Recent and Duplicates panels or the Move command.
 - The Close Button Scale adjusts the “×” size independent of the font scale.
 - A dark theme can also be enabled from the options page.

--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -26,7 +26,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   - Hovering a tab's icon in the popup or Full View shows a custom tooltip with the tab title and URL, truncated for brevity.
   - The columns can extend wider than the window and a horizontal scrollbar appears when needed.
   - Tabs from each window are separated by labeled dividers with extra spacing for clarity.
-  - A colored dot indicates the tab's container. Container names appear next to the dot in Full View so you can easily identify each tab's context.
+  - A colored dot indicates the tab's container.
   - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
   the Recent and Duplicates panels or the Move command.
 - The Close Button Scale adjusts the “×” size independent of the font scale.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -351,6 +351,12 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
     indicator.style.backgroundColor = ctx.colorCode;
     indicator.title = ctx.name;
     indicatorCell.appendChild(indicator);
+    if (document.body.classList.contains('full')) {
+      const label = document.createElement('span');
+      label.className = 'container-name';
+      label.textContent = ctx.name;
+      indicatorCell.appendChild(label);
+    }
   }
   row.appendChild(indicatorCell);
 

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -351,12 +351,6 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
     indicator.style.backgroundColor = ctx.colorCode;
     indicator.title = ctx.name;
     indicatorCell.appendChild(indicator);
-    if (document.body.classList.contains('full')) {
-      const label = document.createElement('span');
-      label.className = 'container-name';
-      label.textContent = ctx.name;
-      indicatorCell.appendChild(label);
-    }
   }
   row.appendChild(indicatorCell);
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -153,9 +153,19 @@ body.popup .tab {
   height: calc(16px * var(--font-scale));
 }
 .container-indicator {
+  display: inline-block;
   width: calc(10px * var(--font-scale));
   height: calc(10px * var(--font-scale));
   border-radius: 50%;
+  margin-right: 0.25em;
+}
+.container-name {
+  margin-left: 0.25em;
+  font-size: 0.8em;
+  white-space: nowrap;
+}
+body.popup .container-name {
+  display: none;
 }
 .tab:hover {
   background: var(--color-hover);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -159,14 +159,6 @@ body.popup .tab {
   border-radius: 50%;
   margin-right: 0.25em;
 }
-.container-name {
-  margin-left: 0.25em;
-  font-size: 0.8em;
-  white-space: nowrap;
-}
-body.popup .container-name {
-  display: none;
-}
 .tab:hover {
   background: var(--color-hover);
 }


### PR DESCRIPTION
## Summary
- ensure the container dot is visible using inline-block display
- document container indicator in README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850d11fabd48331aacaceed199ed0dd