### PR TITLE
Fix popup tab hover

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -361,7 +361,13 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
     iconCell.appendChild(icon);
   
     let tooltip;
+    let hideTimer;
     const showTooltip = () => {
+      if (hideTimer) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+      if (tooltip) return;
       // Allow tooltips in both popup and full views
       hideAllTooltips();
       tooltip = document.createElement('div');
@@ -395,15 +401,17 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
       });
     };
     const hideTooltip = () => {
-      if (tooltip) {
-        tooltip.classList.remove('visible');
-        const el = tooltip;
+      if (!tooltip || hideTimer) return;
+      const el = tooltip;
+      hideTimer = setTimeout(() => {
+        el.classList.remove('visible');
         tooltip = null;
         setTimeout(() => {
           el.classList.remove('left');
           el.remove();
         }, 150);
-      }
+        hideTimer = null;
+      }, 50);
     };
     icon.addEventListener('mouseenter', showTooltip);
     icon.addEventListener('mouseleave', hideTooltip);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -467,3 +467,9 @@ body.full #menu button {
   opacity: 0.5;
   cursor: default;
 }
+
+/* Remove hover shift in popup mode */
+body.popup .tab:hover,
+body.popup[data-theme="dark"] .tab:hover {
+  transform: none;
+}


### PR DESCRIPTION
## Summary
- remove translateY hover shift in popup

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a701a26d883319f91836c9a71ec8e