### PR TITLE
Reduce tile gap in full view

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -385,7 +385,7 @@ body.full #tabs,
   grid-template-rows: repeat(auto-fill, var(--tile-height));
   grid-auto-columns: var(--tile-width);
   grid-auto-flow: column;
-  row-gap: 0.25em;
+  row-gap: 0.1em;
   width: fit-content;
   min-width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- adjust row-gap in full view grid to make tiles closer

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854301e34148331bda01fc3076bcd6d