### PR TITLE
Add animation toggle v1.0.1

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -38,6 +38,7 @@ This is an open source Firefox add-on inspired by the features of **All Tabs Hel
   the Recent and Duplicates panels, the Move command and automatic unloading of inactive tabs.
 - The Close Button Scale adjusts the “×” size independent of the font scale.
 - A dark theme can also be enabled from the options page.
+- Animations can be disabled from the options page for a lightweight interface.
 - Keyboard shortcuts open the popup, sidebar and full view and can be changed from the Options page.
   New shortcuts let you switch between the **All**, **Recent** and **Duplicates** views
   using **Shift+A**, **Shift+R** and **Shift+D** by default. These can be customized or disabled, and the inputs show the combination as you press the keys.

--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -32,6 +32,8 @@
   <br>
   <label>Unload After (minutes): <input type="number" id="opt-auto-unload-mins" min="1" max="1440" value="60"></label> <button type="button" class="default-btn" data-for="opt-auto-unload-mins">Default</button>
   <br>
+  <label><input type="checkbox" id="opt-disable-effects"> Disable Animations</label> <button type="button" class="default-btn" data-for="opt-disable-effects">Default</button>
+  <br>
   <label>Popup Shortcut: <input type="text" id="key-open-popup" placeholder="Alt+Shift+H"></label> <button type="button" class="default-btn" data-for="key-open-popup">Default</button>
   <br>
   <label>Full View Shortcut: <input type="text" id="key-open-full" placeholder="Alt+Shift+F"></label> <button type="button" class="default-btn" data-for="key-open-full">Default</button>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -16,6 +16,7 @@ const DEFAULTS = {
   'opt-enable-move': true,
   'opt-auto-unload': false,
   'opt-auto-unload-mins': 60,
+  'opt-disable-effects': false,
   'key-open-popup': 'Alt+Shift+H',
   'key-open-full': 'Alt+Shift+F',
   'key-unload-all': 'Alt+Shift+U',
@@ -27,7 +28,7 @@ const DEFAULTS = {
 async function load(){
   const data = await browser.storage.local.get([
     'theme','tileWidth','tileScale','fontScale','closeScale','rowGap','scrollSpeed',
-    'showRecent','showDuplicates','enableMove','autoUnload','autoUnloadMinutes',
+    'showRecent','showDuplicates','enableMove','autoUnload','autoUnloadMinutes','disableEffects',
     'keyOpenPopup','keyOpenFull','keyUnloadAll',
     'keyViewAll','keyViewRecent','keyViewDups'
   ]);
@@ -43,6 +44,7 @@ async function load(){
     enableMove=true,
     autoUnload=false,
     autoUnloadMinutes=60,
+    disableEffects=false,
     keyOpenPopup='Alt+Shift+H',
     keyOpenFull='Alt+Shift+F',
     keyUnloadAll='Alt+Shift+U',
@@ -71,6 +73,7 @@ async function load(){
   document.getElementById('opt-auto-unload').checked = autoUnload;
   document.getElementById('opt-auto-unload-mins').value = autoUnloadMinutes;
   document.getElementById('opt-auto-unload-mins').disabled = !autoUnload;
+  document.getElementById('opt-disable-effects').checked = disableEffects;
   document.getElementById('key-open-popup').value = keyOpenPopup;
   document.getElementById('key-open-full').value = keyOpenFull;
   document.getElementById('key-unload-all').value = keyUnloadAll;
@@ -102,10 +105,11 @@ async function save(){
   const keyViewAll=document.getElementById('key-view-all').value.trim();
   const keyViewRecent=document.getElementById('key-view-recent').value.trim();
   const keyViewDups=document.getElementById('key-view-dups').value.trim();
+  const disableEffects=document.getElementById('opt-disable-effects').checked;
   const rowGap=parseFloat(document.getElementById('rowGap').value);
   await browser.storage.local.set({
     theme, tileWidth, tileScale, fontScale, closeScale, rowGap, scrollSpeed,
-    showRecent, showDuplicates, enableMove, autoUnload, autoUnloadMinutes,
+    showRecent, showDuplicates, enableMove, autoUnload, autoUnloadMinutes, disableEffects,
     keyOpenPopup, keyOpenFull, keyUnloadAll,
     keyViewAll, keyViewRecent, keyViewDups
   });
@@ -200,6 +204,7 @@ const elAutoUnloadMins = document.getElementById('opt-auto-unload-mins');
 const elShowRecent = document.getElementById('opt-show-recent');
 const elShowDups = document.getElementById('opt-show-dups');
 const elEnableMove = document.getElementById('opt-enable-move');
+const elDisableEffects = document.getElementById('opt-disable-effects');
 
 const updateMap = {
   tileWidth: updateWidth,
@@ -284,6 +289,11 @@ elEnableMove.addEventListener('change', () => {
   checkDefault('opt-enable-move');
 });
 
+elDisableEffects.addEventListener('change', () => {
+  browser.storage.local.set({ disableEffects: elDisableEffects.checked });
+  checkDefault('opt-disable-effects');
+});
+
 elAutoUnload.addEventListener('change', () => {
   elAutoUnloadMins.disabled = !elAutoUnload.checked;
   browser.storage.local.set({ 'opt-auto-unload': elAutoUnload.checked });
@@ -305,7 +315,7 @@ document.querySelectorAll('input[id^="key-"]').forEach(el => {
 });
 
 browser.storage.onChanged.addListener((changes, area) => {
-  if (area === 'local' && (changes.tileScale || changes.fontScale || changes.closeScale || changes.rowGap || changes.autoUnload || changes.autoUnloadMinutes)) {
+  if (area === 'local' && (changes.tileScale || changes.fontScale || changes.closeScale || changes.rowGap || changes.autoUnload || changes.autoUnloadMinutes || changes.disableEffects)) {
     const tileScale = changes.tileScale ? changes.tileScale.newValue : parseFloat(document.getElementById('tileScale').value);
     const fontScale = changes.fontScale ? changes.fontScale.newValue : parseFloat(document.getElementById('fontScale').value);
     const closeScale = changes.closeScale ? changes.closeScale.newValue : parseFloat(document.getElementById('closeScale').value);
@@ -335,6 +345,10 @@ browser.storage.onChanged.addListener((changes, area) => {
     checkDefault('closeScale');
     checkDefault('rowGap');
     checkDefault('uiScale');
+    if (changes.disableEffects) {
+      elDisableEffects.checked = changes.disableEffects.newValue;
+      checkDefault('opt-disable-effects');
+    }
   }
 });
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -39,6 +39,11 @@ body {
   animation: body-fade-in 0.2s ease-out;
 }
 
+body.no-effects, body.no-effects * {
+  transition: none !important;
+  animation: none !important;
+}
+
 body[data-theme="dark"] {
   --color-bg: #222;
   --color-text: #eee;

--- a/mytabs/theme.js
+++ b/mytabs/theme.js
@@ -1,6 +1,6 @@
 (async function(){
-  let { theme = 'light', tileWidth = 255, tileScale = 0.9, fontScale = 0.8125, closeScale = 1.55, rowGap = 0 } =
-    await browser.storage.local.get(['theme','tileWidth','tileScale','fontScale','closeScale','rowGap']);
+  let { theme = 'light', tileWidth = 255, tileScale = 0.9, fontScale = 0.8125, closeScale = 1.55, rowGap = 0, disableEffects = false } =
+    await browser.storage.local.get(['theme','tileWidth','tileScale','fontScale','closeScale','rowGap','disableEffects']);
   if (closeScale === undefined) {
     closeScale = 1.55;
     browser.storage.local.set({ closeScale });
@@ -8,6 +8,7 @@
 
   function apply(){
     document.body.dataset.theme = theme;
+    document.body.classList.toggle('no-effects', disableEffects);
     const width = tileWidth * tileScale;
     document.documentElement.style.setProperty('--tile-width', width + 'px');
     const isPopup = document.body.classList.contains('popup');
@@ -33,6 +34,7 @@
       if (changes.fontScale) fontScale = changes.fontScale.newValue;
       if (changes.closeScale) closeScale = changes.closeScale.newValue;
       if (changes.rowGap) rowGap = changes.rowGap.newValue;
+      if (changes.disableEffects) disableEffects = changes.disableEffects.newValue;
       apply();
     }
   });


### PR DESCRIPTION
## Summary
- add checkbox to disable UI animations
- sync new option with storage and theme
- support `no-effects` class in styles
- document the option in README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d3adda3fc83318258c99e8371667a