### PR TITLE
Enhance tab count UI

### DIFF
--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
   <body class="full">
-    <div id="counts">Total: <span id="total-count">0</span> | Active: <span id="active-count">0</span></div>
+    <div id="counts"><span class="count total"><span class="label">Total</span>: <span id="total-count">0</span></span> <span class="count active"><span class="label">Active</span>: <span id="active-count">0</span></span></div>
     <div id="menu">
       <button id="btn-all">All</button>
       <button id="btn-recent">Recent</button>

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body class="popup">
-  <div id="counts">Total: <span id="total-count">0</span> | Active: <span id="active-count">0</span></div>
+  <div id="counts"><span class="count total"><span class="label">Total</span>: <span id="total-count">0</span></span> <span class="count active"><span class="label">Active</span>: <span id="active-count">0</span></span></div>
   <div id="menu">
     <button id="btn-all">All</button>
     <button id="btn-recent">Recent</button>

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -99,6 +99,30 @@ body[data-theme="dark"] #easter-egg {
 }
 #counts {
   margin-bottom: 0;
+  display: flex;
+  gap: 0.5em;
+  font-weight: bold;
+}
+
+#counts .count {
+  background: linear-gradient(135deg, var(--color-selected), var(--color-active));
+  padding: 0.1em 0.5em;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: center;
+}
+
+#counts .count::before {
+  margin-right: 0.3em;
+}
+
+#counts .total::before {
+  content: "\1F4D1"; /* bookmark tabs icon */
+}
+
+#counts .active::before {
+  content: "\1F525"; /* fire icon */
 }
 #menu button {
   margin-right: 0.2em;


### PR DESCRIPTION
## Summary
- improve markup for total/active tab counts
- add styled badges with icons in stylesheet

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686bef9836208331aa65992368e997b7