### PR TITLE
fix(v1.5): move default container without id

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1064,7 +1064,7 @@ async function bulkMove() {
 async function bulkAssignToContainer(containerId) {
   const errorEl = document.getElementById('error');
   if (errorEl) errorEl.textContent = '';
-  if (browser.contextualIdentities) {
+  if (browser.contextualIdentities && containerId !== 'firefox-default') {
     try {
       let identities = await browser.contextualIdentities.query({});
       let exists = identities.some(ci => ci.cookieStoreId === containerId);
@@ -1096,14 +1096,17 @@ async function bulkAssignToContainer(containerId) {
         failed.push(tab.title || tab.url);
         continue;
       }
-      const newTab = await browser.tabs.create({
+      const createOpts = {
         url: tab.url,
-        cookieStoreId: containerId,
         index: tab.index,
         windowId: tab.windowId,
         pinned: tab.pinned,
         active: tab.active
-      });
+      };
+      if (containerId !== 'firefox-default') {
+        createOpts.cookieStoreId = containerId;
+      }
+      const newTab = await browser.tabs.create(createOpts);
       try {
         await browser.tabs.remove(tab.id);
       } catch (e) {


### PR DESCRIPTION
## Summary
- avoid specifying cookieStoreId when moving tabs to the default container

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68517c9bc1d88331af7f456d95161e4e