### PR TITLE
Kamil/main/fix-visited-loss-v1.0.1

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -9,8 +9,9 @@ let visitedTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
-// Ensure previous session visit data does not persist
-browser.storage.local.remove('visited').catch(() => {});
+// The visited list is reset on browser startup via onStartup
+// handler. Avoid clearing it here so data persists across
+// background script reloads during the session.
 
 // Track duplicate tabs by URL
 const dupMap = new Map();


### PR DESCRIPTION
## Summary
- keep visited tab data when the background script reloads

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687197cc7200833182bed4e545ffd5c6