### PR TITLE
feat: add container info in tab tooltip

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -23,7 +23,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   - In Full View, overflowing columns can be scrolled horizontally with the mouse wheel.
     Trackpad gestures and horizontal wheels are supported.
   - Scroll speed can be adjusted from the Options page to make scrolling more aggressive.
-  - Hovering a tab's icon in the popup or Full View shows a custom tooltip with the tab title and URL, truncated for brevity.
+  - Hovering a tab's icon in the popup or Full View shows a custom tooltip with the tab title and URL, truncated for brevity. In Full View the tooltip also displays the tab's container name when available.
   - The columns can extend wider than the window and a horizontal scrollbar appears when needed.
   - Tabs from each window are separated by labeled dividers with extra spacing for clarity.
   - A colored dot indicates the tab's container.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -309,7 +309,15 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
       const truncatedUrl = truncateText(tab.url);
       const safeTitle = escapeHtml(truncatedTitle);
       const safeUrl = escapeHtml(truncatedUrl);
-      tooltip.innerHTML = `${safeTitle}<br>${safeUrl}`;
+      let tooltipHtml = `${safeTitle}<br>${safeUrl}`;
+      if (document.body.classList.contains('full')) {
+        const ctx = containerMap.get(tab.cookieStoreId);
+        if (ctx && ctx.name) {
+          const safeCtx = escapeHtml(ctx.name);
+          tooltipHtml += `<br>${safeCtx}`;
+        }
+      }
+      tooltip.innerHTML = tooltipHtml;
       document.body.appendChild(tooltip);
       const rect = icon.getBoundingClientRect();
       let left = rect.right + window.scrollX + 5;


### PR DESCRIPTION
## Summary
- append container name to the tooltip in full view
- document tooltip behavior in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68516c03bec483319251f2e82c2de1ab