### PR TITLE
Add tab grouping support

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -5,6 +5,7 @@ let recent = [];
 let visited = new Set();
 let recentTimer = null;
 let visitedTimer = null;
+let groups = {};
 
 // Track duplicate tabs by URL
 const dupMap = new Map();
@@ -62,9 +63,10 @@ function sendVisitedUpdate() {
     .catch(() => {});
 }
 
-browser.storage.local.get(['recent', 'visited']).then(data => {
+browser.storage.local.get(['recent', 'visited', 'groups']).then(data => {
   recent = data.recent || [];
   visited = new Set(data.visited || []);
+  groups = data.groups || {};
 });
 
 // Initialize duplicate tracking
@@ -141,12 +143,42 @@ function scheduleVisitedSave() {
   }
 }
 
+function scheduleGroupSave() {
+  clearTimeout(scheduleGroupSave.timer);
+  scheduleGroupSave.timer = setTimeout(() => {
+    browser.storage.local.set({ groups });
+  }, 500);
+}
+
 function markVisited(tabId) {
   if (!visited.has(tabId)) {
     visited.add(tabId);
     scheduleVisitedSave();
     sendVisitedUpdate();
   }
+}
+
+function addToGroup(ids, name) {
+  if (!name) return;
+  groups[name] = groups[name] || [];
+  for (const id of ids) {
+    if (!groups[name].includes(id)) groups[name].push(id);
+  }
+  scheduleGroupSave();
+}
+
+function removeFromGroup(ids) {
+  for (const g of Object.keys(groups)) {
+    groups[g] = groups[g].filter(id => !ids.includes(id));
+    if (groups[g].length === 0) delete groups[g];
+  }
+  scheduleGroupSave();
+}
+
+function moveTabsToGroup(ids, name) {
+  if (!name) return;
+  removeFromGroup(ids);
+  addToGroup(ids, name);
 }
 
 browser.tabs.onActivated.addListener(info => {
@@ -169,6 +201,7 @@ browser.tabs.onRemoved.addListener((tabId) => {
     scheduleVisitedSave();
     sendVisitedUpdate();
   }
+  removeFromGroup([tabId]);
   removeDuplicate(tabId);
 });
 
@@ -195,6 +228,14 @@ browser.runtime.onMessage.addListener((msg) => {
     unmarkVisited(msg.tabId);
   } else if (msg && msg.type === 'reorderRecent') {
     reorderRecent(msg.ids || [], msg.toId, msg.before);
+  } else if (msg && msg.type === 'getGroups') {
+    return Promise.resolve({ groups });
+  } else if (msg && msg.type === 'addToGroup') {
+    addToGroup(msg.ids || [], msg.name);
+  } else if (msg && msg.type === 'removeFromGroup') {
+    removeFromGroup(msg.ids || []);
+  } else if (msg && msg.type === 'moveTabsToGroup') {
+    moveTabsToGroup(msg.ids || [], msg.name);
   }
 });
 

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -30,6 +30,7 @@ let currentActiveId = -1;
 let currentVisited = new Set();
 let currentWinMap = null;
 let currentQuery = '';
+let groupMap = new Map();
 
 function matchShortcut(def, e) {
   if (!def) return false;
@@ -200,7 +201,7 @@ function updateSelection(row, selected) {
 
 function clearSelection() {
   for (const item of tabItems) {
-    if (item.separator) continue;
+    if (item.separator || item.group) continue;
     item.selected = false;
     if (item.el) updateSelection(item.el, false);
   }
@@ -456,6 +457,14 @@ function createWindowSeparator(label) {
   return div;
 }
 
+function createGroupSeparator(name) {
+  const div = document.createElement('div');
+  div.className = 'group-separator';
+  div.textContent = name.toUpperCase();
+  div.tabIndex = -1;
+  return div;
+}
+
 function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
   if (!container) return;
   currentDupIds = dupIds;
@@ -467,11 +476,20 @@ function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
   tabItems = [];
   idIndexMap = new Map();
   let lastWin = -1;
+  let lastGroup = null;
   for (const entry of list) {
     const tab = entry.tab ?? entry;
     if (full && tab.windowId !== lastWin) {
       tabItems.push({ separator: true, label: `Window ${winMap.get(tab.windowId)}`, el: null });
       lastWin = tab.windowId;
+      lastGroup = null;
+    }
+    const group = groupMap.get(tab.id) || null;
+    if (group && group !== lastGroup) {
+      tabItems.push({ group: true, label: group, el: null });
+      lastGroup = group;
+    } else if (!group) {
+      lastGroup = null;
     }
     const item = { tab, match: entry.match, selected: false, el: null };
     tabItems.push(item);
@@ -495,7 +513,7 @@ function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
 
   if (document.body.classList.contains('full')) {
     if (!rowHeight) {
-      const sampleItem = tabItems.find(it => !it.separator);
+      const sampleItem = tabItems.find(it => !it.separator && !it.group);
       if (sampleItem) {
         const sample = createTabRow(
           sampleItem.tab,
@@ -516,6 +534,8 @@ function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
       let el;
       if (item.separator) {
         el = createWindowSeparator(item.label);
+      } else if (item.group) {
+        el = createGroupSeparator(item.label);
       } else {
         el = createTabRow(
           item.tab,
@@ -580,22 +600,34 @@ function generateRow(index) {
   const item = tabItems[index];
   if (!item) return document.createElement('div');
   if (!item.el) {
-    item.el = createTabRow(item.tab, currentDupIds.has(item.tab.id), currentActiveId, currentVisited.has(item.tab.id), item);
-    if (currentQuery && item.match && item.tab.title) {
-      const span = item.el.querySelector('.tab-title');
-      if (span) {
-        let html = '';
-        let last = 0;
-        for (const idx of item.match) {
-          html += escapeHtml(span.textContent.slice(last, idx));
-          html += '<mark>' + escapeHtml(span.textContent[idx]) + '</mark>';
-          last = idx + 1;
+    if (item.separator) {
+      item.el = createWindowSeparator(item.label);
+    } else if (item.group) {
+      item.el = createGroupSeparator(item.label);
+    } else {
+      item.el = createTabRow(
+        item.tab,
+        currentDupIds.has(item.tab.id),
+        currentActiveId,
+        currentVisited.has(item.tab.id),
+        item
+      );
+      if (currentQuery && item.match && item.tab.title) {
+        const span = item.el.querySelector('.tab-title');
+        if (span) {
+          let html = '';
+          let last = 0;
+          for (const idx of item.match) {
+            html += escapeHtml(span.textContent.slice(last, idx));
+            html += '<mark>' + escapeHtml(span.textContent[idx]) + '</mark>';
+            last = idx + 1;
+          }
+          html += escapeHtml(span.textContent.slice(last));
+          span.innerHTML = html;
         }
-        html += escapeHtml(span.textContent.slice(last));
-        span.innerHTML = html;
       }
+      if (item.selected) item.el.classList.add('selected');
     }
-    if (item.selected) item.el.classList.add('selected');
   }
   return item.el;
 }
@@ -810,7 +842,7 @@ document.addEventListener('keydown', (e) => {
     let newIdx = idx;
     do {
       newIdx = Math.min(Math.max(newIdx + delta, 0), tabItems.length - 1);
-    } while (tabItems[newIdx] && tabItems[newIdx].separator);
+    } while (tabItems[newIdx] && (tabItems[newIdx].separator || tabItems[newIdx].group));
     idx = newIdx;
     const el = tabItems[newIdx].el;
     requestAnimationFrame(() => {
@@ -836,14 +868,14 @@ document.addEventListener('keydown', (e) => {
       const start = Math.min(lastSelectedIndex, newIdx);
       const end = Math.max(lastSelectedIndex, newIdx);
       for (let i = 0; i < tabItems.length; i++) {
-        if (tabItems[i].separator) continue;
+        if (tabItems[i].separator || tabItems[i].group) continue;
         const sel = i >= start && i <= end;
         tabItems[i].selected = sel;
         if (tabItems[i].el) updateSelection(tabItems[i].el, sel);
       }
     } else if (!e.ctrlKey && !e.metaKey) {
       tabItems.forEach(it => {
-        if (it.separator) return;
+        if (it.separator || it.group) return;
         it.selected = false;
         if (it.el) updateSelection(it.el, false);
       });
@@ -866,7 +898,7 @@ document.addEventListener('keydown', (e) => {
     e.preventDefault();
     let last = -1;
     tabItems.forEach((it, i) => {
-      if (it.separator) return;
+      if (it.separator || it.group) return;
       it.selected = true;
       if (it.el) updateSelection(it.el, true);
       last = i;
@@ -927,6 +959,10 @@ async function init() {
   visitedIds = new Set(visited);
   const { duplicates = [] } = await browser.runtime.sendMessage({ type: 'getDuplicates' });
   currentDupIds = new Set(duplicates);
+  const { groups = {} } = await browser.runtime.sendMessage({ type: 'getGroups' });
+  groupMap = new Map(
+    Object.entries(groups).flatMap(([g, arr]) => arr.map(id => [parseInt(id, 10), g]))
+  );
   await loadOptions();
   registerTabEvents();
   const select = document.getElementById('container-filter');
@@ -1117,7 +1153,7 @@ async function movePendingTo(targetEl, evt) {
 function flagTabsForMove() {
   movePending = getSelectedTabIds().slice();
   tabItems.forEach(it => {
-    if (!it.separator && it.selected && it.el) {
+    if (!it.separator && !it.group && it.selected && it.el) {
       it.el.classList.add('move-pending');
     }
   });
@@ -1159,10 +1195,13 @@ function showContextMenu(e) {
       return bulkAssignToContainer(id);
     });
     addItem('Remove Selected from Container', bulkRemoveFromContainer);
+    addItem('Add to Group', bulkAddToGroup);
+    addItem('Remove from Group', bulkRemoveFromGroup);
   }
 
   if (MOVE_ENABLED && movePending && tabEl) {
     addItem('Move Flagged Tabs Here', () => movePendingTo(tabEl, e));
+    addItem('Move Flagged Tabs to Group', moveFlaggedTabsToGroup);
   }
 
   if (tabEl && (!selected.length || !tabEl.classList.contains('selected'))) {
@@ -1199,7 +1238,7 @@ function showContextMenu(e) {
 document.addEventListener('click', () => context.classList.add('hidden'));
 
 function getSelectedTabIds() {
-  return tabItems.filter(it => !it.separator && it.selected).map(it => it.tab.id);
+  return tabItems.filter(it => !it.separator && !it.group && it.selected).map(it => it.tab.id);
 }
 
 async function bulkClose() {
@@ -1311,6 +1350,45 @@ async function bulkAssignToContainer(containerId) {
 
 async function bulkRemoveFromContainer() {
   await bulkAssignToContainer('firefox-default');
+}
+
+async function bulkAddToGroup() {
+  const ids = getSelectedTabIds();
+  if (!ids.length) return;
+  const name = prompt('Group name');
+  if (!name) return;
+  await browser.runtime.sendMessage({ type: 'addToGroup', ids, name });
+  const { groups = {} } = await browser.runtime.sendMessage({ type: 'getGroups' });
+  groupMap = new Map(
+    Object.entries(groups).flatMap(([g, arr]) => arr.map(id => [parseInt(id, 10), g]))
+  );
+  scheduleUpdate();
+}
+
+async function bulkRemoveFromGroup() {
+  const ids = getSelectedTabIds();
+  if (!ids.length) return;
+  await browser.runtime.sendMessage({ type: 'removeFromGroup', ids });
+  const { groups = {} } = await browser.runtime.sendMessage({ type: 'getGroups' });
+  groupMap = new Map(
+    Object.entries(groups).flatMap(([g, arr]) => arr.map(id => [parseInt(id, 10), g]))
+  );
+  scheduleUpdate();
+}
+
+async function moveFlaggedTabsToGroup() {
+  const ids = movePending;
+  if (!ids || !ids.length) return;
+  const name = prompt('Group name');
+  if (!name) return;
+  await browser.runtime.sendMessage({ type: 'moveTabsToGroup', ids, name });
+  movePending = null;
+  tabItems.forEach(it => it.el?.classList.remove('move-pending'));
+  const { groups = {} } = await browser.runtime.sendMessage({ type: 'getGroups' });
+  groupMap = new Map(
+    Object.entries(groups).flatMap(([g, arr]) => arr.map(id => [parseInt(id, 10), g]))
+  );
+  scheduleUpdate();
 }
 
 function onContainerClick(e) {

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -71,6 +71,10 @@ body[data-theme="dark"] .window-separator {
   background: var(--color-active);
   color: var(--color-bg);
 }
+body[data-theme="dark"] .group-separator {
+  background: var(--color-hover);
+  color: var(--color-text);
+}
 body[data-theme="dark"] .selected {
   background: var(--color-active);
 }
@@ -249,6 +253,20 @@ body.popup .tab > div {
   border-radius: 6px;
   height: calc(var(--tile-height) * 0.9);
   margin: 0.5em 0;
+  box-sizing: border-box;
+}
+.group-separator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 0.85em;
+  background: var(--color-hover);
+  color: var(--color-text);
+  border: 1px dashed var(--color-border);
+  border-radius: 4px;
+  height: calc(var(--tile-height) * 0.8);
+  margin: 0.3em 0;
   box-sizing: border-box;
 }
 button {


### PR DESCRIPTION
## Summary
- handle tab groups in background
- support group separators in popup
- extend popup context menu with group options
- style new group separators

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685750737f08833185364a6ff4132b6c