### PR TITLE
Add tooltip context info

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -22,7 +22,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   - The mouse wheel scrolls the tab list even when the pointer is over the menu or search field.
   - In Full View, overflowing columns can be scrolled horizontally with the mouse wheel.
   - Scroll speed can be adjusted from the Options page to make scrolling more aggressive.
-  - Hovering a tab's icon in Full View shows a custom tooltip with the tab title and URL.
+  - Hovering a tab's icon in either view shows a custom tooltip with the tab title, URL and container name.
   - The columns can extend wider than the window and a horizontal scrollbar appears when needed.
 - Options page lets you choose theme, tile width, tile scale, font scale and close button scale and toggle features such as
   the Recent and Duplicates panels or the Move command.

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "KepiTAB",
-  "version": "0.2",
+  "version": "0.2.1",
   "description": "A simple tab management tool inspired by All Tabs Helper",
     "permissions": [
       "tabs",

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -279,12 +279,13 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
 
     let tooltip;
     const showTooltip = () => {
-      if (!document.body.classList.contains('full')) return;
       tooltip = document.createElement('div');
       tooltip.className = 'tab-tooltip';
       const safeTitle = escapeHtml(tab.title || tab.url);
       const safeUrl = escapeHtml(tab.url);
-      tooltip.innerHTML = `${safeTitle}<br>${safeUrl}`;
+      const ctx = containerMap.get(tab.cookieStoreId);
+      const safeCtx = ctx ? `<br>${escapeHtml(ctx.name)}` : '';
+      tooltip.innerHTML = `${safeTitle}<br>${safeUrl}${safeCtx}`;
       document.body.appendChild(tooltip);
       const rect = icon.getBoundingClientRect();
       tooltip.style.left = `${rect.right + window.scrollX + 5}px`;


### PR DESCRIPTION
## Summary
- show page title, URL and container in tooltip
- enable tooltip on icons for popup view as well
- document new tooltip behavior
- bump manifest version to 0.2.1

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851496b7dc48331942bf436d3b6bb21