### PR TITLE
Add default buttons to options v1

### DIFF
--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -6,43 +6,43 @@
 </head>
 <body>
   <h1>Options</h1>
-  <label>Theme: <select id="theme"><option value="light">Light</option><option value="dark">Dark</option></select></label>
+  <label>Theme: <select id="theme"><option value="light">Light</option><option value="dark">Dark</option></select></label> <button type="button" class="default-btn" data-for="theme">Default</button>
   <br>
-  <label>Tile Width (px): <input type="number" id="tileWidth" min="50" max="600" value="255"></label>
+  <label>Tile Width (px): <input type="number" id="tileWidth" min="50" max="600" value="255"></label> <button type="button" class="default-btn" data-for="tileWidth">Default</button>
   <br>
-  <label>Tile Scale: <input type="number" id="tileScale" min="0.5" max="2" step="0.1" value="0.9"></label>
+  <label>Tile Scale: <input type="number" id="tileScale" min="0.5" max="2" step="0.1" value="0.9"></label> <button type="button" class="default-btn" data-for="tileScale">Default</button>
   <br>
-  <label>Font Scale: <input type="number" id="fontScale" min="0.25" max="2" step="0.1" value="0.8125"></label>
+  <label>Font Scale: <input type="number" id="fontScale" min="0.25" max="2" step="0.1" value="0.8125"></label> <button type="button" class="default-btn" data-for="fontScale">Default</button>
   <br>
-  <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="1.55"></label>
+  <label>Close Button Scale: <input type="number" id="closeScale" min="0.25" max="2" step="0.1" value="1.55"></label> <button type="button" class="default-btn" data-for="closeScale">Default</button>
   <br>
-  <label>UI Scale: <input type="number" id="uiScale" min="0.5" max="2" step="0.1" value="1"></label>
+  <label>UI Scale: <input type="number" id="uiScale" min="0.5" max="2" step="0.1" value="1"></label> <button type="button" class="default-btn" data-for="uiScale">Default</button>
   <br>
-  <label>Row Gap (em): <input type="number" id="rowGap" min="0" max="5" step="0.1" value="0"></label>
+  <label>Row Gap (em): <input type="number" id="rowGap" min="0" max="5" step="0.1" value="0"></label> <button type="button" class="default-btn" data-for="rowGap">Default</button>
   <br>
-  <label>Scroll Speed: <input type="range" id="scrollSpeed" min="0.5" max="3" step="0.1" value="1"><span id="scrollSpeedValue">1</span></label>
+  <label>Scroll Speed: <input type="range" id="scrollSpeed" min="0.5" max="3" step="0.1" value="1"><span id="scrollSpeedValue">1</span></label> <button type="button" class="default-btn" data-for="scrollSpeed">Default</button>
   <br>
-  <label><input type="checkbox" id="opt-show-recent" checked> Show Recent panel</label>
+  <label><input type="checkbox" id="opt-show-recent" checked> Show Recent panel</label> <button type="button" class="default-btn" data-for="opt-show-recent">Default</button>
   <br>
-  <label><input type="checkbox" id="opt-show-dups" checked> Show Duplicates panel</label>
+  <label><input type="checkbox" id="opt-show-dups" checked> Show Duplicates panel</label> <button type="button" class="default-btn" data-for="opt-show-dups">Default</button>
   <br>
-  <label><input type="checkbox" id="opt-enable-move" checked> Enable Move commands</label>
+  <label><input type="checkbox" id="opt-enable-move" checked> Enable Move commands</label> <button type="button" class="default-btn" data-for="opt-enable-move">Default</button>
   <br>
-  <label><input type="checkbox" id="opt-auto-unload"> Auto Unload Inactive Tabs</label>
+  <label><input type="checkbox" id="opt-auto-unload"> Auto Unload Inactive Tabs</label> <button type="button" class="default-btn" data-for="opt-auto-unload">Default</button>
   <br>
-  <label>Unload After (minutes): <input type="number" id="opt-auto-unload-mins" min="1" max="1440" value="60"></label>
+  <label>Unload After (minutes): <input type="number" id="opt-auto-unload-mins" min="1" max="1440" value="60"></label> <button type="button" class="default-btn" data-for="opt-auto-unload-mins">Default</button>
   <br>
-  <label>Popup Shortcut: <input type="text" id="key-open-popup" placeholder="Alt+Shift+H"></label>
+  <label>Popup Shortcut: <input type="text" id="key-open-popup" placeholder="Alt+Shift+H"></label> <button type="button" class="default-btn" data-for="key-open-popup">Default</button>
   <br>
-  <label>Full View Shortcut: <input type="text" id="key-open-full" placeholder="Alt+Shift+F"></label>
+  <label>Full View Shortcut: <input type="text" id="key-open-full" placeholder="Alt+Shift+F"></label> <button type="button" class="default-btn" data-for="key-open-full">Default</button>
   <br>
