### PR TITLE
Add visual polish

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -12,6 +12,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   command to unload all tabs at once. The keyboard shortcut for this command can
   be configured on the Options page.
 - Each tab row includes a button to quickly close that tab.
+- Smooth hover effects highlight each tab row for a polished interface.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.
 - Bulk assign selected tabs to any Firefox container or move them back to the default container.
 - Pinned and active tabs retain their state and original order when moved between windows or containers.

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "KepiTAB Manager",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "A simple tab management tool inspired by All Tabs Helper",
   "icons": { "48": "kepi-tab-manager.ico" },
     "permissions": [

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -36,6 +36,7 @@ body {
   box-sizing: border-box;
   background: var(--color-bg);
   color: var(--color-text);
+  animation: body-fade-in 0.2s ease-out;
 }
 
 body[data-theme="dark"] {
@@ -163,6 +164,9 @@ body.full #tabs {
   -moz-user-select: none;
   user-select: none;
   cursor: grab;
+  transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
+  box-shadow: none;
+  transform: none;
 }
 .tab:active {
   cursor: grabbing;
@@ -183,6 +187,8 @@ body.popup .tab {
 }
 .tab:hover {
   background: var(--color-hover);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
 }
 .tab.active {
   background: var(--color-active);
@@ -451,4 +457,15 @@ body.full #menu button {
 .default-btn:disabled {
   opacity: 0.5;
   cursor: default;
+}
+
+@keyframes body-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kepi-tab",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Development tooling",
   "devDependencies": {
     "stylelint": "^15.0.0"


### PR DESCRIPTION
## Summary
- enhance tab rows with subtle hover animation
- add fade-in animation on load
- update docs with hover info
- bump versions to 0.3.9 and 1.0.1

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859b0c2956883318c7c613f508a1aab