### PR TITLE
Add slide-in effect for context menu

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -335,13 +335,13 @@ button:hover {
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
   z-index: 1000;
   opacity: 0;
-  transform: scale(0.95);
+  transform: translateY(-5px) scale(0.95);
   transition: opacity 0.15s ease, transform 0.15s ease;
 }
 
 #context.visible {
   opacity: 1;
-  transform: scale(1);
+  transform: translateY(0) scale(1);
 }
 
 #context div {


### PR DESCRIPTION
## Summary
- tweak context menu styles so menu slides in on right click

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d47d7a4208331b9c9abebd47a83df