### PR TITLE
Fix popup scroll retention v1.0.3

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -30,6 +30,8 @@ let currentActiveId = -1;
 let currentVisited = new Set();
 let currentWinMap = null;
 let currentQuery = '';
+// Scroll position to restore after certain operations
+let pendingScroll = null;
 
 function matchShortcut(def, e) {
   if (!def) return false;
@@ -589,14 +591,16 @@ function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
         height: container.clientHeight || 400,
         itemHeight: rowHeight,
         total: tabItems.length,
-        generate: generateRow
+        generate: generateRow,
+        scrollContainer
       });
     } else {
       virtualList.refresh(container, {
         height: container.clientHeight || 400,
         itemHeight: rowHeight,
         total: tabItems.length,
-        generate: generateRow
+        generate: generateRow,
+        scrollContainer
       });
     }
   }
@@ -681,11 +685,15 @@ function findDuplicates(tabs) {
 async function update() {
   hideAllTooltips();
   const isFull = document.body.classList.contains('full');
-  const prevScroll = scrollContainer
+  let prevScroll = scrollContainer
     ? isFull
       ? scrollContainer.scrollLeft
       : scrollContainer.scrollTop
     : 0;
+  if (pendingScroll !== null) {
+    prevScroll = pendingScroll;
+    pendingScroll = null;
+  }
   try {
     const allWins = document.body.classList.contains('full');
     const queryOpts = allWins ? {} : { currentWindow: true };
@@ -1356,6 +1364,9 @@ function onContainerClick(e) {
   if (e.target.classList.contains('close-btn')) {
     e.stopPropagation();
     const id = parseInt(tabEl.dataset.tab, 10);
+    if (scrollContainer) {
+      pendingScroll = scrollContainer.scrollTop;
+    }
     browser.tabs.remove(id).then(scheduleUpdate);
     return;
   }


### PR DESCRIPTION
## Summary
- ensure HyperList uses the wrapper as scroll container
- keep scroll position when closing tabs in the popup view

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685be71971fc83319fa533f26fa469b9