### PR TITLE
Fix recent and visited tracking

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -168,7 +168,6 @@ browser.tabs.onActivated.addListener(info => {
 
 browser.tabs.onCreated.addListener(tab => {
   addDuplicate(tab.id, tab.url);
-  pushRecent(tab.id);
 });
 
 browser.tabs.onRemoved.addListener((tabId) => {
@@ -187,8 +186,6 @@ browser.tabs.onRemoved.addListener((tabId) => {
 browser.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.discarded === true) {
     unmarkVisited(tabId);
-  } else if (changeInfo.discarded === false) {
-    markVisited(tabId);
   }
   if (changeInfo.url) {
     removeDuplicate(tabId);


### PR DESCRIPTION
## Summary
- stop marking tabs visited when they automatically load
- add tabs to the recent list only after activation

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686eae0b44a8833198b568db423e0dab