### PR TITLE
Kamil/isolation-stack-v1.0.7

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -61,8 +61,12 @@ body[data-theme="dark"] button {
 }
 body[data-theme="dark"] .tab {
   border-bottom-color: var(--color-border);
+  isolation: isolate;
+  /* isolation zapobiega migotaniu kart */
 }
 body[data-theme="dark"] .tab:hover {
+  position: relative;
+  z-index: 2;
   background: #444;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   transform: translateY(-2px);
@@ -189,6 +193,9 @@ body.full #tabs {
   user-select: none;
   cursor: grab;
 
+  isolation: isolate;
+  /* isolation zapobiega migotaniu kart */
+
   transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
   box-shadow: none;
   transform: none;
@@ -213,6 +220,8 @@ body.popup .tab {
   margin-right: 0.25em;
 }
 .tab:hover {
+  position: relative;
+  z-index: 2; /* z-index zapobiega migotaniu kart */
   background: var(--color-hover);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
   transform: translateY(-2px);


### PR DESCRIPTION
## Summary
- raise `.tab:hover` stacking context using `z-index: 2` and `position: relative`
- apply the same rule to `body[data-theme="dark"] .tab:hover`
- document that the z-index prevents tab flickering

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bb879d51c83318e509087eb9aaecc