### PR TITLE
Kamil/z-index-hover-v1.0.3

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -66,6 +66,8 @@ body[data-theme="dark"] .tab:hover {
   background: #444;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   transform: translateY(-2px);
+  position: relative;
+  z-index: 2; /* z-index zapobiega migotaniu kart */
 }
 body[data-theme="dark"] .duplicate {
   background: #663333;
@@ -188,6 +190,7 @@ body.full #tabs {
   -moz-user-select: none;
   user-select: none;
   cursor: grab;
+  position: relative;
 
   transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
   box-shadow: none;
@@ -216,6 +219,8 @@ body.popup .tab {
   background: var(--color-hover);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
   transform: translateY(-2px);
+  position: relative;
+  z-index: 2; /* z-index zapobiega migotaniu kart */
 }
 .tab.active {
   background: var(--color-active);


### PR DESCRIPTION
## Summary
- add `position: relative` to `.tab` to maintain stacking context
- keep `z-index` hover fixes in dark and light themes

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bb879d51c83318e509087eb9aaecc