### PR TITLE
Add Easter egg overlay

### DIFF
--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -31,6 +31,7 @@
       <button id="bulk-discard">Unload</button>
       <button id="bulk-unload-all">Unload All</button>
     </div>
+    <div id="easter-egg" class="hidden">You've found the Easter Egg!</div>
     <div id="context" class="hidden"></div>
 
     <script src="theme.js"></script>

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -31,6 +31,7 @@
       <button id="bulk-discard">Unload</button>
       <button id="bulk-unload-all">Unload All</button>
     </div>
+  <div id="easter-egg" class="hidden">You've found the Easter Egg!</div>
   <div id="context" class="hidden"></div>
   <script src="theme.js"></script>
   <script src="hyperlist.js"></script>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -32,6 +32,7 @@ let currentWinMap = null;
 let currentQuery = '';
 // Scroll position to restore after certain operations
 let pendingScroll = null;
+let easterEgg;
 
 function matchShortcut(def, e) {
   if (!def) return false;
@@ -952,6 +953,21 @@ async function init() {
   container = document.getElementById('tabs-body') ||
               document.getElementById('tabs');
   scrollContainer = document.getElementById('tabs-wrapper') || container;
+  easterEgg = document.getElementById('easter-egg');
+  const menuEl = document.getElementById('menu');
+  menuEl?.addEventListener('dblclick', () => {
+    if (!easterEgg) return;
+    if (!easterEgg.classList.contains('visible')) {
+      easterEgg.classList.remove('hidden');
+      requestAnimationFrame(() => easterEgg.classList.add('visible'));
+      const hide = () => {
+        easterEgg.classList.remove('visible');
+        setTimeout(() => easterEgg.classList.add('hidden'), 150);
+      };
+      easterEgg.addEventListener('click', hide, { once: true });
+      setTimeout(hide, 2000);
+    }
+  });
   scrollContainer.addEventListener('scroll', saveScroll);
   scrollContainer.addEventListener('scroll', hideAllTooltips);
   scrollContainer.addEventListener('scroll', updateMenuShadow);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -89,6 +89,10 @@ body[data-theme="dark"] #context {
 body[data-theme="dark"] #context div:hover {
   background: #555;
 }
+body[data-theme="dark"] #easter-egg {
+  background: #444;
+  border-color: var(--color-border);
+}
 
 #menu {
   margin-bottom: 0;
@@ -326,6 +330,23 @@ button:hover {
 }
 .hidden {
   display: none;
+}
+#easter-egg {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.95);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  padding: 1em;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  z-index: 1500;
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+#easter-egg.visible {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
 }
 #context {
   position: absolute;


### PR DESCRIPTION
## Summary
- add hidden easter egg styles
- inject easter egg markup in popup and full views
- reveal the easter egg when double-clicking the main menu

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861ae4c27bc833186c861b2df9eb08d