### PR TITLE
Kamil/main/fix-visited-tracking-v1.1.0

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -69,15 +69,13 @@ function sendVisitedUpdate() {
 browser.storage.local.get([
   'autoUnload',
   'autoUnloadMinutes',
-  'recent',
-  'visited'
+  'recent'
 ]).then(data => {
   if (typeof data.autoUnload === 'boolean') autoUnload = data.autoUnload;
   if (typeof data.autoUnloadMinutes === 'number') {
     autoUnloadMinutes = data.autoUnloadMinutes;
   }
   if (Array.isArray(data.recent)) recent = data.recent;
-  if (Array.isArray(data.visited)) visited = new Set(data.visited);
 });
 
 browser.storage.onChanged.addListener((changes, area) => {
@@ -156,7 +154,7 @@ function scheduleVisitedSave() {
   if (!visitedTimer) {
     visitedTimer = setTimeout(() => {
       visitedTimer = null;
-      browser.storage.local.set({ visited: Array.from(visited) });
+      // visited state is kept only for the current session
     }, 500);
   }
 }

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1029,7 +1029,7 @@ async function init() {
   }
   document.addEventListener('contextmenu', showContextMenu);
   container.addEventListener('dragend', clearPlaceholder);
-  const { visited = [] } = await browser.storage.local.get('visited');
+  const { visited = [] } = await browser.runtime.sendMessage({ type: 'getVisited' });
   visitedIds = new Set(visited);
   const { duplicates = [] } = await browser.runtime.sendMessage({ type: 'getDuplicates' });
   currentDupIds = new Set(duplicates);


### PR DESCRIPTION
## Summary
- reset visited state on browser startup
- query current visited tabs via runtime message

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686fab37798c833198604dce93419764