### PR TITLE
Add interface scale control

### DIFF
--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -12,6 +12,8 @@
   <br>
   <label>Tile Scale: <input type="number" id="tileScale" min="0.5" max="2" step="0.1" value="0.9"></label>
   <br>
+  <label>Interface Scale: <input type="range" id="uiScale" min="0.5" max="2" step="0.1" value="0.9"><span id="uiScaleValue">0.9</span></label>
+  <br>
   <label>Font Scale: <input type="number" id="fontScale" min="0.25" max="2" step="0.1" value="0.8125"></label>
   <br>
   <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="0.5"></label>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -1,3 +1,6 @@
+let diffFont = 0;
+let diffClose = 0;
+
 async function load(){
   const data = await browser.storage.local.get([
     'theme','tileWidth','tileScale','fontScale','closeScale','scrollSpeed',
@@ -22,9 +25,16 @@ async function load(){
     closeScale = 0.5;
     browser.storage.local.set({ closeScale });
   }
+  diffFont = tileScale - fontScale;
+  diffClose = tileScale - closeScale;
   document.getElementById('theme').value = theme;
   document.getElementById('tileWidth').value = tileWidth;
   document.getElementById('tileScale').value = tileScale;
+  const elUiScale = document.getElementById('uiScale');
+  if (elUiScale) {
+    elUiScale.value = tileScale;
+    document.getElementById('uiScaleValue').textContent = tileScale;
+  }
   document.getElementById('fontScale').value = fontScale;
   document.getElementById('closeScale').value = closeScale;
   document.getElementById('scrollSpeed').value = scrollSpeed;
@@ -71,20 +81,56 @@ function updateWidth(){
 function updateScale(){
   const tileScale=parseFloat(document.getElementById('tileScale').value);
   const tileWidth=parseInt(document.getElementById('tileWidth').value,10);
+  diffFont = tileScale - parseFloat(document.getElementById('fontScale').value);
+  diffClose = tileScale - parseFloat(document.getElementById('closeScale').value);
   browser.storage.local.set({tileScale});
   document.documentElement.style.setProperty('--tile-width', (tileWidth * tileScale) + 'px');
   document.documentElement.style.setProperty('--tile-scale', tileScale);
+  const elUi = document.getElementById('uiScale');
+  if (elUi) {
+    elUi.value = tileScale;
+    document.getElementById('uiScaleValue').textContent = tileScale.toFixed(1);
+  }
 }
 
 function updateFont(){
   const fontScale=parseFloat(document.getElementById('fontScale').value);
+  diffFont = parseFloat(document.getElementById('tileScale').value) - fontScale;
   browser.storage.local.set({fontScale});
   document.documentElement.style.setProperty('--font-scale', fontScale);
+  const elUi = document.getElementById('uiScale');
+  if (elUi) {
+    elUi.value = parseFloat(document.getElementById('tileScale').value);
+    document.getElementById('uiScaleValue').textContent = elUi.value;
+  }
 }
 
 function updateCloseScale(){
   const closeScale=parseFloat(document.getElementById('closeScale').value);
+  diffClose = parseFloat(document.getElementById('tileScale').value) - closeScale;
   browser.storage.local.set({closeScale});
+  document.documentElement.style.setProperty('--close-scale', closeScale);
+  const elUi = document.getElementById('uiScale');
+  if (elUi) {
+    elUi.value = parseFloat(document.getElementById('tileScale').value);
+    document.getElementById('uiScaleValue').textContent = elUi.value;
+  }
+}
+
+function updateUiScale(){
+  const uiScale = parseFloat(document.getElementById('uiScale').value);
+  const tileWidth=parseInt(document.getElementById('tileWidth').value,10);
+  const tileScale = uiScale;
+  const fontScale = uiScale - diffFont;
+  const closeScale = uiScale - diffClose;
+  browser.storage.local.set({ tileScale, fontScale, closeScale });
+  document.getElementById('tileScale').value = tileScale;
+  document.getElementById('fontScale').value = fontScale;
+  document.getElementById('closeScale').value = closeScale;
+  document.getElementById('uiScaleValue').textContent = uiScale.toFixed(1);
+  document.documentElement.style.setProperty('--tile-width', (tileWidth * tileScale) + 'px');
+  document.documentElement.style.setProperty('--tile-scale', tileScale);
+  document.documentElement.style.setProperty('--font-scale', fontScale);
   document.documentElement.style.setProperty('--close-scale', closeScale);
 }
 
@@ -100,6 +146,7 @@ const elTileScale = document.getElementById('tileScale');
 const elFontScale = document.getElementById('fontScale');
 const elCloseScale = document.getElementById('closeScale');
 const elScrollSpeed = document.getElementById('scrollSpeed');
+const elUiScale = document.getElementById('uiScale');
 
 elTileWidth.addEventListener('input', updateWidth);
 elTileWidth.addEventListener('change', updateWidth);
@@ -113,7 +160,29 @@ elFontScale.addEventListener('change', updateFont);
 elCloseScale.addEventListener('input', updateCloseScale);
 elCloseScale.addEventListener('change', updateCloseScale);
 
+if (elUiScale) {
+  elUiScale.addEventListener('input', updateUiScale);
+  elUiScale.addEventListener('change', updateUiScale);
+}
+
 elScrollSpeed.addEventListener('input', updateScroll);
 elScrollSpeed.addEventListener('change', updateScroll);
 document.getElementById('save').addEventListener('click', save);
+browser.storage.onChanged.addListener((changes, area) => {
+  if (area !== 'local') return;
+  if (changes.tileScale) {
+    const val = changes.tileScale.newValue;
+    elTileScale.value = val;
+    if (elUiScale) {
+      elUiScale.value = val;
+      document.getElementById('uiScaleValue').textContent = val.toFixed(1);
+    }
+  }
+  if (changes.fontScale) {
+    elFontScale.value = changes.fontScale.newValue;
+  }
+  if (changes.closeScale) {
+    elCloseScale.value = changes.closeScale.newValue;
+  }
+});
 load();


### PR DESCRIPTION
## Summary
- add `uiScale` slider to Options page for adjusting overall scale
- sync scale values when changed via wheel or inputs

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68541a1a5b7083318608e5152aee8e3a