### PR TITLE
v1.0.1: improve popup tooltip

### DIFF
--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "KepiTAB Manager",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "A simple tab management tool inspired by All Tabs Helper",
   "icons": { "48": "kepi-tab-manager.ico" },
     "permissions": [

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -361,9 +361,11 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
     iconCell.appendChild(icon);
   
     let tooltip;
+    let hideTimer;
     const showTooltip = () => {
       // Allow tooltips in both popup and full views
       hideAllTooltips();
+      clearTimeout(hideTimer);
       tooltip = document.createElement('div');
       tooltip.className = 'tab-tooltip';
       const truncatedTitle = truncateText(tab.title || tab.url);
@@ -378,6 +380,14 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
       }
       tooltip.innerHTML = tooltipHtml;
       document.body.appendChild(tooltip);
+      tooltip.addEventListener('mouseenter', () => {
+        clearTimeout(hideTimer);
+      });
+      tooltip.addEventListener('mouseleave', () => {
+        hideTimer = setTimeout(() => {
+          if (!icon.matches(':hover')) hideTooltip();
+        }, 0);
+      });
       const rect = icon.getBoundingClientRect();
       let left = rect.right + window.scrollX + 5;
       const top = rect.top + window.scrollY;
@@ -395,6 +405,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
       });
     };
     const hideTooltip = () => {
+      clearTimeout(hideTimer);
       if (tooltip) {
         tooltip.classList.remove('visible');
         const el = tooltip;
@@ -406,7 +417,12 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
       }
     };
     icon.addEventListener('mouseenter', showTooltip);
-    icon.addEventListener('mouseleave', hideTooltip);
+    icon.addEventListener('mouseleave', () => {
+      hideTimer = setTimeout(() => {
+        if (!tooltip || tooltip.matches(':hover')) return;
+        hideTooltip();
+      }, 0);
+    });
   }
   row.appendChild(iconCell);
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -324,7 +324,7 @@ button:hover {
   font-size: 0.85em;
   border-radius: 4px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-  pointer-events: none;
+  pointer-events: auto;
   z-index: 1000;
   opacity: 0;
   transform: translateY(-2px);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kepi-tab",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Development tooling",
   "devDependencies": {
     "stylelint": "^15.0.0"


### PR DESCRIPTION
## Summary
- fix popup tooltip flicker by keeping tooltip visible while hovered
- enable pointer events on tooltip element
- bump extension version to 0.3.10 and tooling to 1.0.1

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685a701a26d883319f91836c9a71ec8e