### PR TITLE
Update default UI settings

### DIFF
--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -8,17 +8,17 @@
   <h1>Options</h1>
   <label>Theme: <select id="theme"><option value="light">Light</option><option value="dark">Dark</option></select></label>
   <br>
-  <label>Tile Width (px): <input type="number" id="tileWidth" min="50" max="600" value="150"></label>
+  <label>Tile Width (px): <input type="number" id="tileWidth" min="50" max="600" value="255"></label>
   <br>
   <label>Tile Scale: <input type="number" id="tileScale" min="0.5" max="2" step="0.1" value="0.9"></label>
   <br>
   <label>Font Scale: <input type="number" id="fontScale" min="0.25" max="2" step="0.1" value="0.8125"></label>
   <br>
-  <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="0.5"></label>
+  <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="1.55"></label>
   <br>
   <label>UI Scale: <input type="number" id="uiScale" min="0.5" max="2" step="0.1" value="1"></label>
   <br>
-  <label>Row Gap (em): <input type="number" id="rowGap" min="0" max="5" step="0.1" value="0.1"></label>
+  <label>Row Gap (em): <input type="number" id="rowGap" min="0" max="5" step="0.1" value="0"></label>
   <br>
   <label>Scroll Speed: <input type="range" id="scrollSpeed" min="0.5" max="3" step="0.1" value="1"><span id="scrollSpeedValue">1</span></label>
   <br>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -1,6 +1,6 @@
 const BASE_TILE_SCALE = 0.9;
 const BASE_FONT_SCALE = 0.8125;
-const BASE_CLOSE_SCALE = 0.5;
+const BASE_CLOSE_SCALE = 1.55;
 
 async function load(){
   const data = await browser.storage.local.get([
@@ -11,11 +11,11 @@ async function load(){
   ]);
   const {
     theme='light',
-    tileWidth=150,
+    tileWidth=255,
     tileScale=0.9,
     fontScale=0.8125,
     scrollSpeed=1,
-    rowGap=0.1,
+    rowGap=0,
     showRecent=true,
     showDuplicates=true,
     enableMove=true,
@@ -28,7 +28,7 @@ async function load(){
   } = data;
   let closeScale = data.closeScale;
   if (closeScale === undefined) {
-    closeScale = 0.5;
+    closeScale = 1.55;
     browser.storage.local.set({ closeScale });
   }
   document.getElementById('theme').value = theme;

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -7,13 +7,13 @@
   --color-selected: #dceaff;
   --color-muted: #888;
   --color-visited: #f0fff0;
-  --tile-width: 150px;
+  --tile-width: 255px;
   --tile-height: 32px;
   --tile-scale: 0.9;
   --tile-height: calc(32px * var(--tile-scale));
   --font-scale: 0.8125;
-  --close-scale: 0.5;
-  --row-gap: 0.1em;
+  --close-scale: 1.55;
+  --row-gap: 0em;
   --color-close: #888;
   --color-close-hover: #f33;
 }

--- a/mytabs/theme.js
+++ b/mytabs/theme.js
@@ -1,8 +1,8 @@
 (async function(){
-  let { theme = 'light', tileWidth = 150, tileScale = 0.9, fontScale = 0.8125, closeScale = 0.5, rowGap = 0.1 } =
+  let { theme = 'light', tileWidth = 255, tileScale = 0.9, fontScale = 0.8125, closeScale = 1.55, rowGap = 0 } =
     await browser.storage.local.get(['theme','tileWidth','tileScale','fontScale','closeScale','rowGap']);
   if (closeScale === undefined) {
-    closeScale = 0.5;
+    closeScale = 1.55;
     browser.storage.local.set({ closeScale });
   }
 


### PR DESCRIPTION
## Summary
- adjust default UI scales for tiles and fonts
- update CSS vars for new defaults
- revise options page values
- use updated defaults when loading settings

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685943e35c5483318ec09cb1053a178a