### PR TITLE
Fix popup scroll fade

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -151,7 +151,6 @@ body.popup #tabs::after {
   height: 1em;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 0.3s;
   z-index: 1;
 }
 body.popup #tabs.fade-top::before {


### PR DESCRIPTION
## Summary
- remove opacity transition from popup fade overlay to keep scrolling stable

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bd37aa708833198569443f26e435a