### PR TITLE
Fix active tab counter in full view

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -34,6 +34,8 @@ let currentQuery = '';
 let pendingScroll = null;
 let easterEgg;
 
+const EXT_URL = browser.runtime.getURL('');
+
 function showEasterEgg() {
   if (!easterEgg || easterEgg.classList.contains('visible')) return;
   const hide = () => {
@@ -765,6 +767,7 @@ async function update() {
     const allWins = document.body.classList.contains('full');
     const queryOpts = allWins ? {} : { currentWindow: true };
     let allTabs = await browser.tabs.query(queryOpts);
+    allTabs = allTabs.filter(t => !t.url.startsWith(EXT_URL));
     if (filterContainerId) {
       allTabs = allTabs.filter(t => t.cookieStoreId === filterContainerId);
     }


### PR DESCRIPTION
## Summary
- ignore extension pages when computing tab counts

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686fb9118d908331a8d079e023320ed2