### PR TITLE
Kamil/fix-popup-scroll-animation-v1.0.3

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -569,7 +569,15 @@ document.addEventListener('keydown', (e) => {
     const el = tabItems[newIdx].el;
     requestAnimationFrame(() => {
       el?.focus();
-      el?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      if (el && scrollContainer) {
+        const top = el.offsetTop;
+        const bottom = top + el.offsetHeight;
+        if (top < scrollContainer.scrollTop) {
+          scrollContainer.scrollTop = top;
+        } else if (bottom > scrollContainer.scrollTop + scrollContainer.clientHeight) {
+          scrollContainer.scrollTop = bottom - scrollContainer.clientHeight;
+        }
+      }
     });
     return newIdx;
   };

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -90,6 +90,7 @@ body[data-theme="dark"] #context div:hover {
   margin-top: 0.2em;
   max-height: 400px;
   overflow-y: auto;
+  scroll-behavior: auto;
 }
 
 .tab {


### PR DESCRIPTION
## Summary
- keep the focused item visible using manual scroll positioning
- enforce `scroll-behavior: auto` on the tab list container

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685bce0d5d748331a2ead42a037d1162