### PR TITLE
Fix active count in full view

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -768,6 +768,8 @@ async function update() {
     if (filterContainerId) {
       allTabs = allTabs.filter(t => t.cookieStoreId === filterContainerId);
     }
+    const extPrefix = browser.runtime.getURL('');
+    allTabs = allTabs.filter(t => !t.url.startsWith(extPrefix));
     if (allWins) {
       const wins = await browser.windows.getAll({populate: false});
       const order = new Map(wins.map((w, i) => [w.id, i]));


### PR DESCRIPTION
## Summary
- avoid counting extension pages in tab metrics

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686fb9118d908331a8d079e023320ed2