### PR TITLE
Kamil/fix-hover-zindex-v1.0.5

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -61,8 +61,11 @@ body[data-theme="dark"] button {
 }
 body[data-theme="dark"] .tab {
   border-bottom-color: var(--color-border);
+  contain: paint;
 }
 body[data-theme="dark"] .tab:hover {
+  position: relative;
+  z-index: 2; /* z-index zapobiega migotaniu kart */
   background: #444;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   transform: translateY(-2px);
@@ -189,6 +192,10 @@ body.full #tabs {
   user-select: none;
   cursor: grab;
 
+  position: relative;
+  z-index: 1;
+  contain: paint;
+
   transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
   box-shadow: none;
   transform: none;
@@ -213,6 +220,8 @@ body.popup .tab {
   margin-right: 0.25em;
 }
 .tab:hover {
+  position: relative;
+  z-index: 2; /* z-index zapobiega migotaniu kart */
   background: var(--color-hover);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
   transform: translateY(-2px);


### PR DESCRIPTION
## Summary
- refine hover stacking by adding `contain: paint` to tabs
- elevate hovered tabs with `z-index: 2` and a Polish comment explaining the flicker fix

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bb879d51c83318e509087eb9aaecc