### PR TITLE
feature: group container support v0.3.7

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -16,6 +16,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Bulk assign selected tabs to any Firefox container or move them back to the default container.
 - Pinned and active tabs retain their state and original order when moved between windows or containers.
 - Container-related actions require Firefox's container feature and the `contextualIdentities` permission. If containers are disabled, the container filter and "Add to Container" buttons will not be shown.
+- New buttons in the bulk actions panel let you create or delete containers on the fly. Enter a group name and choose color and icon to create a container and move selected tabs into it.
 - A **Full View** window shows tabs in a responsive grid that fills the entire window.
   - The number of columns adapts to the window size.
   - Custom context menu reveals extension version and links to the Options page.

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -24,6 +24,29 @@
     </div>
     <div id="bulk-actions">
       <select id="container-target"></select>
+      <input id="new-container-name" type="text" placeholder="Group name" />
+      <select id="new-container-color">
+        <option value="blue">Blue</option>
+        <option value="turquoise">Turquoise</option>
+        <option value="green">Green</option>
+        <option value="yellow">Yellow</option>
+        <option value="orange">Orange</option>
+        <option value="red">Red</option>
+        <option value="pink">Pink</option>
+        <option value="purple">Purple</option>
+      </select>
+      <select id="new-container-icon">
+        <option value="fingerprint">Fingerprint</option>
+        <option value="briefcase">Briefcase</option>
+        <option value="dollar">Dollar</option>
+        <option value="cart">Cart</option>
+        <option value="circle">Circle</option>
+        <option value="gift">Gift</option>
+        <option value="vacation">Vacation</option>
+        <option value="food">Food</option>
+      </select>
+      <button id="create-container">Create Group</button>
+      <button id="delete-container">Delete Group</button>
       <button id="bulk-add-container">Add to Container</button>
       <button id="bulk-remove-container">Remove from Container</button>
       <button id="bulk-close">Close</button>

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "KepiTAB",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "A simple tab management tool inspired by All Tabs Helper",
     "permissions": [
       "tabs",

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -22,6 +22,29 @@
   <div id="tabs"></div>
     <div id="bulk-actions">
       <select id="container-target"></select>
+      <input id="new-container-name" type="text" placeholder="Group name" />
+      <select id="new-container-color">
+        <option value="blue">Blue</option>
+        <option value="turquoise">Turquoise</option>
+        <option value="green">Green</option>
+        <option value="yellow">Yellow</option>
+        <option value="orange">Orange</option>
+        <option value="red">Red</option>
+        <option value="pink">Pink</option>
+        <option value="purple">Purple</option>
+      </select>
+      <select id="new-container-icon">
+        <option value="fingerprint">Fingerprint</option>
+        <option value="briefcase">Briefcase</option>
+        <option value="dollar">Dollar</option>
+        <option value="cart">Cart</option>
+        <option value="circle">Circle</option>
+        <option value="gift">Gift</option>
+        <option value="vacation">Vacation</option>
+        <option value="food">Food</option>
+      </select>
+      <button id="create-container">Create Group</button>
+      <button id="delete-container">Delete Group</button>
       <button id="bulk-add-container">Add to Container</button>
       <button id="bulk-remove-container">Remove from Container</button>
       <button id="bulk-close">Close</button>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -328,6 +328,28 @@ function refreshContainerDropdowns(identities) {
   }
 }
 
+async function createContainer(name) {
+  try {
+    const color = document.getElementById('new-container-color')?.value || 'blue';
+    const icon = document.getElementById('new-container-icon')?.value || 'fingerprint';
+    await browser.contextualIdentities.create({ name, color, icon });
+    const identities = await getContainerIdentities();
+    refreshContainerDropdowns(identities);
+  } catch (e) {
+    document.getElementById('error').textContent = 'Could not create container: ' + (e.message || e);
+  }
+}
+
+async function deleteContainer(id) {
+  try {
+    await browser.contextualIdentities.remove(id);
+    const identities = await getContainerIdentities();
+    refreshContainerDropdowns(identities);
+  } catch (e) {
+    document.getElementById('error').textContent = 'Could not remove container: ' + (e.message || e);
+  }
+}
+
 function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   const row = document.createElement('div');
   const isFull = document.body.classList.contains('full');
@@ -993,11 +1015,45 @@ async function init() {
   if (addContainerBtn) {
     if (containersAvailable) {
       addContainerBtn.addEventListener('click', () => {
-        const id = targetSelect ? targetSelect.value : 'firefox-default';
-        bulkAssignToContainer(id);
+        const name = document.getElementById('new-container-name')?.value.trim();
+        if (name) {
+          document.getElementById('new-container-name').value = '';
+          bulkAssignToContainer(null, name);
+        } else {
+          const id = targetSelect ? targetSelect.value : 'firefox-default';
+          bulkAssignToContainer(id);
+        }
       });
     } else {
       addContainerBtn.disabled = true;
+    }
+  }
+
+  const createContainerBtn = document.getElementById('create-container');
+  if (createContainerBtn) {
+    if (containersAvailable) {
+      createContainerBtn.addEventListener('click', async () => {
+        const name = document.getElementById('new-container-name')?.value.trim();
+        if (!name) return;
+        document.getElementById('new-container-name').value = '';
+        await createContainer(name);
+      });
+    } else {
+      createContainerBtn.disabled = true;
+    }
+  }
+
+  const deleteContainerBtn = document.getElementById('delete-container');
+  if (deleteContainerBtn) {
+    if (containersAvailable) {
+      deleteContainerBtn.addEventListener('click', async () => {
+        const id = targetSelect ? targetSelect.value : '';
+        if (!id || id === 'firefox-default') return;
+        if (!confirm(`Delete container '${containerMap.get(id)?.name || id}'?`)) return;
+        await deleteContainer(id);
+      });
+    } else {
+      deleteContainerBtn.disabled = true;
     }
   }
 
@@ -1246,7 +1302,7 @@ async function bulkMove() {
   scheduleUpdate();
 }
 
-async function bulkAssignToContainer(containerId) {
+async function bulkAssignToContainer(containerId, createName) {
   const errorEl = document.getElementById('error');
   if (errorEl) errorEl.textContent = '';
   let identities = [];
@@ -1254,7 +1310,14 @@ async function bulkAssignToContainer(containerId) {
     try {
       identities = await getContainerIdentities();
       refreshContainerDropdowns(identities);
-      if (containerId !== 'firefox-default') {
+      if (createName) {
+        const color = document.getElementById('new-container-color')?.value || 'blue';
+        const icon = document.getElementById('new-container-icon')?.value || 'fingerprint';
+        const created = await browser.contextualIdentities.create({ name: createName, color, icon });
+        containerId = created.cookieStoreId;
+        identities = await getContainerIdentities();
+        refreshContainerDropdowns(identities);
+      } else if (containerId !== 'firefox-default') {
         const exists = identities.some(ci => ci.cookieStoreId === containerId);
         if (!exists) {
           if (errorEl) errorEl.textContent = 'Selected container does not exist';


### PR DESCRIPTION
## Summary
- add container management UI in popup and full views
- handle creation and deletion of containers via popup.js
- allow moving tabs into a new container on the fly
- document group creation in README
- bump extension version to 0.3.7

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68570575912c8331b76899593f7817de