### PR TITLE
Add keyboard-driven search

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -20,6 +20,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   - The number of columns adapts to the window size.
   - Custom context menu reveals extension version and links to the Options page.
   - The mouse wheel scrolls the tab list even when the pointer is over the menu or search field.
+  - Typing with no input focused automatically fills the search box. Press **Escape** to clear it.
   - In Full View, overflowing columns can be scrolled horizontally with the mouse wheel.
     Trackpad gestures and horizontal wheels are supported.
   - Scroll speed can be adjusted from the Options page to make scrolling more aggressive.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -684,8 +684,29 @@ browser.runtime.onMessage.addListener((msg) => {
   }
 });
 
-document.getElementById('search').addEventListener('input', scheduleUpdate);
+const searchBox = document.getElementById('search');
+searchBox.addEventListener('input', scheduleUpdate);
 document.getElementById('btn-all').addEventListener('click', () => { view = 'all'; scheduleUpdate(); });
+
+document.addEventListener('keydown', (e) => {
+  if (!searchBox) return;
+  if (e.key === 'Escape') {
+    if (searchBox.value) {
+      searchBox.value = '';
+      scheduleUpdate();
+    }
+    return;
+  }
+  if (document.activeElement.tagName !== 'INPUT' &&
+      e.key.length === 1 &&
+      !e.ctrlKey && !e.metaKey && !e.altKey) {
+    searchBox.focus();
+    searchBox.value += e.key;
+    scheduleUpdate();
+    e.preventDefault();
+    e.stopPropagation();
+  }
+}, true);
 
 document.addEventListener('keydown', (e) => {
   if (!tabItems.length) return;


### PR DESCRIPTION
## Summary
- focus search field on keypress
- clear search with Escape
- document the new behaviour in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851f1a86ba88331a18d9a976f36554d