### PR TITLE
Fix container list updating

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -26,6 +26,7 @@ let currentActiveId = -1;
 let currentVisited = new Set();
 let currentWinMap = null;
 let currentQuery = '';
+let containerUpdateListener;
 
 function adjustGridWidth() {
   if (!document.body.classList.contains('full')) return;
@@ -245,14 +246,6 @@ async function activateTab(id, winId) {
 }
 
 async function getContainerIdentities() {
-  if (containerCache) {
-    return containerCache;
-  }
-  const stored = await browser.storage.local.get('containerIdentities');
-  if (stored.containerIdentities) {
-    containerCache = stored.containerIdentities;
-    return containerCache;
-  }
   if (!browser.contextualIdentities) {
     containerCache = [];
     return containerCache;
@@ -262,9 +255,49 @@ async function getContainerIdentities() {
     await browser.storage.local.set({ containerIdentities: containerCache });
   } catch (e) {
     console.error('Contextual identities unavailable', e);
-    containerCache = [];
+    if (!containerCache) {
+      const stored = await browser.storage.local.get('containerIdentities');
+      containerCache = stored.containerIdentities || [];
+    }
   }
   return containerCache;
+}
+
+function refreshContainerDropdowns(identities) {
+  const filter = document.getElementById('container-filter');
+  const target = document.getElementById('container-target');
+  containerMap.clear();
+  identities.forEach(ci => containerMap.set(ci.cookieStoreId, ci));
+  if (filter) {
+    const current = filter.value;
+    filter.textContent = '';
+    const optAll = document.createElement('option');
+    optAll.value = '';
+    optAll.textContent = 'All Containers';
+    filter.appendChild(optAll);
+    identities.forEach(ci => {
+      const opt = document.createElement('option');
+      opt.value = ci.cookieStoreId;
+      opt.textContent = ci.name;
+      filter.appendChild(opt);
+    });
+    filter.value = containerMap.has(current) ? current : '';
+  }
+  if (target) {
+    const currentT = target.value;
+    target.textContent = '';
+    const optDefault = document.createElement('option');
+    optDefault.value = 'firefox-default';
+    optDefault.textContent = 'Default';
+    target.appendChild(optDefault);
+    identities.forEach(ci => {
+      const opt = document.createElement('option');
+      opt.value = ci.cookieStoreId;
+      opt.textContent = ci.name;
+      target.appendChild(opt);
+    });
+    target.value = containerMap.has(currentT) ? currentT : (identities[0]?.cookieStoreId || 'firefox-default');
+  }
 }
 
 function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
@@ -786,6 +819,7 @@ async function init() {
   visitedIds = new Set(visited);
   await loadOptions();
   registerTabEvents();
+  registerContainerEvents();
   const select = document.getElementById('container-filter');
   let containerIdents = [];
   let containersAvailable = !!browser.contextualIdentities;
@@ -802,62 +836,34 @@ async function init() {
     document.getElementById('error').textContent =
       'Container actions disabled: container feature not available';
   }
-  if (select) {
-    if (browser.contextualIdentities) {
+  targetSelect = document.getElementById('container-target');
+  if (select || targetSelect) {
+    if (containersAvailable) {
       try {
-        const identities = await getContainerIdentities();
-        identities.forEach(ci => {
-          containerMap.set(ci.cookieStoreId, ci);
-          const opt = document.createElement('option');
-          opt.value = ci.cookieStoreId;
-          opt.textContent = ci.name;
-          select.appendChild(opt);
-        });
-        select.addEventListener('change', () => {
-          filterContainerId = select.value;
-          scheduleUpdate();
-        });
+        refreshContainerDropdowns(containerIdents);
+        if (select) {
+          select.addEventListener('change', () => {
+            filterContainerId = select.value;
+            scheduleUpdate();
+          });
+        }
       } catch (e) {
         console.error('Contextual identities unavailable', e);
         document.getElementById('error').textContent =
           'Container actions disabled: ' + (e.message || e);
-        select.disabled = true;
+        if (select) select.disabled = true;
+        if (targetSelect) targetSelect.disabled = true;
         containersAvailable = false;
+        document.getElementById('container-filter')?.setAttribute('disabled', 'true');
         document.getElementById('container-target')?.setAttribute('disabled', 'true');
         document.getElementById('bulk-add-container')?.setAttribute('disabled', 'true');
         document.getElementById('bulk-remove-container')?.setAttribute('disabled', 'true');
       }
     } else {
-      select.disabled = true;
-      document.getElementById('container-target')?.setAttribute('disabled', 'true');
-      document.getElementById('bulk-add-container')?.setAttribute('disabled', 'true');
-      document.getElementById('bulk-remove-container')?.setAttribute('disabled', 'true');
-    }
-  }
-  targetSelect = document.getElementById('container-target');
-  if (targetSelect) {
-    if (browser.contextualIdentities) {
-      try {
-        const identities = await getContainerIdentities();
-        identities.forEach(ci => {
-          const opt = document.createElement('option');
-          opt.value = ci.cookieStoreId;
-          opt.textContent = ci.name;
-          targetSelect.appendChild(opt);
-        });
-      } catch (e) {
-        console.error('Contextual identities unavailable', e);
-        document.getElementById('error').textContent =
-          'Container actions disabled: ' + (e.message || e);
-        targetSelect.disabled = true;
-        containersAvailable = false;
-        document.getElementById('container-filter')?.setAttribute('disabled', 'true');
-        document.getElementById('bulk-add-container')?.setAttribute('disabled', 'true');
-        document.getElementById('bulk-remove-container')?.setAttribute('disabled', 'true');
-      }
-    } else {
-      targetSelect.disabled = true;
+      if (select) select.disabled = true;
+      if (targetSelect) targetSelect.disabled = true;
       document.getElementById('container-filter')?.setAttribute('disabled', 'true');
+      document.getElementById('container-target')?.setAttribute('disabled', 'true');
       document.getElementById('bulk-add-container')?.setAttribute('disabled', 'true');
       document.getElementById('bulk-remove-container')?.setAttribute('disabled', 'true');
     }
@@ -913,6 +919,25 @@ function registerTabEvents() {
   browser.tabs.onAttached.addListener(updateListener);
 }
 
+function registerContainerEvents() {
+  if (!browser.contextualIdentities || containerUpdateListener) return;
+  containerUpdateListener = async () => {
+    const ids = await getContainerIdentities();
+    refreshContainerDropdowns(ids);
+  };
+  browser.contextualIdentities.onCreated.addListener(containerUpdateListener);
+  browser.contextualIdentities.onRemoved.addListener(containerUpdateListener);
+  browser.contextualIdentities.onUpdated.addListener(containerUpdateListener);
+}
+
+function unregisterContainerEvents() {
+  if (!browser.contextualIdentities || !containerUpdateListener) return;
+  browser.contextualIdentities.onCreated.removeListener(containerUpdateListener);
+  browser.contextualIdentities.onRemoved.removeListener(containerUpdateListener);
+  browser.contextualIdentities.onUpdated.removeListener(containerUpdateListener);
+  containerUpdateListener = null;
+}
+
 function unregisterTabEvents() {
   browser.tabs.onCreated.removeListener(updateListener);
   browser.tabs.onRemoved.removeListener(updateListener);
@@ -924,6 +949,7 @@ function unregisterTabEvents() {
 
 function cleanup() {
   unregisterTabEvents();
+  unregisterContainerEvents();
   resetTabState();
 }
 
@@ -1064,23 +1090,23 @@ async function bulkMove() {
 async function bulkAssignToContainer(containerId) {
   const errorEl = document.getElementById('error');
   if (errorEl) errorEl.textContent = '';
+  let identities = [];
   if (browser.contextualIdentities) {
     try {
-      let identities = await browser.contextualIdentities.query({});
-      let exists = identities.some(ci => ci.cookieStoreId === containerId);
-      if (!exists) {
-        containerCache = null;
-        identities = await getContainerIdentities();
-        exists = identities.some(ci => ci.cookieStoreId === containerId);
-      }
-      if (!exists) {
-        if (errorEl) errorEl.textContent = 'Selected container does not exist';
-        return;
+      identities = await getContainerIdentities();
+      refreshContainerDropdowns(identities);
+      if (containerId !== 'firefox-default') {
+        const exists = identities.some(ci => ci.cookieStoreId === containerId);
+        if (!exists) {
+          if (errorEl) errorEl.textContent = 'Selected container does not exist';
+          return;
+        }
       }
     } catch (e) {
       console.error('Contextual identities unavailable', e);
-      if (errorEl) errorEl.textContent =
-        'Container actions disabled: ' + (e.message || e);
+      if (errorEl) {
+        errorEl.textContent = 'Container actions disabled: ' + (e.message || e);
+      }
       return;
     }
   }


### PR DESCRIPTION
## Summary
- refresh container selectors when containers are created, updated or removed
- add default container option to container dropdown

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68517c9bc1d88331af7f456d95161e4e