### PR TITLE
Fix tooltip flicker v2

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -361,7 +361,13 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
     iconCell.appendChild(icon);
   
     let tooltip;
+    let hideTimer;
     const showTooltip = () => {
+      if (hideTimer) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+      if (tooltip) return;
       // Allow tooltips in both popup and full views
       hideAllTooltips();
       tooltip = document.createElement('div');
@@ -395,15 +401,17 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
       });
     };
     const hideTooltip = () => {
-      if (tooltip) {
-        tooltip.classList.remove('visible');
-        const el = tooltip;
+      if (!tooltip || hideTimer) return;
+      const el = tooltip;
+      hideTimer = setTimeout(() => {
+        el.classList.remove('visible');
         tooltip = null;
         setTimeout(() => {
           el.classList.remove('left');
           el.remove();
         }, 150);
-      }
+        hideTimer = null;
+      }, 50);
     };
     icon.addEventListener('mouseenter', showTooltip);
     icon.addEventListener('mouseleave', hideTooltip);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -66,6 +66,10 @@ body[data-theme="dark"] .tab:hover {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   transform: translateY(-2px);
 }
+body.popup .tab:hover,
+body.popup[data-theme="dark"] .tab:hover {
+  transform: none;
+}
 body[data-theme="dark"] .duplicate {
   background: #663333;
 }


### PR DESCRIPTION
## Summary
- cancel tooltip hide timer (previous change)
- disable tab translation in popup mode to keep tooltips visible

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a701a26d883319f91836c9a71ec8e