### PR TITLE
Clear persisted visit info on startup

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -72,6 +72,13 @@ browser.storage.local.get(['recent', 'visited', 'autoUnload', 'autoUnloadMinutes
   if (typeof data.autoUnloadMinutes === 'number') autoUnloadMinutes = data.autoUnloadMinutes;
 });
 
+browser.runtime.onStartup.addListener(async () => {
+  recent = [];
+  visited.clear();
+  await browser.storage.local.set({ recent, visited: [] });
+  sendVisitedUpdate();
+});
+
 browser.storage.onChanged.addListener((changes, area) => {
   if (area === 'local') {
     if (changes.autoUnload) autoUnload = changes.autoUnload.newValue;


### PR DESCRIPTION
## Summary
- reset visited and recent lists when the browser starts to avoid stale tab state

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686f53e4f4708331bdd34eba0263f19a