### PR TITLE
Add tab grouping support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
 # KepiTAB
 
-This repository contains the source code for **KepiTAB**, a simple Firefox extension for managing open tabs. The add-on provides quick filtering, duplicate detection, a full multi-column view and optional dark theme. The popup lists tabs from the current window while the full view shows tabs from every open Firefox window. Windows are now separated by bold labeled dividers with extra spacing for clarity. Multiple selected tabs can be dragged together to any position. A keyboard shortcut can unload all open tabs to free memory. The options page allows toggling features like the Recent and Duplicates panels and lets you set the tile width plus independent tile, font and close button scaling used in the full view. A new option controls the row gap between tiles in full view. You can also customize the shortcuts for opening the popup, opening the full view and unloading all tabs. Additional shortcuts let you switch views with **Shift+A**, **Shift+R** and **Shift+D**, and these can also be customized or disabled. Shortcut fields now listen for key presses and display the exact combination you enter. The close button scale adjusts the × button size separately from the font scale. Popup mode applies a reduced tile and font scale so more tabs fit in the window. The interface scale can be adjusted from the Options page or by holding **Ctrl** and scrolling, and the extension remembers your preference. Visited tabs appear bold while unvisited tabs are dimmed. See the `mytabs` directory for the extension files.
-Container-related actions require Firefox's container feature and the `contextualIdentities` permission. Starting with version 0.3 the extension also needs the `cookies` permission so tabs can be opened in a different container. If containers are disabled, the container filter and "Add to Container" buttons will not be shown. Pinned and active tabs keep their state and order when moved between windows or containers.
+This repository contains the source code for **KepiTAB**, a simple Firefox extension for managing open tabs. The add-on provides quick filtering, duplicate detection, a full multi-column view and optional dark theme.
+
+The popup lists tabs from the current window while the full view shows tabs from every open Firefox window. Windows are now separated by bold labeled dividers with extra spacing for clarity. Multiple selected tabs can be dragged together to any position. A keyboard shortcut can unload all open tabs to free memory.
+
+Selected tabs can also be grouped via a bulk action. New groups appear at the position of the first selected tab, or you can pass a group ID to `bulkAddToGroup()` to reuse an existing group.
+
+The options page allows toggling features like the Recent and Duplicates panels and lets you set the tile width plus independent tile, font and close button scaling used in the full view. A new option controls the row gap between tiles in full view.
+
+You can also customize the shortcuts for opening the popup, opening the full view and unloading all tabs. Additional shortcuts let you switch views with **Shift+A**, **Shift+R** and **Shift+D**, and these can also be customized or disabled. Shortcut fields now listen for key presses and display the exact combination you enter.
+
+The close button scale adjusts the × button size separately from the font scale. Popup mode applies a reduced tile and font scale so more tabs fit in the window. The interface scale can be adjusted from the Options page or by holding **Ctrl** and scrolling, and the extension remembers your preference. Visited tabs appear bold while unvisited tabs are dimmed. See the `mytabs` directory for the extension files.
+
+Container-related actions require Firefox's container feature and the `contextualIdentities` permission. Starting with version 0.4 the extension also needs the `tabGroups` permission in addition to the `cookies` permission so tabs can be grouped or opened in a different container. If containers are disabled, the container filter, "Add to Container" and "Add to Group" buttons will not be shown. Pinned and active tabs keep their state and order when moved between windows or containers.
 
 ## Development
 
 Install dev dependencies and run Stylelint to check the stylesheet.
