### PR TITLE
Add animated view transitions v1.1.0

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -13,6 +13,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   be configured on the Options page.
 - Each tab row includes a button to quickly close that tab.
 - Smooth hover effects highlight each tab row for a polished interface.
+- Animated view transitions make switching between the **All**, **Recent** and **Duplicates** panels seamless.
 - Sticky menu gains a subtle shadow while scrolling for a professional look.
 - Tab list edges fade in and out while scrolling to signal more content.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -86,6 +86,14 @@ function hideAllTooltips() {
   document.querySelectorAll('.tab-tooltip').forEach(t => t.remove());
 }
 
+function triggerViewAnimation() {
+  const el = document.getElementById('tabs');
+  if (!el) return;
+  el.classList.remove('view-transition');
+  void el.offsetWidth;
+  el.classList.add('view-transition');
+}
+
 function showPlaceholder(target, before) {
   if (dropTarget === target &&
       target.classList.contains(before ? 'drop-before' : 'drop-after')) {
@@ -162,6 +170,7 @@ async function loadOptions() {
       btnRecent.style.display = '';
       btnRecent.addEventListener('click', () => {
         view = 'recent';
+        triggerViewAnimation();
         scheduleUpdate();
       });
     } else {
@@ -174,6 +183,7 @@ async function loadOptions() {
       btnDups.style.display = '';
       btnDups.addEventListener('click', () => {
         view = 'dups';
+        triggerViewAnimation();
         scheduleUpdate();
       });
     } else {
@@ -789,13 +799,18 @@ clearBtn?.addEventListener('click', () => {
 });
 
 updateClearButton();
-document.getElementById('btn-all').addEventListener('click', () => { view = 'all'; scheduleUpdate(); });
+document.getElementById('btn-all').addEventListener('click', () => {
+  view = 'all';
+  triggerViewAnimation();
+  scheduleUpdate();
+});
 
 document.addEventListener('keydown', (e) => {
   if (!searchBox) return;
 
   if (matchShortcut(KEY_VIEW_ALL, e)) {
     view = 'all';
+    triggerViewAnimation();
     scheduleUpdate();
     e.preventDefault();
     e.stopPropagation();
@@ -803,6 +818,7 @@ document.addEventListener('keydown', (e) => {
   }
   if (matchShortcut(KEY_VIEW_RECENT, e) && SHOW_RECENT) {
     view = 'recent';
+    triggerViewAnimation();
     scheduleUpdate();
     e.preventDefault();
     e.stopPropagation();
@@ -810,6 +826,7 @@ document.addEventListener('keydown', (e) => {
   }
   if (matchShortcut(KEY_VIEW_DUPS, e) && SHOW_DUPLICATES) {
     view = 'dups';
+    triggerViewAnimation();
     scheduleUpdate();
     e.preventDefault();
     e.stopPropagation();

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -540,3 +540,18 @@ body.full #counts.scrolled {
     transform: none;
   }
 }
+
+@keyframes view-fade {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+#tabs.view-transition {
+  animation: view-fade 0.3s ease-out;
+}


### PR DESCRIPTION
## Summary
- animate the tab list when changing between All, Recent and Duplicates views
- expose this feature in documentation

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d2a6a0e0c8331bb5506207fdb3eca