### PR TITLE
Add configurable shortcuts for tab views

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -38,7 +38,10 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   - **Alt+Shift+H** opens the popup.
   - **Alt+Shift+F** opens the Full View window.
   - **Alt+Shift+U** unloads all tabs.
-- Middle-clicking the toolbar icon opens the Full View window.
+  - **Shift+A** switches to the All tab.
+  - **Shift+R** switches to the Recent tab.
+  - **Shift+D** switches to the Duplicates tab.
+  - Middle-clicking the toolbar icon opens the Full View window.
 
 ## Keyboard Shortcuts
 

--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -34,6 +34,12 @@
   <br>
   <label>Unload All Shortcut: <input type="text" id="key-unload-all" placeholder="Alt+Shift+U"></label>
   <br>
+  <label>All Tab Shortcut: <input type="text" id="key-tab-all" placeholder="Shift+A"></label>
+  <br>
+  <label>Recent Tab Shortcut: <input type="text" id="key-tab-recent" placeholder="Shift+R"></label>
+  <br>
+  <label>Duplicates Tab Shortcut: <input type="text" id="key-tab-dups" placeholder="Shift+D"></label>
+  <br>
   <button id="save">Save</button>
   <script src="theme.js"></script>
   <script src="options.js"></script>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -6,7 +6,8 @@ async function load(){
   const data = await browser.storage.local.get([
     'theme','tileWidth','tileScale','fontScale','closeScale','rowGap','scrollSpeed',
     'showRecent','showDuplicates','enableMove',
-    'keyOpenPopup','keyOpenFull','keyUnloadAll'
+    'keyOpenPopup','keyOpenFull','keyUnloadAll',
+    'keyTabAll','keyTabRecent','keyTabDups'
   ]);
   const {
     theme='light',
@@ -20,7 +21,10 @@ async function load(){
     enableMove=true,
     keyOpenPopup='Alt+Shift+H',
     keyOpenFull='Alt+Shift+F',
-    keyUnloadAll='Alt+Shift+U'
+    keyUnloadAll='Alt+Shift+U',
+    keyTabAll='Shift+A',
+    keyTabRecent='Shift+R',
+    keyTabDups='Shift+D'
   } = data;
   let closeScale = data.closeScale;
   if (closeScale === undefined) {
@@ -43,6 +47,9 @@ async function load(){
   document.getElementById('key-open-popup').value = keyOpenPopup;
   document.getElementById('key-open-full').value = keyOpenFull;
   document.getElementById('key-unload-all').value = keyUnloadAll;
+  document.getElementById('key-tab-all').value = keyTabAll;
+  document.getElementById('key-tab-recent').value = keyTabRecent;
+  document.getElementById('key-tab-dups').value = keyTabDups;
   document.documentElement.style.setProperty('--tile-width', (tileWidth * tileScale) + 'px');
   document.documentElement.style.setProperty('--tile-scale', tileScale);
   document.documentElement.style.setProperty('--font-scale', fontScale);
@@ -62,11 +69,15 @@ async function save(){
   const keyOpenPopup=document.getElementById('key-open-popup').value.trim();
   const keyOpenFull=document.getElementById('key-open-full').value.trim();
   const keyUnloadAll=document.getElementById('key-unload-all').value.trim();
+  const keyTabAll=document.getElementById('key-tab-all').value.trim();
+  const keyTabRecent=document.getElementById('key-tab-recent').value.trim();
+  const keyTabDups=document.getElementById('key-tab-dups').value.trim();
   const rowGap=parseFloat(document.getElementById('rowGap').value);
   await browser.storage.local.set({
     theme, tileWidth, tileScale, fontScale, closeScale, rowGap, scrollSpeed,
     showRecent, showDuplicates, enableMove,
-    keyOpenPopup, keyOpenFull, keyUnloadAll
+    keyOpenPopup, keyOpenFull, keyUnloadAll,
+    keyTabAll, keyTabRecent, keyTabDups
   });
 }
 

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -6,6 +6,9 @@ let SHOW_RECENT = true;
 let SHOW_DUPLICATES = true;
 let MOVE_ENABLED = true;
 let SCROLL_SPEED = 1;
+let KEY_TAB_ALL = 'Shift+A';
+let KEY_TAB_RECENT = 'Shift+R';
+let KEY_TAB_DUPS = 'Shift+D';
 
 let lastSelectedIndex = -1;
 let container; // tab list element
@@ -95,6 +98,18 @@ function debounce(fn, delay) {
   };
 }
 
+function matchesShortcut(e, shortcut) {
+  if (!shortcut) return false;
+  const parts = shortcut.split('+');
+  const key = parts.pop().toLowerCase();
+  const mods = new Set(parts.map(p => p.toLowerCase()));
+  if ((mods.has('ctrl') || mods.has('control')) !== e.ctrlKey) return false;
+  if (mods.has('shift') !== e.shiftKey) return false;
+  if (mods.has('alt') !== e.altKey) return false;
+  if ((mods.has('meta') || mods.has('cmd') || mods.has('command')) !== e.metaKey) return false;
+  return e.key.toLowerCase() === key;
+}
+
 function escapeHtml(str) {
   return str.replace(/[&<>"']/g, c => ({
     '&': '&amp;',
@@ -115,13 +130,19 @@ async function loadOptions() {
     showDuplicates = true,
     enableMove = true,
     scrollSpeed = 1,
-    keyUnloadAll = 'Alt+Shift+U'
+    keyUnloadAll = 'Alt+Shift+U',
+    keyTabAll = 'Shift+A',
+    keyTabRecent = 'Shift+R',
+    keyTabDups = 'Shift+D'
   } = await browser.storage.local.get([
     'showRecent',
     'showDuplicates',
     'enableMove',
     'scrollSpeed',
-    'keyUnloadAll'
+    'keyUnloadAll',
+    'keyTabAll',
+    'keyTabRecent',
+    'keyTabDups'
   ]);
   SHOW_RECENT = showRecent !== false;
   SHOW_DUPLICATES = showDuplicates !== false;
@@ -155,6 +176,9 @@ async function loadOptions() {
   }
   const unloadBtn = document.getElementById('bulk-unload-all');
   if (unloadBtn) unloadBtn.title = `Shortcut: ${keyUnloadAll}`;
+  KEY_TAB_ALL = keyTabAll;
+  KEY_TAB_RECENT = keyTabRecent;
+  KEY_TAB_DUPS = keyTabDups;
 }
 
 function updateSelection(row, selected) {
@@ -814,7 +838,19 @@ document.addEventListener('keydown', (e) => {
     });
     lastSelectedIndex = last;
   } else if (!e.ctrlKey && !e.metaKey && !e.altKey) {
-    switch (e.key.toLowerCase()) {
+    if (matchesShortcut(e, KEY_TAB_ALL)) {
+      e.preventDefault();
+      view = 'all';
+      scheduleUpdate();
+    } else if (matchesShortcut(e, KEY_TAB_RECENT) && SHOW_RECENT) {
+      e.preventDefault();
+      view = 'recent';
+      scheduleUpdate();
+    } else if (matchesShortcut(e, KEY_TAB_DUPS) && SHOW_DUPLICATES) {
+      e.preventDefault();
+      view = 'dups';
+      scheduleUpdate();
+    } else switch (e.key.toLowerCase()) {
       case 'c':
         bulkClose();
         break;


### PR DESCRIPTION
## Summary
- add default shortcuts for switching to All, Recent and Duplicates views
- expose shortcut settings on the Options page
- load and save the new shortcuts
- implement keyboard handling for custom view shortcuts

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68547f550f588331812aa9f37e0ac585