### PR TITLE
Move stylelint-order to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
   "name": "kepi-tab",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Development tooling",
   "devDependencies": {
-    "stylelint": "^15.0.0"
-  },
-  "dependencies": {
+    "stylelint": "^15.0.0",
     "stylelint-order": "^6.0.4"
   },
+  "dependencies": {},
   "scripts": {
     "lint": "stylelint mytabs/style.css",
     "postinstall": "npx stylelint --version"


### PR DESCRIPTION
## Summary
- move `stylelint-order` from dependencies to devDependencies
- bump package version to v1.0.2

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685bcd1a78a08331afceeebcd78c067a