-  <label>Unload All Shortcut: <input type="text" id="key-unload-all" placeholder="Alt+Shift+U"></label>
+  <label>Unload All Shortcut: <input type="text" id="key-unload-all" placeholder="Alt+Shift+U"></label> <button type="button" class="default-btn" data-for="key-unload-all">Default</button>
   <br>
-  <label>All View Shortcut: <input type="text" id="key-view-all" placeholder="Shift+A"></label>
+  <label>All View Shortcut: <input type="text" id="key-view-all" placeholder="Shift+A"></label> <button type="button" class="default-btn" data-for="key-view-all">Default</button>
   <br>
-  <label>Recent View Shortcut: <input type="text" id="key-view-recent" placeholder="Shift+R"></label>
+  <label>Recent View Shortcut: <input type="text" id="key-view-recent" placeholder="Shift+R"></label> <button type="button" class="default-btn" data-for="key-view-recent">Default</button>
   <br>
-  <label>Duplicates View Shortcut: <input type="text" id="key-view-dups" placeholder="Shift+D"></label>
+  <label>Duplicates View Shortcut: <input type="text" id="key-view-dups" placeholder="Shift+D"></label> <button type="button" class="default-btn" data-for="key-view-dups">Default</button>
   <br>
   <button id="save">Save</button>
   <script src="theme.js"></script>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -2,6 +2,28 @@ const BASE_TILE_SCALE = 0.9;
 const BASE_FONT_SCALE = 0.8125;
 const BASE_CLOSE_SCALE = 1.55;
 
