### PR TITLE
Kamil/fix-popup-animation-v1.2.1

### DIFF
--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -19,7 +19,9 @@
     <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
   </div>
   <div id="error"></div>
-  <div id="tabs"></div>
+  <div id="tabs-wrapper">
+    <div id="tabs"></div>
+  </div>
     <div id="bulk-actions">
       <select id="container-target"></select>
       <button id="bulk-add-container">Add to Container</button>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -924,9 +924,7 @@ document.addEventListener('keydown', (e) => {
 async function init() {
   container = document.getElementById('tabs-body') ||
               document.getElementById('tabs');
-  scrollContainer = document.body.classList.contains('full')
-    ? document.getElementById('tabs-wrapper')
-    : container;
+  scrollContainer = document.getElementById('tabs-wrapper') || container;
   scrollContainer.addEventListener('scroll', saveScroll);
   scrollContainer.addEventListener('scroll', hideAllTooltips);
   scrollContainer.addEventListener('scroll', updateMenuShadow);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -138,12 +138,19 @@ body.popup {
   overflow-x: hidden;
 }
 body.popup #tabs {
+  max-height: none;
+  overflow: visible;
+}
+body.popup #tabs-wrapper {
+  max-height: 400px;
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-gutter: stable;
+  box-sizing: border-box;
+  position: relative;
 }
-body.popup #tabs::before,
-body.popup #tabs::after {
+body.popup #tabs-wrapper::before,
+body.popup #tabs-wrapper::after {
   content: '';
   position: sticky;
   left: 0;
@@ -154,12 +161,12 @@ body.popup #tabs::after {
   transition: opacity 0.3s;
   z-index: 1;
 }
-body.popup #tabs.fade-top::before {
+body.popup #tabs-wrapper.fade-top::before {
   top: 0;
   background: linear-gradient(to bottom, var(--color-bg), transparent);
   opacity: 1;
 }
-body.popup #tabs.fade-bottom::after {
+body.popup #tabs-wrapper.fade-bottom::after {
   bottom: 0;
   background: linear-gradient(to top, var(--color-bg), transparent);
   opacity: 1;


### PR DESCRIPTION
## Summary
- ensure tab hover animation isn't clipped in popup
- wrap popup tab list in `#tabs-wrapper`
- route scroll events to the wrapper
- update CSS to allow visible overflow

## Testing
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_685baf7285f48331867c7df3766e2163