### PR TITLE
Add search clear button v1

### DIFF
--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -14,7 +14,10 @@
         <option value="">All Containers</option>
       </select>
     </div>
-    <input type="text" id="search" placeholder="Search tabs" />
+    <div class="search-wrapper">
+      <input type="text" id="search" placeholder="Search tabs" />
+      <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
+    </div>
     <div id="error"></div>
     <div id="tabs-wrapper" class="tab-grid-wrapper">
       <div id="tabs" class="tab-grid"></div>

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -14,7 +14,10 @@
       <option value="">All Containers</option>
     </select>
   </div>
-  <input type="text" id="search" placeholder="Search tabs" />
+  <div class="search-wrapper">
+    <input type="text" id="search" placeholder="Search tabs" />
+    <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
+  </div>
   <div id="error"></div>
   <div id="tabs"></div>
     <div id="bulk-actions">

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -687,7 +687,28 @@ browser.runtime.onMessage.addListener((msg) => {
 });
 
 const searchBox = document.getElementById('search');
-searchBox.addEventListener('input', scheduleUpdate);
+const clearBtn = document.getElementById('search-clear');
+
+function updateClearButton() {
+  if (clearBtn) {
+    clearBtn.classList.toggle('hidden', !searchBox.value);
+  }
+}
+
+searchBox.addEventListener('input', () => {
+  updateClearButton();
+  scheduleUpdate();
+});
+
+clearBtn?.addEventListener('click', () => {
+  if (searchBox.value) {
+    searchBox.value = '';
+    updateClearButton();
+    scheduleUpdate();
+  }
+});
+
+updateClearButton();
 document.getElementById('btn-all').addEventListener('click', () => { view = 'all'; scheduleUpdate(); });
 
 document.addEventListener('keydown', (e) => {

--- a/mytabs/sidebar.html
+++ b/mytabs/sidebar.html
@@ -5,7 +5,10 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <input type="text" id="search" placeholder="Search tabs" />
+  <div class="search-wrapper">
+    <input type="text" id="search" placeholder="Search tabs" />
+    <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
+  </div>
   <div id="error"></div>
   <div id="tabs"></div>
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -95,6 +95,27 @@ body[data-theme="dark"] #context div:hover {
   margin-left: 0.2em;
 }
 
+.search-wrapper {
+  position: relative;
+}
+
+.clear-btn {
+  position: absolute;
+  right: 0.4em;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+.clear-btn.hidden {
+  display: none;
+}
+
 #search {
   width: 100%;
   padding: 0.2em;


### PR DESCRIPTION
## Summary
- add search input wrapper with clear button across HTML pages
- style new clear button and wrapper
- handle clearing search input via JS

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854475cfb88833182a06d9bb202753d