### PR TITLE
Add stylized Easter egg overlay

### DIFF
--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -31,6 +31,12 @@
       <button id="bulk-discard">Unload</button>
       <button id="bulk-unload-all">Unload All</button>
     </div>
+    <div id="easter-egg" class="hidden">
+      <div class="egg-content">
+        <h2>🎉 Hidden Menu 🎉</h2>
+        <p>Surprise! You found it.</p>
+      </div>
+    </div>
     <div id="context" class="hidden"></div>
 
     <script src="theme.js"></script>

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -31,6 +31,12 @@
       <button id="bulk-discard">Unload</button>
       <button id="bulk-unload-all">Unload All</button>
     </div>
+  <div id="easter-egg" class="hidden">
+    <div class="egg-content">
+      <h2>🎉 Hidden Menu 🎉</h2>
+      <p>Surprise! You found it.</p>
+    </div>
+  </div>
   <div id="context" class="hidden"></div>
   <script src="theme.js"></script>
   <script src="hyperlist.js"></script>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -32,6 +32,24 @@ let currentWinMap = null;
 let currentQuery = '';
 // Scroll position to restore after certain operations
 let pendingScroll = null;
+let easterEgg;
+
+function showEasterEgg() {
+  if (!easterEgg || easterEgg.classList.contains('visible')) return;
+  const hide = () => {
+    easterEgg.classList.remove('visible');
+    setTimeout(() => easterEgg.classList.add('hidden'), 150);
+    document.removeEventListener('keydown', escHandler);
+  };
+  const escHandler = ev => {
+    if (ev.key === 'Escape') hide();
+  };
+  easterEgg.classList.remove('hidden');
+  requestAnimationFrame(() => easterEgg.classList.add('visible'));
+  easterEgg.addEventListener('click', hide, { once: true });
+  document.addEventListener('keydown', escHandler);
+  setTimeout(hide, 3000);
+}
 
 function matchShortcut(def, e) {
   if (!def) return false;
@@ -952,6 +970,9 @@ async function init() {
   container = document.getElementById('tabs-body') ||
               document.getElementById('tabs');
   scrollContainer = document.getElementById('tabs-wrapper') || container;
+  easterEgg = document.getElementById('easter-egg');
+  const menuEl = document.getElementById('menu');
+  menuEl?.addEventListener('dblclick', showEasterEgg);
   scrollContainer.addEventListener('scroll', saveScroll);
   scrollContainer.addEventListener('scroll', hideAllTooltips);
   scrollContainer.addEventListener('scroll', updateMenuShadow);
@@ -1239,9 +1260,8 @@ function showContextMenu(e) {
   }
 
   if (!tabEl && !selected.length) {
-    const info = document.createElement('div');
-    info.textContent = `KepiTAB Manager v${browser.runtime.getManifest().version}`;
-    context.appendChild(info);
+    showEasterEgg();
+    return;
   }
 
   addItem('Unload All Tabs', bulkUnloadAll);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -89,6 +89,10 @@ body[data-theme="dark"] #context {
 body[data-theme="dark"] #context div:hover {
   background: #555;
 }
+body[data-theme="dark"] #easter-egg {
+  background: linear-gradient(135deg, #444, #222);
+  border-color: var(--color-border);
+}
 
 #menu {
   margin-bottom: 0;
@@ -326,6 +330,32 @@ button:hover {
 }
 .hidden {
   display: none;
+}
+#easter-egg {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.95);
+  background: linear-gradient(135deg, #fff8dc, #ffe4e1);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1em;
+  max-width: 300px;
+  text-align: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  z-index: 1500;
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+#easter-egg.visible {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+#easter-egg .egg-content h2 {
+  margin: 0 0 0.5em;
+}
+#easter-egg .egg-content p {
+  margin: 0;
 }
 #context {
   position: absolute;


### PR DESCRIPTION
## Summary
- rework `easter-egg` container markup in both popup and full view
- style the overlay with gradients and centered content
- allow dismissal via escape key and lengthen display time

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861ae4c27bc833186c861b2df9eb08d