### PR TITLE
Fix tooltip flicker v4

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -332,6 +332,9 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   const row = document.createElement('div');
   const isFull = document.body.classList.contains('full');
   row.className = 'tab';
+  const content = document.createElement('div');
+  content.className = 'tab-content';
+  row.appendChild(content);
   row.dataset.tab = tab.id;
   row.dataset.windowId = tab.windowId;
   row.tabIndex = 0;
@@ -361,7 +364,13 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
     iconCell.appendChild(icon);
   
     let tooltip;
+    let hideTimer;
     const showTooltip = () => {
+      if (hideTimer) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+      if (tooltip) return;
       // Allow tooltips in both popup and full views
       hideAllTooltips();
       tooltip = document.createElement('div');
@@ -395,20 +404,22 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
       });
     };
     const hideTooltip = () => {
-      if (tooltip) {
-        tooltip.classList.remove('visible');
-        const el = tooltip;
+      if (!tooltip || hideTimer) return;
+      const el = tooltip;
+      hideTimer = setTimeout(() => {
+        el.classList.remove('visible');
         tooltip = null;
         setTimeout(() => {
           el.classList.remove('left');
           el.remove();
         }, 150);
-      }
+        hideTimer = null;
+      }, 250);
     };
     icon.addEventListener('mouseenter', showTooltip);
-    icon.addEventListener('mouseleave', hideTooltip);
+    row.addEventListener('mouseleave', hideTooltip);
   }
-  row.appendChild(iconCell);
+  content.appendChild(iconCell);
 
   const indicatorCell = document.createElement('div');
   const ctx = containerMap.get(tab.cookieStoreId);
@@ -419,7 +430,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
     indicator.title = ctx.name;
     indicatorCell.appendChild(indicator);
   }
-  row.appendChild(indicatorCell);
+  content.appendChild(indicatorCell);
 
 
   const titleCell = document.createElement('div');
@@ -427,7 +438,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   title.textContent = tab.title || tab.url;
   title.className = 'tab-title';
   titleCell.appendChild(title);
-  row.appendChild(titleCell);
+  content.appendChild(titleCell);
 
   const closeCell = document.createElement('div');
   const closeBtn = document.createElement('button');
@@ -435,7 +446,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   closeBtn.textContent = '×';
   closeBtn.title = 'Close tab';
   closeCell.appendChild(closeBtn);
-  row.appendChild(closeCell);
+  content.appendChild(closeCell);
 
   // ensure dragging works from any cell in popup mode
   row.querySelectorAll('*').forEach(el => {

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -61,7 +61,7 @@ body[data-theme="dark"] button {
 body[data-theme="dark"] .tab {
   border-bottom-color: var(--color-border);
 }
-body[data-theme="dark"] .tab:hover {
+body[data-theme="dark"] .tab:hover .tab-content {
   background: #444;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   transform: translateY(-2px);
@@ -145,7 +145,7 @@ body.popup .tab {
   width: 100%;
   padding-right: 0.5em;
 }
-body.popup .tab > div:last-child {
+body.popup .tab-content > div:last-child {
   margin-left: auto;
   margin-right: 0.5em;
 }
@@ -154,8 +154,6 @@ body.full #tabs {
 }
 
 .tab {
-  display: flex;
-  align-items: center;
   padding: 0;
   border-bottom: none;
   break-inside: avoid;
@@ -165,10 +163,15 @@ body.full #tabs {
   -moz-user-select: none;
   user-select: none;
   cursor: grab;
+}
+.tab-content {
+  display: flex;
+  align-items: center;
+  width: 100%;
   transition: background-color 0.2s ease, box-shadow 0.2s ease,
     transform 0.2s ease;
 }
-.tab:active {
+.tab:active .tab-content {
   cursor: grabbing;
   transform: translateY(0);
 }
@@ -186,7 +189,7 @@ body.popup .tab {
   border-radius: 50%;
   margin-right: 0.25em;
 }
-.tab:hover {
+.tab:hover .tab-content {
   background: var(--color-hover);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
   transform: translateY(-2px);
@@ -229,14 +232,14 @@ body[data-theme="dark"] .tab.move-pending {
   flex: 1 1 auto;
   min-width: 0;
 }
-.tab > div {
+.tab-content > div {
   padding: 0 0.2em;
   vertical-align: middle;
 }
-body.popup .tab > div {
+body.popup .tab-content > div {
   padding: 0 0.1em;
 }
-.tab > div:nth-child(3) {
+.tab-content > div:nth-child(3) {
   flex: 1 1 auto;
   min-width: 0;
 }


### PR DESCRIPTION
## Summary
- keep popup card hover animation without losing tooltip
- wrap tab row contents in a `.tab-content` container
- adjust CSS and JS to transform inner content only

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a701a26d883319f91836c9a71ec8e