### PR TITLE
fix manifest background for firefox mv3

### DIFF
--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -15,8 +15,7 @@
       "cookies"
     ],
   "background": {
-    "scripts": ["background.js"],
-    "service_worker": "background.js"
+    "scripts": ["background.js"]
   },
   "action": {
     "default_title": "KepiTAB Manager",


### PR DESCRIPTION
## Summary
- remove `service_worker` background field to ensure Manifest V3 support in Firefox

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686864efe5d083318654a36129e786ab