### PR TITLE
Fix recent tab persistence

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -66,10 +66,18 @@ function sendVisitedUpdate() {
 }
 
 // Clear session-specific data from previous runs
-browser.storage.local.get(['autoUnload', 'autoUnloadMinutes']).then(data => {
+browser.storage.local.get([
+  'autoUnload',
+  'autoUnloadMinutes',
+  'recent',
+  'visited'
+]).then(data => {
   if (typeof data.autoUnload === 'boolean') autoUnload = data.autoUnload;
-  if (typeof data.autoUnloadMinutes === 'number') autoUnloadMinutes = data.autoUnloadMinutes;
-  browser.storage.local.remove(['recent', 'visited']);
+  if (typeof data.autoUnloadMinutes === 'number') {
+    autoUnloadMinutes = data.autoUnloadMinutes;
+  }
+  if (Array.isArray(data.recent)) recent = data.recent;
+  if (Array.isArray(data.visited)) visited = new Set(data.visited);
 });
 
 browser.storage.onChanged.addListener((changes, area) => {


### PR DESCRIPTION
## Summary
- keep recent and visited lists when the extension background restarts

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686f8b87e8b88331a6e2fabbada5d5dc