### PR TITLE
Add flip animation for duplicates view v1.1.2

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -13,6 +13,8 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   be configured on the Options page.
 - Each tab row includes a button to quickly close that tab.
 - Smooth hover effects highlight each tab row for a polished interface.
+- Dramatic 3D transitions create a breathtaking effect when switching between the **All**, **Recent** and **Duplicates** panels.
+- A flip animation spices up the **Duplicates** view for added flair.
 - Sticky menu gains a subtle shadow while scrolling for a professional look.
 - Tab list edges fade in and out while scrolling to signal more content.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -86,6 +86,14 @@ function hideAllTooltips() {
   document.querySelectorAll('.tab-tooltip').forEach(t => t.remove());
 }
 
+function triggerViewAnimation(effect = 'wow') {
+  const el = document.getElementById('tabs');
+  if (!el) return;
+  el.classList.remove('view-transition', 'view-wow', 'view-flip');
+  void el.offsetWidth;
+  el.classList.add(`view-${effect}`, 'view-transition');
+}
+
 function showPlaceholder(target, before) {
   if (dropTarget === target &&
       target.classList.contains(before ? 'drop-before' : 'drop-after')) {
@@ -162,6 +170,7 @@ async function loadOptions() {
       btnRecent.style.display = '';
       btnRecent.addEventListener('click', () => {
         view = 'recent';
+        triggerViewAnimation();
         scheduleUpdate();
       });
     } else {
@@ -174,6 +183,7 @@ async function loadOptions() {
       btnDups.style.display = '';
       btnDups.addEventListener('click', () => {
         view = 'dups';
+        triggerViewAnimation('flip');
         scheduleUpdate();
       });
     } else {
@@ -789,13 +799,18 @@ clearBtn?.addEventListener('click', () => {
 });
 
 updateClearButton();
-document.getElementById('btn-all').addEventListener('click', () => { view = 'all'; scheduleUpdate(); });
+document.getElementById('btn-all').addEventListener('click', () => {
+  view = 'all';
+  triggerViewAnimation();
+  scheduleUpdate();
+});
 
 document.addEventListener('keydown', (e) => {
   if (!searchBox) return;
 
   if (matchShortcut(KEY_VIEW_ALL, e)) {
     view = 'all';
+    triggerViewAnimation();
     scheduleUpdate();
     e.preventDefault();
     e.stopPropagation();
@@ -803,6 +818,7 @@ document.addEventListener('keydown', (e) => {
   }
   if (matchShortcut(KEY_VIEW_RECENT, e) && SHOW_RECENT) {
     view = 'recent';
+    triggerViewAnimation();
     scheduleUpdate();
     e.preventDefault();
     e.stopPropagation();
@@ -810,6 +826,7 @@ document.addEventListener('keydown', (e) => {
   }
   if (matchShortcut(KEY_VIEW_DUPS, e) && SHOW_DUPLICATES) {
     view = 'dups';
+    triggerViewAnimation('flip');
     scheduleUpdate();
     e.preventDefault();
     e.stopPropagation();

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -148,6 +148,7 @@ body.popup #tabs-wrapper {
   scrollbar-gutter: stable;
   box-sizing: border-box;
   position: relative;
+  perspective: 700px;
 }
 body.popup #tabs-wrapper::before,
 body.popup #tabs-wrapper::after {
@@ -448,6 +449,7 @@ body.full #tabs-wrapper,
   min-height: 0;
   margin: 0 !important;
   padding: 0 !important;
+  perspective: 700px;
   position: relative;
 }
 body.full #tabs-wrapper::before,
@@ -539,4 +541,44 @@ body.full #counts.scrolled {
     opacity: 1;
     transform: none;
   }
+}
+
+@keyframes view-wow {
+  0% {
+    opacity: 0;
+    transform: rotateX(-90deg) scale(0.8);
+  }
+  70% {
+    opacity: 1;
+    transform: rotateX(15deg) scale(1.05);
+  }
+  100% {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes view-flip {
+  0% {
+    opacity: 0;
+    transform: rotateY(-90deg) scale(0.8);
+  }
+  70% {
+    opacity: 1;
+    transform: rotateY(15deg) scale(1.05);
+  }
+  100% {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+#tabs.view-wow.view-transition {
+  animation: view-wow 0.6s cubic-bezier(0.23, 1, 0.32, 1);
+  transform-origin: top center;
+}
+
+#tabs.view-flip.view-transition {
+  animation: view-flip 0.6s cubic-bezier(0.23, 1, 0.32, 1);
+  transform-origin: top center;
 }


### PR DESCRIPTION
## Summary
- create a new `view-flip` animation to enhance the duplicates panel
- extend `triggerViewAnimation` to accept an animation type
- trigger the flip effect when switching to duplicates
- document the flip effect in the feature list

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d2a6a0e0c8331bb5506207fdb3eca