-Configuration is stored in `.stylelintrc.json` and uses the
-`stylelint-order` plugin. Before running the linter, execute
-`npm install` and then run `npm run lint`.
+Configuration is stored in `.stylelintrc.json` and uses the `stylelint-order` plugin.
+Before running the linter, execute `npm install` and then run `npm run lint`.
 
 ```bash
 npm install

--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -14,8 +14,11 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 - Each tab row includes a button to quickly close that tab.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.
 - Bulk assign selected tabs to any Firefox container or move them back to the default container.
+- Bulk add selected tabs to a tab group.
+  - If no group exists, a new one is created at the position of the first selected tab.
+  - Developers can pass an existing group ID to `bulkAddToGroup()` to append tabs.
 - Pinned and active tabs retain their state and original order when moved between windows or containers.
-- Container-related actions require Firefox's container feature and the `contextualIdentities` permission. If containers are disabled, the container filter and "Add to Container" buttons will not be shown.
+- Container-related actions require Firefox's container feature and the `contextualIdentities` permission. Version 0.4 also needs the `tabGroups` permission so tabs can be grouped. If containers are disabled, the container filter, "Add to Container" and "Add to Group" buttons will not be shown.
 - A **Full View** window shows tabs in a responsive grid that fills the entire window.
   - The number of columns adapts to the window size.
   - Custom context menu reveals extension version and links to the Options page.

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -25,6 +25,7 @@
     <div id="bulk-actions">
       <select id="container-target"></select>
       <button id="bulk-add-container">Add to Container</button>
+      <button id="bulk-add-group">Add to Group</button>
       <button id="bulk-remove-container">Remove from Container</button>
       <button id="bulk-close">Close</button>
       <button id="bulk-reload">Reload</button>

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,11 +1,12 @@
 {
   "manifest_version": 2,
   "name": "KepiTAB",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "A simple tab management tool inspired by All Tabs Helper",
     "permissions": [
       "tabs",
       "tabHide",
+      "tabGroups",
       "storage",
       "contextMenus",
       "contextualIdentities",

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -23,6 +23,7 @@
     <div id="bulk-actions">
       <select id="container-target"></select>
       <button id="bulk-add-container">Add to Container</button>
+      <button id="bulk-add-group">Add to Group</button>
       <button id="bulk-remove-container">Remove from Container</button>
       <button id="bulk-close">Close</button>
       <button id="bulk-reload">Reload</button>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1001,6 +1001,15 @@ async function init() {
     }
   }
 
+  const addGroupBtn = document.getElementById('bulk-add-group');
+  if (addGroupBtn) {
+    if (browser.tabs.group) {
+      addGroupBtn.addEventListener('click', () => bulkAddToGroup());
+    } else {
+      addGroupBtn.disabled = true;
+    }
+  }
+
   const removeContainerBtn = document.getElementById('bulk-remove-container');
   if (removeContainerBtn) {
     if (containersAvailable) {
@@ -1026,6 +1035,12 @@ function registerTabEvents() {
   browser.tabs.onActivated.addListener(updateListener);
   browser.tabs.onDetached.addListener(updateListener);
   browser.tabs.onAttached.addListener(updateListener);
+  if (browser.tabGroups) {
+    browser.tabGroups.onCreated.addListener(updateListener);
+    browser.tabGroups.onRemoved.addListener(updateListener);
+    browser.tabGroups.onUpdated.addListener(updateListener);
+    browser.tabGroups.onMoved.addListener(updateListener);
+  }
 }
 
 function unregisterTabEvents() {
@@ -1035,6 +1050,12 @@ function unregisterTabEvents() {
   browser.tabs.onActivated.removeListener(updateListener);
   browser.tabs.onDetached.removeListener(updateListener);
   browser.tabs.onAttached.removeListener(updateListener);
+  if (browser.tabGroups) {
+    browser.tabGroups.onCreated.removeListener(updateListener);
+    browser.tabGroups.onRemoved.removeListener(updateListener);
+    browser.tabGroups.onUpdated.removeListener(updateListener);
+    browser.tabGroups.onMoved.removeListener(updateListener);
+  }
 }
 
 function cleanup() {
@@ -1242,6 +1263,25 @@ async function bulkMove() {
     for (const tab of tabs) {
       await browser.tabs.move(tab.id, { windowId: other.id, index: -1 });
     }
+  }
+  scheduleUpdate();
+}
+
+async function bulkAddToGroup(groupId) {
+  const ids = getSelectedTabIds();
+  if (!ids.length || !browser.tabs.group) return;
+  try {
+    const first = await browser.tabs.get(ids[0]);
+    const params = {
+      tabIds: ids,
+      createProperties: { windowId: first.windowId, index: first.index }
+    };
+    if (groupId !== undefined && groupId !== null) {
+      params.groupId = groupId;
+    }
+    await browser.tabs.group(params);
+  } catch (e) {
+    console.error('Failed to group tabs', e);
   }
   scheduleUpdate();
 }


### PR DESCRIPTION
## Summary
- bump extension version and add tabGroups permission
- add Add to Group bulk action in popup and full views
- implement bulkAddToGroup and listen to tab group events
- document new feature and permission
- fix grouping position in existing windows
- fix bulkAddToGroup not handling undefined groupId
- clarify grouping docs

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6857fc48aa8083319041230f1845900f