### PR TITLE
Kamil/z-index-hover-v1.0.6

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -61,12 +61,16 @@ body[data-theme="dark"] button {
 }
 body[data-theme="dark"] .tab {
   border-bottom-color: var(--color-border);
+  will-change: transform;
+  backface-visibility: hidden;
 }
 body[data-theme="dark"] .tab:hover {
+  will-change: transform;
+  backface-visibility: hidden;
   background: #444;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   transform: translateY(-2px);
-}
+} 
 body[data-theme="dark"] .duplicate {
   background: #663333;
 }
@@ -189,6 +193,9 @@ body.full #tabs {
   user-select: none;
   cursor: grab;
 
+  will-change: transform;
+  backface-visibility: hidden;
+
   transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
   box-shadow: none;
   transform: none;
@@ -213,6 +220,8 @@ body.popup .tab {
   margin-right: 0.25em;
 }
 .tab:hover {
+  will-change: transform;
+  backface-visibility: hidden;
   background: var(--color-hover);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
   transform: translateY(-2px);


### PR DESCRIPTION
## Summary
- switch away from z-index layering
- use 3D rendering hints to prevent hover flicker

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bb879d51c83318e509087eb9aaecc