### PR TITLE
Add scroll shadow and smooth behavior v0.4.0

### DIFF
--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "KepiTAB Manager",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "A simple tab management tool inspired by All Tabs Helper",
   "icons": { "48": "kepi-tab-manager.ico" },
     "permissions": [

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -84,6 +84,12 @@ function hideAllTooltips() {
   document.querySelectorAll('.tab-tooltip').forEach(t => t.remove());
 }
 
+function toggleScrollClass() {
+  const scrolled = scrollContainer &&
+    (scrollContainer.scrollTop > 0 || scrollContainer.scrollLeft > 0);
+  document.body.classList.toggle('scrolled', scrolled);
+}
+
 function showPlaceholder(target, before) {
   if (dropTarget === target &&
       target.classList.contains(before ? 'drop-before' : 'drop-after')) {
@@ -229,6 +235,7 @@ async function restoreScroll() {
       scrollContainer.scrollTop = scrollTop;
     }
   }
+  toggleScrollClass();
   restored = true;
 }
 
@@ -902,6 +909,7 @@ async function init() {
     : container;
   scrollContainer.addEventListener('scroll', saveScroll);
   scrollContainer.addEventListener('scroll', hideAllTooltips);
+  scrollContainer.addEventListener('scroll', toggleScrollClass);
   container.addEventListener('click', onContainerClick);
   container.addEventListener('dragstart', onContainerDragStart);
   container.addEventListener('dragover', onContainerDragOver);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -89,6 +89,14 @@ body[data-theme="dark"] #context div:hover {
 #counts {
   margin-bottom: 0;
 }
+#menu,
+#counts {
+  transition: box-shadow 0.3s;
+}
+body.scrolled #menu,
+body.scrolled #counts {
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+}
 #menu button {
   margin-right: 0.2em;
 }
@@ -139,6 +147,9 @@ body.popup #tabs {
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-gutter: stable;
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-muted) var(--color-bg);
 }
 body.popup .tab {
   width: 100%;
@@ -400,6 +411,9 @@ body.full #tabs-wrapper,
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-x: none;
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-muted) var(--color-bg);
   flex: 1 1 auto;
   display: block;
   width: 100%;
@@ -468,4 +482,22 @@ body.full #menu button {
     opacity: 1;
     transform: none;
   }
+}
+
+/* Scrollbar styling */
+body.popup #tabs::-webkit-scrollbar,
+body.full #tabs-wrapper::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+body.popup #tabs::-webkit-scrollbar-thumb,
+body.full #tabs-wrapper::-webkit-scrollbar-thumb {
+  background-color: var(--color-muted);
+  border-radius: 4px;
+}
+
+body.popup #tabs::-webkit-scrollbar-track,
+body.full #tabs-wrapper::-webkit-scrollbar-track {
+  background-color: var(--color-bg);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kepi-tab",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Development tooling",
   "devDependencies": {
     "stylelint": "^15.0.0"


### PR DESCRIPTION
## Summary
- update extension version to 0.4.0
- style scrollbars and add smooth scrolling
- add header shadow when scrolling

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859d251b098833196e2330913cc33d1