### PR TITLE
Kamil/main/fix-session-highlight-v1.0.1

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -65,11 +65,11 @@ function sendVisitedUpdate() {
     .catch(() => {});
 }
 
-browser.storage.local.get(['recent', 'visited', 'autoUnload', 'autoUnloadMinutes']).then(data => {
-  recent = data.recent || [];
-  visited = new Set(data.visited || []);
+// Clear session-specific data from previous runs
+browser.storage.local.get(['autoUnload', 'autoUnloadMinutes']).then(data => {
   if (typeof data.autoUnload === 'boolean') autoUnload = data.autoUnload;
   if (typeof data.autoUnloadMinutes === 'number') autoUnloadMinutes = data.autoUnloadMinutes;
+  browser.storage.local.remove(['recent', 'visited']);
 });
 
 browser.storage.onChanged.addListener((changes, area) => {


### PR DESCRIPTION
## Summary
- reset `visited` and `recent` lists on startup to avoid stale tab IDs

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686f53e4f4708331bdd34eba0263f19a