### PR TITLE
Kamil/fix-tab-hover-flicker-v1.0.2

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -61,11 +61,15 @@ body[data-theme="dark"] button {
 }
 body[data-theme="dark"] .tab {
   border-bottom-color: var(--color-border);
+  position: relative;
+  z-index: 1; /* baseline stacking to avoid flicker */
 }
 body[data-theme="dark"] .tab:hover {
   background: #444;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   transform: translateY(-2px);
+  position: relative;
+  z-index: 2; /* prevents tab flickering */
 }
 body[data-theme="dark"] .duplicate {
   background: #663333;
@@ -192,6 +196,8 @@ body.full #tabs {
   transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
   box-shadow: none;
   transform: none;
+  position: relative;
+  z-index: 1; /* baseline stacking to avoid flicker */
 
 }
 .tab:active {
@@ -216,6 +222,8 @@ body.popup .tab {
   background: var(--color-hover);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
   transform: translateY(-2px);
+  position: relative;
+  z-index: 2; /* prevents tab flickering */
 }
 .tab.active {
   background: var(--color-active);


### PR DESCRIPTION
## Summary
- set baseline z-index on `.tab` and dark theme variant to avoid hover flicker

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bb879d51c83318e509087eb9aaecc