### PR TITLE
Fix tab list refresh

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -792,6 +792,7 @@ function registerTabEvents() {
   browser.tabs.onUpdated.addListener(updateListener);
   browser.tabs.onActivated.addListener(updateListener);
   browser.tabs.onDetached.addListener(updateListener);
+  browser.tabs.onMoved.addListener(updateListener);
   browser.tabs.onAttached.addListener(updateListener);
 }
 
@@ -801,6 +802,7 @@ function unregisterTabEvents() {
   browser.tabs.onUpdated.removeListener(updateListener);
   browser.tabs.onActivated.removeListener(updateListener);
   browser.tabs.onDetached.removeListener(updateListener);
+  browser.tabs.onMoved.removeListener(updateListener);
   browser.tabs.onAttached.removeListener(updateListener);
 }
 


### PR DESCRIPTION
## Summary
- refresh tabs when they are moved

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685192b561a48331b147426b7643243b