### PR TITLE
fix v1.6: ensure default container selection

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -267,6 +267,39 @@ async function getContainerIdentities() {
   return containerCache;
 }
 
+function refreshContainerDropdowns(identities) {
+  const filter = document.getElementById('container-filter');
+  const target = document.getElementById('container-target');
+  containerMap.clear();
+  identities.forEach(ci => containerMap.set(ci.cookieStoreId, ci));
+  if (filter) {
+    const current = filter.value;
+    filter.textContent = '';
+    const optAll = document.createElement('option');
+    optAll.value = '';
+    optAll.textContent = 'All Containers';
+    filter.appendChild(optAll);
+    identities.forEach(ci => {
+      const opt = document.createElement('option');
+      opt.value = ci.cookieStoreId;
+      opt.textContent = ci.name;
+      filter.appendChild(opt);
+    });
+    filter.value = containerMap.has(current) ? current : '';
+  }
+  if (target) {
+    const currentT = target.value;
+    target.textContent = '';
+    identities.forEach(ci => {
+      const opt = document.createElement('option');
+      opt.value = ci.cookieStoreId;
+      opt.textContent = ci.name;
+      target.appendChild(opt);
+    });
+    target.value = containerMap.has(currentT) ? currentT : (identities[0]?.cookieStoreId || 'firefox-default');
+  }
+}
+
 function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   const row = document.createElement('div');
   const isFull = document.body.classList.contains('full');
@@ -787,11 +820,13 @@ async function init() {
   await loadOptions();
   registerTabEvents();
   const select = document.getElementById('container-filter');
+  targetSelect = document.getElementById('container-target');
   let containerIdents = [];
   let containersAvailable = !!browser.contextualIdentities;
   if (browser.contextualIdentities) {
     try {
       containerIdents = await getContainerIdentities();
+      refreshContainerDropdowns(containerIdents);
     } catch (e) {
       containersAvailable = false;
       console.error('Contextual identities unavailable', e);
@@ -803,30 +838,11 @@ async function init() {
       'Container actions disabled: container feature not available';
   }
   if (select) {
-    if (browser.contextualIdentities) {
-      try {
-        const identities = await getContainerIdentities();
-        identities.forEach(ci => {
-          containerMap.set(ci.cookieStoreId, ci);
-          const opt = document.createElement('option');
-          opt.value = ci.cookieStoreId;
-          opt.textContent = ci.name;
-          select.appendChild(opt);
-        });
-        select.addEventListener('change', () => {
-          filterContainerId = select.value;
-          scheduleUpdate();
-        });
-      } catch (e) {
-        console.error('Contextual identities unavailable', e);
-        document.getElementById('error').textContent =
-          'Container actions disabled: ' + (e.message || e);
-        select.disabled = true;
-        containersAvailable = false;
-        document.getElementById('container-target')?.setAttribute('disabled', 'true');
-        document.getElementById('bulk-add-container')?.setAttribute('disabled', 'true');
-        document.getElementById('bulk-remove-container')?.setAttribute('disabled', 'true');
-      }
+    if (containersAvailable) {
+      select.addEventListener('change', () => {
+        filterContainerId = select.value;
+        scheduleUpdate();
+      });
     } else {
       select.disabled = true;
       document.getElementById('container-target')?.setAttribute('disabled', 'true');
@@ -834,26 +850,10 @@ async function init() {
       document.getElementById('bulk-remove-container')?.setAttribute('disabled', 'true');
     }
   }
-  targetSelect = document.getElementById('container-target');
   if (targetSelect) {
-    if (browser.contextualIdentities) {
-      try {
-        const identities = await getContainerIdentities();
-        identities.forEach(ci => {
-          const opt = document.createElement('option');
-          opt.value = ci.cookieStoreId;
-          opt.textContent = ci.name;
-          targetSelect.appendChild(opt);
-        });
-      } catch (e) {
-        console.error('Contextual identities unavailable', e);
-        document.getElementById('error').textContent =
-          'Container actions disabled: ' + (e.message || e);
-        targetSelect.disabled = true;
-        containersAvailable = false;
-        document.getElementById('container-filter')?.setAttribute('disabled', 'true');
-        document.getElementById('bulk-add-container')?.setAttribute('disabled', 'true');
-        document.getElementById('bulk-remove-container')?.setAttribute('disabled', 'true');
+    if (containersAvailable) {
+      if (containerIdents.length && !targetSelect.value) {
+        targetSelect.value = containerIdents[0].cookieStoreId;
       }
     } else {
       targetSelect.disabled = true;
@@ -1064,13 +1064,14 @@ async function bulkMove() {
 async function bulkAssignToContainer(containerId) {
   const errorEl = document.getElementById('error');
   if (errorEl) errorEl.textContent = '';
-  if (browser.contextualIdentities) {
+  if (browser.contextualIdentities && containerId !== 'firefox-default') {
     try {
       let identities = await browser.contextualIdentities.query({});
       let exists = identities.some(ci => ci.cookieStoreId === containerId);
       if (!exists) {
         containerCache = null;
         identities = await getContainerIdentities();
+        refreshContainerDropdowns(identities);
         exists = identities.some(ci => ci.cookieStoreId === containerId);
       }
       if (!exists) {


### PR DESCRIPTION
## Summary
- refresh dropdowns on init
- choose first container as default for bulk actions

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68517c9bc1d88331af7f456d95161e4e