### PR TITLE
Add context menu fade effect v1

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1080,6 +1080,16 @@ window.addEventListener('resize', () => {
 
 // custom context menu
 const context = document.getElementById('context');
+
+function hideContextMenu() {
+  context.classList.remove('show');
+}
+
+context.addEventListener('transitionend', () => {
+  if (!context.classList.contains('show')) {
+    context.classList.add('hidden');
+  }
+});
 async function movePendingTo(targetEl, evt) {
   const ids = movePending;
   if (!ids || !ids.length) return;
@@ -1140,7 +1150,7 @@ function showContextMenu(e) {
     const item = document.createElement('div');
     item.textContent = label;
     item.addEventListener('click', async () => {
-      context.classList.add('hidden');
+      hideContextMenu();
       await fn();
     });
     context.appendChild(item);
@@ -1194,9 +1204,10 @@ function showContextMenu(e) {
   context.style.left = e.pageX + 'px';
   context.style.top = e.pageY + 'px';
   context.classList.remove('hidden');
+  requestAnimationFrame(() => context.classList.add('show'));
 }
 
-document.addEventListener('click', () => context.classList.add('hidden'));
+document.addEventListener('click', hideContextMenu);
 
 function getSelectedTabIds() {
   return tabItems.filter(it => !it.separator && it.selected).map(it => it.tab.id);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -289,6 +289,16 @@ button:hover {
   padding: 0.2em;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
   z-index: 1000;
+  opacity: 0;
+  transform: scale(0.95);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  pointer-events: none;
+}
+
+#context.show {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
 }
 
 #context div {


### PR DESCRIPTION
## Summary
- add opacity transition for the context menu
- animate the menu show/hide via JavaScript

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685a5ac8c6e48331b872856d0a782621