### PR TITLE
Fix visited state reset

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -9,9 +9,6 @@ let visitedTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
-// Ensure previous session visit data does not persist
-browser.storage.local.remove('visited').catch(() => {});
-
 // Track duplicate tabs by URL
 const dupMap = new Map();
 const dupIds = new Set();
@@ -72,13 +69,15 @@ function sendVisitedUpdate() {
 browser.storage.local.get([
   'autoUnload',
   'autoUnloadMinutes',
-  'recent'
+  'recent',
+  'visited'
 ]).then(data => {
   if (typeof data.autoUnload === 'boolean') autoUnload = data.autoUnload;
   if (typeof data.autoUnloadMinutes === 'number') {
     autoUnloadMinutes = data.autoUnloadMinutes;
   }
   if (Array.isArray(data.recent)) recent = data.recent;
+  if (Array.isArray(data.visited)) visited = new Set(data.visited);
 });
 
 // Reset visited tabs on each startup to avoid stale highlighting


### PR DESCRIPTION
## Summary
- load visited tab state from storage on background startup
- keep visited records between service worker restarts

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687197cc7200833182bed4e545ffd5c6