### PR TITLE
Add MOVE flag and right-click move feature

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -11,6 +11,8 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Perform bulk operations (close, reload, unload, move) on selected tabs, and a
   command to unload all tabs at once. The keyboard shortcut for this command can
   be configured on the Options page.
+- Right-click once to mark selected tabs for moving, then right-click another
+  tab to drop them at that position.
 - Each tab row includes a button to quickly close that tab.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.
 - Bulk assign selected tabs to any Firefox container or move them back to the default container.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -26,6 +26,8 @@ let currentActiveId = -1;
 let currentVisited = new Set();
 let currentWinMap = null;
 let currentQuery = '';
+let movePending = false;
+let moveIds = [];
 
 function adjustGridWidth() {
   if (!document.body.classList.contains('full')) return;
@@ -60,6 +62,55 @@ function clearPlaceholder() {
 
 function hideAllTooltips() {
   document.querySelectorAll('.tab-tooltip').forEach(t => t.remove());
+}
+
+function startMoveFlag() {
+  moveIds = getSelectedTabIds();
+  if (!moveIds.length) return;
+  movePending = true;
+  moveIds.forEach(id => {
+    const el = container.querySelector(`.tab[data-tab="${id}"]`);
+    if (el) el.classList.add('move-flag');
+  });
+}
+
+function clearMoveFlag() {
+  movePending = false;
+  moveIds = [];
+  document.querySelectorAll('.tab.move-flag').forEach(el =>
+    el.classList.remove('move-flag'));
+}
+
+async function completeMoveFlag(toEl, y) {
+  if (!movePending || !toEl) return;
+  const toId = parseInt(toEl.dataset.tab, 10);
+  const toTab = await browser.tabs.get(toId);
+  const rect = toEl.getBoundingClientRect();
+  const before = y < rect.top + rect.height / 2;
+  let index = before ? toTab.index : toTab.index + 1;
+  const ids = moveIds.filter(id => id !== toId);
+  for (const id of ids) {
+    const fromTab = await browser.tabs.get(id);
+    let idx = index;
+    if (fromTab.windowId === toTab.windowId && fromTab.index < index) {
+      idx--;
+    }
+    if (idx < 0) idx = 0;
+    await browser.tabs.move(id, { windowId: toTab.windowId, index: idx });
+    if (fromTab.windowId !== toTab.windowId || fromTab.index >= index) {
+      index++;
+    }
+  }
+  if (view === 'recent') {
+    await browser.runtime.sendMessage({
+      type: 'reorderRecent',
+      ids,
+      toId,
+      before
+    }).catch(() => {});
+  }
+  clearMoveFlag();
+  scheduleUpdate();
 }
 
 function showPlaceholder(target, before) {
@@ -971,6 +1022,21 @@ window.addEventListener('resize', () => {
 // custom context menu
 const context = document.getElementById('context');
 function showContextMenu(e) {
+  if (MOVE_ENABLED && movePending) {
+    e.preventDefault();
+    hideAllTooltips();
+    context.classList.add('hidden');
+    const tabEl = e.target.closest('.tab');
+    completeMoveFlag(tabEl, e.clientY);
+    return;
+  }
+  if (MOVE_ENABLED && !movePending && getSelectedTabIds().length) {
+    e.preventDefault();
+    hideAllTooltips();
+    context.classList.add('hidden');
+    startMoveFlag();
+    return;
+  }
   e.preventDefault();
   hideAllTooltips();
   const tabEl = e.target.closest('.tab');

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -169,6 +169,12 @@ body.popup .tab {
 .tab.selected {
   background: var(--color-selected);
 }
+.tab.move-flag {
+  outline: 2px dashed #f90;
+}
+body[data-theme="dark"] .tab.move-flag {
+  outline-color: #fb0;
+}
 .tab:focus {
   outline: 1px solid #888;
 }


### PR DESCRIPTION
## Summary
- implement two-step MOVE mode triggered by right-click
- highlight flagged tabs with dashed outline
- document new right-click move operation

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68537930d8c883318f3a72f5d2dc523d