### PR TITLE
Add dynamic scale sync for options

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -24,7 +24,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   - In Full View, overflowing columns can be scrolled horizontally with the mouse wheel.
     Trackpad gestures and horizontal wheels are supported.
   - Scroll speed can be adjusted from the Options page to make scrolling more aggressive.
-  - Hold **Ctrl** and use the mouse wheel to change the interface scale. The selected scale is saved.
+  - Hold **Ctrl** and use the mouse wheel to change the interface scale. The selected scale is saved and the values in the Options page update automatically.
   - Hovering a tab's icon in the popup or Full View shows a custom tooltip with the tab title and URL, truncated for brevity. If the tab belongs to a container, the tooltip also displays the container name.
   - The columns can extend wider than the window and a horizontal scrollbar appears when needed.
   - Tabs from each window are separated by labeled dividers with extra spacing for clarity.

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "KepiTAB",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A simple tab management tool inspired by All Tabs Helper",
     "permissions": [
       "tabs",

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -101,6 +101,14 @@ const elFontScale = document.getElementById('fontScale');
 const elCloseScale = document.getElementById('closeScale');
 const elScrollSpeed = document.getElementById('scrollSpeed');
 
+async function refreshScaleInputs() {
+  const { tileScale = 0.9, fontScale = 0.8125, closeScale = 0.5 } =
+    await browser.storage.local.get(['tileScale', 'fontScale', 'closeScale']);
+  elTileScale.value = tileScale;
+  elFontScale.value = fontScale;
+  elCloseScale.value = closeScale;
+}
+
 elTileWidth.addEventListener('input', updateWidth);
 elTileWidth.addEventListener('change', updateWidth);
 
@@ -116,4 +124,5 @@ elCloseScale.addEventListener('change', updateCloseScale);
 elScrollSpeed.addEventListener('input', updateScroll);
 elScrollSpeed.addEventListener('change', updateScroll);
 document.getElementById('save').addEventListener('click', save);
+window.addEventListener('theme-applied', refreshScaleInputs);
 load();


### PR DESCRIPTION
## Summary
- update manifest version to 0.3.2
- sync scale input fields when `Ctrl` + scroll is used
- mention automatic scale updates in README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68541a1a5b7083318608e5152aee8e3a