### PR TITLE
fix v1.6: update container dropdowns on changes

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -267,6 +267,39 @@ async function getContainerIdentities() {
   return containerCache;
 }
 
+function refreshContainerDropdowns(identities) {
+  const filter = document.getElementById('container-filter');
+  const target = document.getElementById('container-target');
+  containerMap.clear();
+  identities.forEach(ci => containerMap.set(ci.cookieStoreId, ci));
+  if (filter) {
+    const current = filter.value;
+    filter.textContent = '';
+    const optAll = document.createElement('option');
+    optAll.value = '';
+    optAll.textContent = 'All Containers';
+    filter.appendChild(optAll);
+    identities.forEach(ci => {
+      const opt = document.createElement('option');
+      opt.value = ci.cookieStoreId;
+      opt.textContent = ci.name;
+      filter.appendChild(opt);
+    });
+    filter.value = containerMap.has(current) ? current : '';
+  }
+  if (target) {
+    const currentT = target.value;
+    target.textContent = '';
+    identities.forEach(ci => {
+      const opt = document.createElement('option');
+      opt.value = ci.cookieStoreId;
+      opt.textContent = ci.name;
+      target.appendChild(opt);
+    });
+    target.value = containerMap.has(currentT) ? currentT : (identities[0]?.cookieStoreId || 'firefox-default');
+  }
+}
+
 function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   const row = document.createElement('div');
   const isFull = document.body.classList.contains('full');
@@ -786,6 +819,7 @@ async function init() {
   visitedIds = new Set(visited);
   await loadOptions();
   registerTabEvents();
+  registerContainerEvents();
   const select = document.getElementById('container-filter');
   let containerIdents = [];
   let containersAvailable = !!browser.contextualIdentities;
@@ -922,8 +956,29 @@ function unregisterTabEvents() {
   browser.tabs.onAttached.removeListener(updateListener);
 }
 
+function registerContainerEvents() {
+  if (!browser.contextualIdentities) return;
+  browser.contextualIdentities.onCreated.addListener(refreshContainersHandler);
+  browser.contextualIdentities.onRemoved.addListener(refreshContainersHandler);
+  browser.contextualIdentities.onUpdated.addListener(refreshContainersHandler);
+}
+
+function unregisterContainerEvents() {
+  if (!browser.contextualIdentities) return;
+  browser.contextualIdentities.onCreated.removeListener(refreshContainersHandler);
+  browser.contextualIdentities.onRemoved.removeListener(refreshContainersHandler);
+  browser.contextualIdentities.onUpdated.removeListener(refreshContainersHandler);
+}
+
+async function refreshContainersHandler() {
+  containerCache = null;
+  const identities = await getContainerIdentities();
+  refreshContainerDropdowns(identities);
+}
+
 function cleanup() {
   unregisterTabEvents();
+  unregisterContainerEvents();
   resetTabState();
 }
 
@@ -1064,13 +1119,14 @@ async function bulkMove() {
 async function bulkAssignToContainer(containerId) {
   const errorEl = document.getElementById('error');
   if (errorEl) errorEl.textContent = '';
-  if (browser.contextualIdentities) {
+  if (browser.contextualIdentities && containerId !== 'firefox-default') {
     try {
       let identities = await browser.contextualIdentities.query({});
       let exists = identities.some(ci => ci.cookieStoreId === containerId);
       if (!exists) {
         containerCache = null;
         identities = await getContainerIdentities();
+        refreshContainerDropdowns(identities);
         exists = identities.some(ci => ci.cookieStoreId === containerId);
       }
       if (!exists) {


### PR DESCRIPTION
## Summary
- register container identity listeners
- refresh dropdowns when container list changes

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68517c9bc1d88331af7f456d95161e4e