### PR TITLE
Fix popup hover animation overlap

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -66,6 +66,8 @@ body[data-theme="dark"] .tab:hover {
   background: #444;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   transform: translateY(-2px);
+  position: relative;
+  z-index: 2;
 }
 body[data-theme="dark"] .duplicate {
   background: #663333;
@@ -216,6 +218,8 @@ body.popup .tab {
   background: var(--color-hover);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
   transform: translateY(-2px);
+  position: relative;
+  z-index: 2;
 }
 .tab.active {
   background: var(--color-active);


### PR DESCRIPTION
## Summary
- ensure hovered tabs appear above popup fade gradient

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685baf7285f48331867c7df3766e2163