### PR TITLE
Prevent popup tab clipping v1.0.0

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -141,6 +141,7 @@ body.popup #tabs {
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-gutter: stable;
+  padding: 2px 0;
 }
 body.popup #tabs::before,
 body.popup #tabs::after {


### PR DESCRIPTION
## Summary
- adjust popup tabs container padding to accommodate hover animations

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bb27fabec8331b6ded73477615a22