### PR TITLE
Fix full view visited persistence

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -9,8 +9,8 @@ let visitedTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
-// Ensure previous session visit data does not persist
-browser.storage.local.remove('visited').catch(() => {});
+// `visited` data should persist across service worker restarts.
+// Only clear it when the browser actually starts up.
 
 // Track duplicate tabs by URL
 const dupMap = new Map();


### PR DESCRIPTION
## Summary
- preserve visited tab tracking across service worker restarts

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687197cc7200833182bed4e545ffd5c6