### PR TITLE
v0.3.2: Move Close to first position in context menu

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1002,13 +1002,17 @@ function showContextMenu(e) {
   if (tabEl && (!selected.length || !tabEl.classList.contains('selected'))) {
     const id = parseInt(tabEl.dataset.tab, 10);
     const win = parseInt(tabEl.dataset.windowId, 10);
+    // Place Close as the first entry for single-tab actions
+    addItem('Close', async () => {
+      await browser.tabs.remove(id);
+      scheduleUpdate();
+    });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
       await browser.tabs.discard(id);
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
       scheduleUpdate();
     });
-    addItem('Close', async () => { await browser.tabs.remove(id); scheduleUpdate(); });
     if (MOVE_ENABLED) {
       addItem('Move', async () => {
         const t = await browser.tabs.get(id);


### PR DESCRIPTION
## Summary
- move the Close command to the top of the context menu

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68535a57d6188331aae6615057790fe8