### PR TITLE
Add search clear button v2

### DIFF
--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -14,7 +14,10 @@
         <option value="">All Containers</option>
       </select>
     </div>
-    <input type="text" id="search" placeholder="Search tabs" />
+    <div class="search-wrapper">
+      <input type="text" id="search" placeholder="Search tabs" />
+      <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
+    </div>
     <div id="error"></div>
     <div id="tabs-wrapper" class="tab-grid-wrapper">
       <div id="tabs" class="tab-grid"></div>

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -14,7 +14,10 @@
       <option value="">All Containers</option>
     </select>
   </div>
-  <input type="text" id="search" placeholder="Search tabs" />
+  <div class="search-wrapper">
+    <input type="text" id="search" placeholder="Search tabs" />
+    <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
+  </div>
   <div id="error"></div>
   <div id="tabs"></div>
     <div id="bulk-actions">

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -687,7 +687,28 @@ browser.runtime.onMessage.addListener((msg) => {
 });
 
 const searchBox = document.getElementById('search');
-searchBox.addEventListener('input', scheduleUpdate);
+const clearBtn = document.getElementById('search-clear');
+
+function updateClearButton() {
+  if (clearBtn) {
+    clearBtn.classList.toggle('hidden', !searchBox.value);
+  }
+}
+
+searchBox.addEventListener('input', () => {
+  updateClearButton();
+  scheduleUpdate();
+});
+
+clearBtn?.addEventListener('click', () => {
+  if (searchBox.value) {
+    searchBox.value = '';
+    updateClearButton();
+    scheduleUpdate();
+  }
+});
+
+updateClearButton();
 document.getElementById('btn-all').addEventListener('click', () => { view = 'all'; scheduleUpdate(); });
 
 document.addEventListener('keydown', (e) => {

--- a/mytabs/sidebar.html
+++ b/mytabs/sidebar.html
@@ -5,7 +5,10 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <input type="text" id="search" placeholder="Search tabs" />
+  <div class="search-wrapper">
+    <input type="text" id="search" placeholder="Search tabs" />
+    <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
+  </div>
   <div id="error"></div>
   <div id="tabs"></div>
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -95,8 +95,27 @@ body[data-theme="dark"] #context div:hover {
   margin-left: 0.2em;
 }
 
+.search-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.clear-btn {
+  margin-left: 0.2em;
+  border: none;
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+.clear-btn.hidden {
+  display: none;
+}
+
 #search {
-  width: 100%;
+  flex: 1;
   padding: 0.2em;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- adjust layout so the search clear button sits next to the input text
- keep showing the button only when text is typed

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6854475cfb88833182a06d9bb202753d