### PR TITLE
feat: support MV3

### DIFF
--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -1,8 +1,8 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "KepiTAB Manager",
 
-  "version": "0.4.2",
+  "version": "0.5.0",
 
   "description": "A simple tab management tool inspired by All Tabs Helper",
   "icons": { "48": "kepi-tab-manager.ico" },
@@ -14,8 +14,10 @@
       "contextualIdentities",
       "cookies"
     ],
-  "background": { "scripts": ["background.js"] },
-  "browser_action": {
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
     "default_title": "KepiTAB Manager",
     "default_icon": "kepi-tab-manager.ico",
     "default_popup": "popup.html"


### PR DESCRIPTION
## Summary
- migrate manifest to version 3 with a service worker background script
- switch to the `action` key for toolbar UI
- bump extension version to 0.5.0

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6864fba040b48331bd4f8ca944108dd0