### PR TITLE
Fix visited state for background tabs

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -168,7 +168,6 @@ browser.tabs.onActivated.addListener(info => {
 
 browser.tabs.onCreated.addListener(tab => {
   addDuplicate(tab.id, tab.url);
-  pushRecent(tab.id);
 });
 
 browser.tabs.onRemoved.addListener((tabId) => {
@@ -184,10 +183,10 @@ browser.tabs.onRemoved.addListener((tabId) => {
   removeDuplicate(tabId);
 });
 
-browser.tabs.onUpdated.addListener((tabId, changeInfo) => {
+browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (changeInfo.discarded === true) {
     unmarkVisited(tabId);
-  } else if (changeInfo.discarded === false) {
+  } else if (changeInfo.discarded === false && tab && tab.active) {
     markVisited(tabId);
   }
   if (changeInfo.url) {


### PR DESCRIPTION
## Summary
- avoid adding newly created tabs to the recent list
- mark tabs as visited only after activation

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686eae0b44a8833198b568db423e0dab