### PR TITLE
fix v1.4: allow assigning tabs to default container

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1064,7 +1064,7 @@ async function bulkMove() {
 async function bulkAssignToContainer(containerId) {
   const errorEl = document.getElementById('error');
   if (errorEl) errorEl.textContent = '';
-  if (browser.contextualIdentities) {
+  if (browser.contextualIdentities && containerId !== 'firefox-default') {
     try {
       let identities = await browser.contextualIdentities.query({});
       let exists = identities.some(ci => ci.cookieStoreId === containerId);


### PR DESCRIPTION
## Summary
- ensure bulk container assignment works with the default container

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68517c9bc1d88331af7f456d95161e4e