### PR TITLE
Fix scroll overlay animation

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -151,7 +151,7 @@ body.popup #tabs::after {
   height: 1em;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 0.3s;
+  transition: none;
   z-index: 1;
 }
 body.popup #tabs.fade-top::before {
@@ -452,7 +452,7 @@ body.full #tabs-wrapper::after {
   width: 1em;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 0.3s;
+  transition: none;
   z-index: 1;
 }
 body.full #tabs-wrapper.fade-left::before {


### PR DESCRIPTION
## Summary
- disable opacity transitions for scroll overlays in popup and full views

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685bd1f0a278833193e2e923da295c21