### PR TITLE
Fix popup hover overlap

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -216,6 +216,8 @@ body.popup .tab {
   background: var(--color-hover);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
   transform: translateY(-2px);
+  position: relative;
+  z-index: 2;
 }
 .tab.active {
   background: var(--color-active);


### PR DESCRIPTION
## Summary
- ensure hovered tabs have higher stacking context

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bb46878708331b92b60bbac41a5f8