### PR TITLE
Kamil/z-index-hover-v1.0.2

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -61,11 +61,15 @@ body[data-theme="dark"] button {
 }
 body[data-theme="dark"] .tab {
   border-bottom-color: var(--color-border);
+  position: relative;
+  z-index: 1;
 }
 body[data-theme="dark"] .tab:hover {
   background: #444;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   transform: translateY(-2px);
+  position: relative;
+  z-index: 2; /* z-index zapobiega migotaniu kart */
 }
 body[data-theme="dark"] .duplicate {
   background: #663333;
@@ -189,6 +193,9 @@ body.full #tabs {
   user-select: none;
   cursor: grab;
 
+  position: relative;
+  z-index: 1;
+
   transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
   box-shadow: none;
   transform: none;
@@ -216,6 +223,8 @@ body.popup .tab {
   background: var(--color-hover);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
   transform: translateY(-2px);
+  position: relative;
+  z-index: 2; /* z-index zapobiega migotaniu kart */
 }
 .tab.active {
   background: var(--color-active);


### PR DESCRIPTION
## Summary
- set default z-index on tab elements to maintain stacking context
- keep hover z-index for dark and light themes with a Polish comment

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb879d51c83318e509087eb9aaecc