### PR TITLE
fix: show all visited tabs in recent panel

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -5,7 +5,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
 ## Features
 
 - The popup shows tabs from the current window, while the Full View lists tabs from all windows with fuzzy filtering by title or URL.
-- Shows a **Recent** panel using an LRU buffer.
+- Shows a **Recent** panel listing all visited tabs.
 - Highlights duplicate tabs and provides a dedicated **Duplicates** view.
 - Visited tabs appear in **bold** while unvisited tabs are dimmed, making new pages easy to spot.
 - Perform bulk operations (close, reload, unload, move) on selected tabs, and a

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -1,4 +1,5 @@
-const MAX_RECENT = 30;
+// No cap on stored tabs so the Recent panel lists every visited tab
+const MAX_RECENT = Infinity;
 const action = browser.browserAction || browser.action;
 
 let recent = [];

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "KepiTAB Manager",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "A simple tab management tool inspired by All Tabs Helper",
   "icons": { "48": "kepi-tab-manager.ico" },
     "permissions": [


### PR DESCRIPTION
## Summary
- keep all visited tabs in Recent panel by removing MAX_RECENT limit
- document Recent panel in README
- bump extension version to 0.3.8

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859a9ec0f588331944b64dc66ce0c5b