### PR TITLE
Fix recent drag ordering v1

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -119,6 +119,17 @@ function pushRecent(tabId) {
   scheduleRecentSave();
 }
 
+function reorderRecent(ids, toId, before) {
+  ids = ids.filter(id => id !== toId);
+  if (!ids.length) return;
+  recent = recent.filter(id => !ids.includes(id));
+  let idx = recent.indexOf(toId);
+  if (idx === -1) idx = recent.length;
+  if (!before) idx += 1;
+  recent.splice(idx, 0, ...ids);
+  scheduleRecentSave();
+}
+
 function scheduleVisitedSave() {
   if (!visitedTimer) {
     visitedTimer = setTimeout(() => {
@@ -181,6 +192,8 @@ browser.runtime.onMessage.addListener((msg) => {
     return Promise.resolve({ duplicates: Array.from(dupIds) });
   } else if (msg && msg.type === 'unmarkVisited') {
     unmarkVisited(msg.tabId);
+  } else if (msg && msg.type === 'reorderRecent') {
+    reorderRecent(msg.ids || [], msg.toId, msg.before);
   }
 });
 

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1236,6 +1236,14 @@ async function onContainerDrop(e) {
       index++;
     }
   }
+  if (view === 'recent') {
+    await browser.runtime.sendMessage({
+      type: 'reorderRecent',
+      ids,
+      toId,
+      before
+    }).catch(() => {});
+  }
   scheduleUpdate();
 }
 


### PR DESCRIPTION
## Summary
- preserve tab order when dragging in Recent view
- update Recent list in background

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852b93b6a8c833187ca34802df6fca9