### PR TITLE
Enhance scroll visuals with fade overlays v0.4.1

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -13,6 +13,8 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   be configured on the Options page.
 - Each tab row includes a button to quickly close that tab.
 - Smooth hover effects highlight each tab row for a polished interface.
+- Sticky menu gains a subtle shadow while scrolling for a professional look.
+- Scrolling lists fade at their edges to indicate more content.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.
 - Bulk assign selected tabs to any Firefox container or move them back to the default container.
 - Pinned and active tabs retain their state and original order when moved between windows or containers.

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "KepiTAB Manager",
-  "version": "0.3.9",
+  "version": "0.4.1",
   "description": "A simple tab management tool inspired by All Tabs Helper",
   "icons": { "48": "kepi-tab-manager.ico" },
     "permissions": [

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -216,6 +216,25 @@ const saveScroll = debounce(() => {
   }
 }, 200);
 
+function updateMenuShadow() {
+  const menu = document.getElementById('menu');
+  const counts = document.getElementById('counts');
+  if (!menu || !scrollContainer) return;
+  const scrolled =
+    scrollContainer.scrollTop > 0 || scrollContainer.scrollLeft > 0;
+  menu.classList.toggle('scrolled', scrolled);
+  counts?.classList.toggle('scrolled', scrolled);
+}
+
+function updateScrollFade() {
+  if (!scrollContainer) return;
+  const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
+  const atTop = scrollTop === 0;
+  const atBottom = Math.ceil(scrollTop + clientHeight) >= scrollHeight;
+  scrollContainer.classList.toggle('fade-top', !atTop);
+  scrollContainer.classList.toggle('fade-bottom', !atBottom);
+}
+
 async function restoreScroll() {
   if (restored) return;
   if (document.body.classList.contains('full')) {
@@ -230,6 +249,7 @@ async function restoreScroll() {
     }
   }
   restored = true;
+  updateScrollFade();
 }
 
 async function getTabs(allTabs) {
@@ -902,6 +922,8 @@ async function init() {
     : container;
   scrollContainer.addEventListener('scroll', saveScroll);
   scrollContainer.addEventListener('scroll', hideAllTooltips);
+  scrollContainer.addEventListener('scroll', updateMenuShadow);
+  scrollContainer.addEventListener('scroll', updateScrollFade);
   container.addEventListener('click', onContainerClick);
   container.addEventListener('dragstart', onContainerDragStart);
   container.addEventListener('dragover', onContainerDragOver);
@@ -1015,6 +1037,8 @@ async function init() {
   else if (moveBtn) moveBtn.style.display = 'none';
   await update();
   restoreScroll();
+  updateMenuShadow();
+  updateScrollFade();
 }
 
 // keep the tab list current while the popup is open

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -139,6 +139,40 @@ body.popup #tabs {
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-gutter: stable;
+  position: relative;
+}
+
+#tabs::before,
+#tabs::after,
+#tabs-wrapper::before,
+#tabs-wrapper::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1em;
+  pointer-events: none;
+  background: linear-gradient(var(--color-bg), transparent);
+  transition: opacity 0.2s;
+  opacity: 0;
+  z-index: 2;
+}
+
+#tabs::after,
+#tabs-wrapper::after {
+  top: auto;
+  bottom: 0;
+  background: linear-gradient(transparent, var(--color-bg));
+}
+
+#tabs.fade-top::before,
+#tabs-wrapper.fade-top::before {
+  opacity: 1;
+}
+
+#tabs.fade-bottom::after,
+#tabs-wrapper.fade-bottom::after {
+  opacity: 1;
 }
 body.popup .tab {
   width: 100%;
@@ -400,6 +434,7 @@ body.full #tabs-wrapper,
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-x: none;
+  position: relative;
   flex: 1 1 auto;
   display: block;
   width: 100%;
@@ -445,9 +480,15 @@ body.full #menu {
   align-items: center;
   justify-content: space-between;
   padding: 0.3em 0;
+  transition: box-shadow 0.2s ease;
 }
 body.full #menu button {
   flex: 1 1 auto;
+}
+body.full #menu.scrolled,
+body.full #counts.scrolled {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  transition: box-shadow 0.2s ease;
 }
 
 .default-btn {


### PR DESCRIPTION
## Summary
- add top/bottom fade effect to scrollable lists
- hook new `updateScrollFade` to scroll events
- bump extension version to 0.4.1
- document fade effect in README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859d251b098833196e2330913cc33d1