### PR TITLE
Fix tooltip flicker v4

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -332,6 +332,9 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   const row = document.createElement('div');
   const isFull = document.body.classList.contains('full');
   row.className = 'tab';
+  const inner = document.createElement('div');
+  inner.className = 'tab-inner';
+  row.appendChild(inner);
   row.dataset.tab = tab.id;
   row.dataset.windowId = tab.windowId;
   row.tabIndex = 0;
@@ -361,7 +364,13 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
     iconCell.appendChild(icon);
   
     let tooltip;
+    let hideTimer;
     const showTooltip = () => {
+      if (hideTimer) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+      if (tooltip) return;
       // Allow tooltips in both popup and full views
       hideAllTooltips();
       tooltip = document.createElement('div');
@@ -395,20 +404,22 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
       });
     };
     const hideTooltip = () => {
-      if (tooltip) {
-        tooltip.classList.remove('visible');
-        const el = tooltip;
+      if (!tooltip || hideTimer) return;
+      const el = tooltip;
+      hideTimer = setTimeout(() => {
+        el.classList.remove('visible');
         tooltip = null;
         setTimeout(() => {
           el.classList.remove('left');
           el.remove();
         }, 150);
-      }
+        hideTimer = null;
+      }, 250);
     };
     icon.addEventListener('mouseenter', showTooltip);
-    icon.addEventListener('mouseleave', hideTooltip);
+    row.addEventListener('mouseleave', hideTooltip);
   }
-  row.appendChild(iconCell);
+  inner.appendChild(iconCell);
 
   const indicatorCell = document.createElement('div');
   const ctx = containerMap.get(tab.cookieStoreId);
@@ -419,7 +430,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
     indicator.title = ctx.name;
     indicatorCell.appendChild(indicator);
   }
-  row.appendChild(indicatorCell);
+  inner.appendChild(indicatorCell);
 
 
   const titleCell = document.createElement('div');
@@ -427,7 +438,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   title.textContent = tab.title || tab.url;
   title.className = 'tab-title';
   titleCell.appendChild(title);
-  row.appendChild(titleCell);
+  inner.appendChild(titleCell);
 
   const closeCell = document.createElement('div');
   const closeBtn = document.createElement('button');
@@ -435,7 +446,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   closeBtn.textContent = '×';
   closeBtn.title = 'Close tab';
   closeCell.appendChild(closeBtn);
-  row.appendChild(closeCell);
+  inner.appendChild(closeCell);
 
   // ensure dragging works from any cell in popup mode
   row.querySelectorAll('*').forEach(el => {

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -64,6 +64,8 @@ body[data-theme="dark"] .tab {
 body[data-theme="dark"] .tab:hover {
   background: #444;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+}
+body[data-theme="dark"] .tab:hover .tab-inner {
   transform: translateY(-2px);
 }
 body[data-theme="dark"] .duplicate {
@@ -145,7 +147,7 @@ body.popup .tab {
   width: 100%;
   padding-right: 0.5em;
 }
-body.popup .tab > div:last-child {
+body.popup .tab-inner > div:last-child {
   margin-left: auto;
   margin-right: 0.5em;
 }
@@ -168,6 +170,12 @@ body.full #tabs {
   transition: background-color 0.2s ease, box-shadow 0.2s ease,
     transform 0.2s ease;
 }
+.tab-inner {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  transition: transform 0.2s ease;
+}
 .tab:active {
   cursor: grabbing;
   transform: translateY(0);
@@ -189,6 +197,8 @@ body.popup .tab {
 .tab:hover {
   background: var(--color-hover);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+.tab:hover .tab-inner {
   transform: translateY(-2px);
 }
 .tab.active {
@@ -229,14 +239,14 @@ body[data-theme="dark"] .tab.move-pending {
   flex: 1 1 auto;
   min-width: 0;
 }
-.tab > div {
+.tab-inner > div {
   padding: 0 0.2em;
   vertical-align: middle;
 }
-body.popup .tab > div {
+body.popup .tab-inner > div {
   padding: 0 0.1em;
 }
-.tab > div:nth-child(3) {
+.tab-inner > div:nth-child(3) {
   flex: 1 1 auto;
   min-width: 0;
 }


### PR DESCRIPTION
## Summary
- move hover transform to an inner wrapper so pointer stays in row
- wrap tab content in `.tab-inner` container
- adjust tooltip logic to use new wrapper

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a701a26d883319f91836c9a71ec8e