### PR TITLE
Fix popup scroll animation glitch

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -526,10 +526,8 @@ body.full #counts.scrolled {
 @keyframes body-fade-in {
   from {
     opacity: 0;
-    transform: translateY(4px);
   }
   to {
     opacity: 1;
-    transform: none;
   }
 }


### PR DESCRIPTION
## Summary
- remove `translateY` from `body-fade-in` keyframes

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bd1f0a278833193e2e923da295c21