### PR TITLE
Fix popup hover transform issue

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -168,6 +168,12 @@ body.popup .tab {
   width: 100%;
   padding-right: 0.5em;
 }
+body.popup .tab:hover {
+  transform: none;
+}
+body.popup[data-theme="dark"] .tab:hover {
+  transform: none;
+}
 body.popup .tab > div:last-child {
   margin-left: auto;
   margin-right: 0.5em;


### PR DESCRIPTION
## Summary
- override hover transform in popup mode to avoid jittery animations

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bd52da6e083319416bdc268d25d88