### PR TITLE
Fix popup scroll animation v0.4.2

### DIFF
--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "KepiTAB Manager",
 
-  "version": "0.4.1",
+  "version": "0.4.2",
 
   "description": "A simple tab management tool inspired by All Tabs Helper",
   "icons": { "48": "kepi-tab-manager.ico" },

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -151,7 +151,7 @@ body.popup #tabs::after {
   height: 1em;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 0.3s;
+  transition: none;
   z-index: 1;
 }
 body.popup #tabs.fade-top::before {
@@ -452,7 +452,7 @@ body.full #tabs-wrapper::after {
   width: 1em;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 0.3s;
+  transition: none;
   z-index: 1;
 }
 body.full #tabs-wrapper.fade-left::before {


### PR DESCRIPTION
## Summary
- stop fading overlays from animating on scroll
- bump extension version to 0.4.2

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bd52da6e083319416bdc268d25d88