### PR TITLE
Add clear search feature

### DIFF
--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -14,7 +14,10 @@
         <option value="">All Containers</option>
       </select>
     </div>
-    <input type="text" id="search" placeholder="Search tabs" />
+    <div id="search-wrapper">
+      <input type="text" id="search" placeholder="Search tabs" />
+      <button id="clear-search" aria-label="Clear search">&#215;</button>
+    </div>
     <div id="error"></div>
     <div id="tabs-wrapper" class="tab-grid-wrapper">
       <div id="tabs" class="tab-grid"></div>

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "KepiTAB",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A simple tab management tool inspired by All Tabs Helper",
     "permissions": [
       "tabs",

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -14,7 +14,10 @@
       <option value="">All Containers</option>
     </select>
   </div>
-  <input type="text" id="search" placeholder="Search tabs" />
+  <div id="search-wrapper">
+    <input type="text" id="search" placeholder="Search tabs" />
+    <button id="clear-search" aria-label="Clear search">&#215;</button>
+  </div>
   <div id="error"></div>
   <div id="tabs"></div>
     <div id="bulk-actions">

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -687,7 +687,27 @@ browser.runtime.onMessage.addListener((msg) => {
 });
 
 const searchBox = document.getElementById('search');
-searchBox.addEventListener('input', scheduleUpdate);
+const clearBtn = document.getElementById('clear-search');
+
+function toggleClear() {
+  if (clearBtn) {
+    clearBtn.classList.toggle('visible', !!searchBox.value);
+  }
+}
+
+searchBox.addEventListener('input', () => {
+  scheduleUpdate();
+  toggleClear();
+});
+
+if (clearBtn) {
+  clearBtn.addEventListener('click', () => {
+    searchBox.value = '';
+    toggleClear();
+    scheduleUpdate();
+    searchBox.focus();
+  });
+}
 document.getElementById('btn-all').addEventListener('click', () => { view = 'all'; scheduleUpdate(); });
 
 document.addEventListener('keydown', (e) => {
@@ -695,6 +715,7 @@ document.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') {
     if (searchBox.value) {
       searchBox.value = '';
+      toggleClear();
       scheduleUpdate();
     }
     return;
@@ -704,6 +725,7 @@ document.addEventListener('keydown', (e) => {
       !e.ctrlKey && !e.metaKey && !e.altKey) {
     searchBox.focus();
     searchBox.value += e.key;
+    toggleClear();
     scheduleUpdate();
     e.preventDefault();
     e.stopPropagation();
@@ -924,6 +946,7 @@ async function init() {
   if (MOVE_ENABLED && moveBtn) moveBtn.addEventListener('click', bulkMove);
   else if (moveBtn) moveBtn.style.display = 'none';
   await update();
+  toggleClear();
   restoreScroll();
 }
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -95,10 +95,30 @@ body[data-theme="dark"] #context div:hover {
   margin-left: 0.2em;
 }
 
+#search-wrapper {
+  position: relative;
+}
+
 #search {
   width: 100%;
-  padding: 0.2em;
+  padding: 0.2em 1.4em 0.2em 0.2em;
   box-sizing: border-box;
+}
+
+#clear-search {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 1.4em;
+  height: 100%;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  display: none;
+}
+
+#clear-search.visible {
+  display: block;
 }
 
 #tabs {


### PR DESCRIPTION
## Summary
- add wrapper for the search field with clear button
- show clear button only when there is text
- implement clear logic in JS
- bump extension version to 0.3.3

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854475cfb88833182a06d9bb202753d