### PR TITLE
Optimize duplicate tracking

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -9,6 +9,21 @@ let visitedTimer = null;
 // Track duplicate tabs by URL
 const dupMap = new Map();
 const dupIds = new Set();
+let dupUpdateTimer = null;
+
+function sendDuplicateUpdate() {
+  browser.runtime.sendMessage({ type: 'duplicatesUpdated', duplicates: Array.from(dupIds) })
+    .catch(() => {});
+}
+
+function scheduleDuplicateUpdate() {
+  if (!dupUpdateTimer) {
+    dupUpdateTimer = setTimeout(() => {
+      dupUpdateTimer = null;
+      sendDuplicateUpdate();
+    }, 200);
+  }
+}
 
 function addDuplicate(tabId, url) {
   let ids = dupMap.get(url);
@@ -21,6 +36,7 @@ function addDuplicate(tabId, url) {
       for (const id of ids) dupIds.add(id);
     }
   }
+  scheduleDuplicateUpdate();
 }
 
 function removeDuplicate(tabId) {
@@ -31,6 +47,7 @@ function removeDuplicate(tabId) {
       }
       if (ids.size === 0) dupMap.delete(url);
       dupIds.delete(tabId);
+      scheduleDuplicateUpdate();
       break;
     }
   }

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -218,9 +218,7 @@ async function getTabs(allTabs) {
     return result;
   }
   if (view === 'dups') {
-    const { duplicates = [] } = await browser.runtime.sendMessage({ type: 'getDuplicates' });
-    const dupSet = new Set(duplicates);
-    return allTabs.filter(t => dupSet.has(t.id));
+    return allTabs.filter(t => currentDupIds.has(t.id));
   }
   return allTabs;
 }
@@ -649,8 +647,7 @@ async function update() {
     document.getElementById('active-count').textContent = activeCount;
     let tabs = await getTabs(allTabs);
     const winMap = allWins ? new Map((await browser.windows.getAll({populate: false})).map((w, i) => [w.id, i + 1])) : null;
-    const { duplicates = [] } = await browser.runtime.sendMessage({ type: 'getDuplicates' });
-    const dupIds = new Set(duplicates);
+    const dupIds = currentDupIds;
     const activeId = allTabs.find(t => t.active)?.id ?? -1;
     const searchInput = document.getElementById('search');
     const query = searchInput.value.trim();
@@ -680,6 +677,9 @@ const scheduleUpdate = debounce(update, 200);
 browser.runtime.onMessage.addListener((msg) => {
   if (msg && msg.type === 'visitedUpdated') {
     visitedIds = new Set(msg.visited || []);
+    scheduleUpdate();
+  } else if (msg && msg.type === 'duplicatesUpdated') {
+    currentDupIds = new Set(msg.duplicates || []);
     scheduleUpdate();
   }
 });
@@ -833,6 +833,8 @@ async function init() {
   container.addEventListener('dragend', clearPlaceholder);
   const { visited = [] } = await browser.storage.local.get('visited');
   visitedIds = new Set(visited);
+  const { duplicates = [] } = await browser.runtime.sendMessage({ type: 'getDuplicates' });
+  currentDupIds = new Set(duplicates);
   await loadOptions();
   registerTabEvents();
   const select = document.getElementById('container-filter');


### PR DESCRIPTION
## Summary
- broadcast duplicate tab updates with throttling
- update UI duplicate set from events
- avoid querying duplicates each refresh

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6851fc00cf3c8331884d497b46bfc475