### PR TITLE
Reduce tile spacing in full view

### DIFF
--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "KepiTAB",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A simple tab management tool inspired by All Tabs Helper",
     "permissions": [
       "tabs",

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -226,7 +226,7 @@ body.popup .tab > div {
   border: 2px solid var(--color-border);
   border-radius: 6px;
   height: calc(var(--tile-height) * 0.9);
-  margin: 0.5em 0;
+  margin: 0.25em 0;
   box-sizing: border-box;
 }
 button {
@@ -385,7 +385,7 @@ body.full #tabs,
   grid-template-rows: repeat(auto-fill, var(--tile-height));
   grid-auto-columns: var(--tile-width);
   grid-auto-flow: column;
-  row-gap: 0.25em;
+  row-gap: 0.15em;
   width: fit-content;
   min-width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- reduce the margin above and below window divider tiles
- tighten row gap in the full view grid layout
- bump extension version to 0.3.3

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854301e34148331bda01fc3076bcd6d