### PR TITLE
feat: show container info in tooltip

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -279,12 +279,13 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
 
     let tooltip;
     const showTooltip = () => {
-      if (!document.body.classList.contains('full')) return;
       tooltip = document.createElement('div');
       tooltip.className = 'tab-tooltip';
       const safeTitle = escapeHtml(tab.title || tab.url);
       const safeUrl = escapeHtml(tab.url);
-      tooltip.innerHTML = `${safeTitle}<br>${safeUrl}`;
+      const ctx = containerMap.get(tab.cookieStoreId);
+      const safeCtx = escapeHtml(ctx ? ctx.name : 'Default');
+      tooltip.innerHTML = `${safeTitle}<br>${safeUrl}<br><em>${safeCtx}</em>`;
       document.body.appendChild(tooltip);
       const rect = icon.getBoundingClientRect();
       tooltip.style.left = `${rect.right + window.scrollX + 5}px`;

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -196,6 +196,12 @@ button:hover {
   pointer-events: none;
   z-index: 1000;
 }
+.tab-tooltip em {
+  display: block;
+  font-style: normal;
+  color: var(--color-muted);
+  font-size: 0.85em;
+}
 
 body[data-theme="dark"] .tab-tooltip {
   background: var(--color-hover);


### PR DESCRIPTION
## Summary
- display tab container name in tooltip
- enable tooltip in popup view
- style tooltip context label

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851496b7dc48331942bf436d3b6bb21