### PR TITLE
Add Gecko browser settings

### DIFF
--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -4,6 +4,8 @@
 
   "version": "1.0.0",
 
+  "browser_specific_settings": { "gecko": { "id": "kepi@addon" } },
+
   "description": "A simple tab management tool",
   "icons": { "48": "kepi-tab-manager.ico" },
     "permissions": [


### PR DESCRIPTION
## Summary
- add Gecko-specific ID to the extension manifest

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68685f760a60833196e4654052cbc0d9