### PR TITLE
Add fade effect when scrolling v0.4.1

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -13,6 +13,8 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   be configured on the Options page.
 - Each tab row includes a button to quickly close that tab.
 - Smooth hover effects highlight each tab row for a polished interface.
+- Sticky menu gains a subtle shadow while scrolling for a professional look.
+- Tab list edges fade in and out while scrolling to signal more content.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.
 - Bulk assign selected tabs to any Firefox container or move them back to the default container.
 - Pinned and active tabs retain their state and original order when moved between windows or containers.

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "KepiTAB Manager",
-  "version": "0.3.9",
+  "version": "0.4.1",
   "description": "A simple tab management tool inspired by All Tabs Helper",
   "icons": { "48": "kepi-tab-manager.ico" },
     "permissions": [

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -216,6 +216,32 @@ const saveScroll = debounce(() => {
   }
 }, 200);
 
+function updateMenuShadow() {
+  const menu = document.getElementById('menu');
+  const counts = document.getElementById('counts');
+  if (!menu || !scrollContainer) return;
+  const scrolled =
+    scrollContainer.scrollTop > 0 || scrollContainer.scrollLeft > 0;
+  menu.classList.toggle('scrolled', scrolled);
+  counts?.classList.toggle('scrolled', scrolled);
+}
+
+function updateFadeOverlay() {
+  if (!scrollContainer) return;
+  const atTop = scrollContainer.scrollTop <= 0;
+  const atBottom =
+    scrollContainer.scrollTop + scrollContainer.clientHeight >=
+    scrollContainer.scrollHeight;
+  const atLeft = scrollContainer.scrollLeft <= 0;
+  const atRight =
+    scrollContainer.scrollLeft + scrollContainer.clientWidth >=
+    scrollContainer.scrollWidth;
+  scrollContainer.classList.toggle('fade-top', !atTop);
+  scrollContainer.classList.toggle('fade-bottom', !atBottom);
+  scrollContainer.classList.toggle('fade-left', !atLeft);
+  scrollContainer.classList.toggle('fade-right', !atRight);
+}
+
 async function restoreScroll() {
   if (restored) return;
   if (document.body.classList.contains('full')) {
@@ -229,6 +255,7 @@ async function restoreScroll() {
       scrollContainer.scrollTop = scrollTop;
     }
   }
+  updateFadeOverlay();
   restored = true;
 }
 
@@ -902,6 +929,8 @@ async function init() {
     : container;
   scrollContainer.addEventListener('scroll', saveScroll);
   scrollContainer.addEventListener('scroll', hideAllTooltips);
+  scrollContainer.addEventListener('scroll', updateMenuShadow);
+  scrollContainer.addEventListener('scroll', updateFadeOverlay);
   container.addEventListener('click', onContainerClick);
   container.addEventListener('dragstart', onContainerDragStart);
   container.addEventListener('dragover', onContainerDragOver);
@@ -1015,6 +1044,8 @@ async function init() {
   else if (moveBtn) moveBtn.style.display = 'none';
   await update();
   restoreScroll();
+  updateMenuShadow();
+  updateFadeOverlay();
 }
 
 // keep the tab list current while the popup is open

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -127,10 +127,10 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0;
   max-height: 400px;
   overflow-y: hidden;
-
   overflow-x: hidden;
   width: 100%;
   box-sizing: border-box;
+  position: relative;
 }
 body.popup {
   overflow-x: hidden;
@@ -139,6 +139,28 @@ body.popup #tabs {
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-gutter: stable;
+}
+body.popup #tabs::before,
+body.popup #tabs::after {
+  content: '';
+  position: sticky;
+  left: 0;
+  right: 0;
+  height: 1em;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s;
+  z-index: 1;
+}
+body.popup #tabs.fade-top::before {
+  top: 0;
+  background: linear-gradient(to bottom, var(--color-bg), transparent);
+  opacity: 1;
+}
+body.popup #tabs.fade-bottom::after {
+  bottom: 0;
+  background: linear-gradient(to top, var(--color-bg), transparent);
+  opacity: 1;
 }
 body.popup .tab {
   width: 100%;
@@ -406,6 +428,29 @@ body.full #tabs-wrapper,
   min-height: 0;
   margin: 0 !important;
   padding: 0 !important;
+  position: relative;
+}
+body.full #tabs-wrapper::before,
+body.full #tabs-wrapper::after {
+  content: '';
+  position: sticky;
+  top: 0;
+  bottom: 0;
+  width: 1em;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s;
+  z-index: 1;
+}
+body.full #tabs-wrapper.fade-left::before {
+  left: 0;
+  background: linear-gradient(to right, var(--color-bg), transparent);
+  opacity: 1;
+}
+body.full #tabs-wrapper.fade-right::after {
+  right: 0;
+  background: linear-gradient(to left, var(--color-bg), transparent);
+  opacity: 1;
 }
 body.full #tabs,
 .tab-grid {
@@ -445,9 +490,15 @@ body.full #menu {
   align-items: center;
   justify-content: space-between;
   padding: 0.3em 0;
+  transition: box-shadow 0.2s ease;
 }
 body.full #menu button {
   flex: 1 1 auto;
+}
+body.full #menu.scrolled,
+body.full #counts.scrolled {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  transition: box-shadow 0.2s ease;
 }
 
 .default-btn {


### PR DESCRIPTION
## Summary
- add fade overlays for scroll containers
- toggle fade visibility from JS based on scroll position
- bump manifest version to v0.4.1
- document fading edges in README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859d251b098833196e2330913cc33d1