+const DEFAULTS = {
+  theme: 'light',
+  tileWidth: 255,
+  tileScale: 0.9,
+  fontScale: 0.8125,
+  closeScale: 1.55,
+  uiScale: 1,
+  rowGap: 0,
+  scrollSpeed: 1,
+  'opt-show-recent': true,
+  'opt-show-dups': true,
+  'opt-enable-move': true,
+  'opt-auto-unload': false,
+  'opt-auto-unload-mins': 60,
+  'key-open-popup': 'Alt+Shift+H',
+  'key-open-full': 'Alt+Shift+F',
+  'key-unload-all': 'Alt+Shift+U',
+  'key-view-all': 'Shift+A',
+  'key-view-recent': 'Shift+R',
+  'key-view-dups': 'Shift+D'
+};
+
 async function load(){
   const data = await browser.storage.local.get([
     'theme','tileWidth','tileScale','fontScale','closeScale','rowGap','scrollSpeed',
@@ -60,6 +82,7 @@ async function load(){
   document.documentElement.style.setProperty('--font-scale', fontScale);
   document.documentElement.style.setProperty('--close-scale', closeScale);
   document.documentElement.style.setProperty('--row-gap', rowGap + 'em');
+  Object.keys(DEFAULTS).forEach(checkDefault);
 }
 async function save(){
   const theme=document.getElementById('theme').value;
@@ -162,6 +185,7 @@ function handleShortcutInput(e){
   }
   e.preventDefault();
   e.target.value=formatShortcut(e);
+  checkDefault(e.target.id);
 }
 
 const elTileWidth = document.getElementById('tileWidth');
@@ -173,36 +197,111 @@ const elScrollSpeed = document.getElementById('scrollSpeed');
 const elRowGap = document.getElementById('rowGap');
 const elAutoUnload = document.getElementById('opt-auto-unload');
 const elAutoUnloadMins = document.getElementById('opt-auto-unload-mins');
+const elShowRecent = document.getElementById('opt-show-recent');
+const elShowDups = document.getElementById('opt-show-dups');
+const elEnableMove = document.getElementById('opt-enable-move');
 
-elTileWidth.addEventListener('input', updateWidth);
-elTileWidth.addEventListener('change', updateWidth);
+const updateMap = {
+  tileWidth: updateWidth,
+  tileScale: updateScale,
+  fontScale: updateFont,
+  closeScale: updateCloseScale,
+  uiScale: updateUIScale,
+  rowGap: updateRowGap,
+  scrollSpeed: updateScroll
+};
 
-elTileScale.addEventListener('input', updateScale);
-elTileScale.addEventListener('change', updateScale);
+function checkDefault(id) {
+  const input = document.getElementById(id);
+  const btn = document.querySelector(`button[data-for="${id}"]`);
+  if (!input || !btn) return;
+  let val;
+  if (input.type === 'checkbox') {
+    val = input.checked;
+  } else {
+    val = input.value;
+    if (input.type === 'number' || input.type === 'range') {
+      val = parseFloat(val);
+    }
+  }
+  btn.disabled = val === DEFAULTS[id];
+}
 
-elFontScale.addEventListener('input', updateFont);
-elFontScale.addEventListener('change', updateFont);
+document.querySelectorAll('.default-btn').forEach(btn => {
+  const id = btn.dataset.for;
+  btn.addEventListener('click', () => {
+    const input = document.getElementById(id);
+    if (!input) return;
+    const val = DEFAULTS[id];
+    if (input.type === 'checkbox') {
+      input.checked = val;
+      browser.storage.local.set({ [id]: val });
+    } else {
+      input.value = val;
+      if (updateMap[id]) {
+        updateMap[id]();
+      }
+    }
+    checkDefault(id);
+    if (id === 'uiScale') {
+      checkDefault('tileScale');
+      checkDefault('fontScale');
+      checkDefault('closeScale');
+    }
+  });
+});
 
-elCloseScale.addEventListener('input', updateCloseScale);
-elCloseScale.addEventListener('change', updateCloseScale);
+elTileWidth.addEventListener('input', () => { updateWidth(); checkDefault('tileWidth'); });
+elTileWidth.addEventListener('change', () => { updateWidth(); checkDefault('tileWidth'); });
 
-elRowGap.addEventListener('input', updateRowGap);
-elRowGap.addEventListener('change', updateRowGap);
+elTileScale.addEventListener('input', () => { updateScale(); checkDefault('tileScale'); });
+elTileScale.addEventListener('change', () => { updateScale(); checkDefault('tileScale'); });
+
+elFontScale.addEventListener('input', () => { updateFont(); checkDefault('fontScale'); });
+elFontScale.addEventListener('change', () => { updateFont(); checkDefault('fontScale'); });
+
+elCloseScale.addEventListener('input', () => { updateCloseScale(); checkDefault('closeScale'); });
+elCloseScale.addEventListener('change', () => { updateCloseScale(); checkDefault('closeScale'); });
+
+elRowGap.addEventListener('input', () => { updateRowGap(); checkDefault('rowGap'); });
+elRowGap.addEventListener('change', () => { updateRowGap(); checkDefault('rowGap'); });
+
+elAutoUnloadMins.addEventListener('input', () => checkDefault('opt-auto-unload-mins'));
+elAutoUnloadMins.addEventListener('change', () => checkDefault('opt-auto-unload-mins'));
+
+elShowRecent.addEventListener('change', () => {
+  browser.storage.local.set({ 'opt-show-recent': elShowRecent.checked });
+  checkDefault('opt-show-recent');
+});
+
+elShowDups.addEventListener('change', () => {
+  browser.storage.local.set({ 'opt-show-dups': elShowDups.checked });
+  checkDefault('opt-show-dups');
+});
+
+elEnableMove.addEventListener('change', () => {
+  browser.storage.local.set({ 'opt-enable-move': elEnableMove.checked });
+  checkDefault('opt-enable-move');
+});
 
 elAutoUnload.addEventListener('change', () => {
   elAutoUnloadMins.disabled = !elAutoUnload.checked;
+  browser.storage.local.set({ 'opt-auto-unload': elAutoUnload.checked });
+  checkDefault('opt-auto-unload');
 });
 
-elUIScale.addEventListener('input', updateUIScale);
-elUIScale.addEventListener('change', updateUIScale);
+elUIScale.addEventListener('input', () => { updateUIScale(); checkDefault('uiScale'); });
+elUIScale.addEventListener('change', () => { updateUIScale(); checkDefault('uiScale'); });
 
-elScrollSpeed.addEventListener('input', updateScroll);
-elScrollSpeed.addEventListener('change', updateScroll);
+elScrollSpeed.addEventListener('input', () => { updateScroll(); checkDefault('scrollSpeed'); });
+elScrollSpeed.addEventListener('change', () => { updateScroll(); checkDefault('scrollSpeed'); });
 document.getElementById('save').addEventListener('click', save);
 
 document.querySelectorAll('input[id^="key-"]').forEach(el => {
   el.addEventListener('keydown', handleShortcutInput);
   el.addEventListener('focus', () => el.select());
+  el.addEventListener('input', () => checkDefault(el.id));
+  el.addEventListener('change', () => checkDefault(el.id));
 });
 
 browser.storage.onChanged.addListener((changes, area) => {
@@ -225,10 +324,17 @@ browser.storage.onChanged.addListener((changes, area) => {
     if (changes.autoUnload) {
       elAutoUnload.checked = changes.autoUnload.newValue;
       elAutoUnloadMins.disabled = !elAutoUnload.checked;
+      checkDefault('opt-auto-unload');
     }
     if (changes.autoUnloadMinutes) {
       elAutoUnloadMins.value = changes.autoUnloadMinutes.newValue;
+      checkDefault('opt-auto-unload-mins');
     }
+    checkDefault('tileScale');
+    checkDefault('fontScale');
+    checkDefault('closeScale');
+    checkDefault('rowGap');
+    checkDefault('uiScale');
   }
 });
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -443,3 +443,12 @@ body.full #menu {
 body.full #menu button {
   flex: 1 1 auto;
 }
+
+.default-btn {
+  margin-left: 0.3em;
+}
+
+.default-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}


### PR DESCRIPTION
## Summary
- add Default buttons for all option inputs
- implement reset logic in options.js
- style disabled Default buttons

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859a7cec5fc833182ac0ea4ba03ecc7