### PR TITLE
Kamil/fix-tab-hover-v1.0.5

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -66,6 +66,7 @@ body[data-theme="dark"] .tab:hover {
   background: #444;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   transform: translateY(-2px);
+  /* contain zapobiega migotaniu kart */
 }
 body[data-theme="dark"] .duplicate {
   background: #663333;
@@ -189,6 +190,9 @@ body.full #tabs {
   user-select: none;
   cursor: grab;
 
+  position: relative;
+  contain: layout paint;
+
   transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
   box-shadow: none;
   transform: none;
@@ -216,6 +220,7 @@ body.popup .tab {
   background: var(--color-hover);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
   transform: translateY(-2px);
+  /* contain zapobiega migotaniu kart */
 }
 .tab.active {
   background: var(--color-active);


### PR DESCRIPTION
## Summary
- use `contain: layout paint` on tabs to establish a new paint containment
- drop previous isolation rules and update comments referencing hover flicker workaround

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bb879d51c83318e509087eb9aaecc