### PR TITLE
Kamil/main/fix-visited-mark-v1.0.2

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -199,9 +199,7 @@ browser.tabs.onRemoved.addListener((tabId) => {
 });
 
 browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (changeInfo.discarded === true) {
-    unmarkVisited(tabId);
-  } else if (changeInfo.discarded === false && tab && tab.active) {
+  if (changeInfo.discarded === false && tab && tab.active) {
     markVisited(tabId);
   }
   if (changeInfo.url) {
@@ -263,7 +261,6 @@ async function unloadAllTabs() {
     .map(async t => {
       try {
         await browser.tabs.discard(t.id);
-        unmarkVisited(t.id);
       } catch (_) {}
     }));
 }
@@ -277,7 +274,6 @@ async function checkAutoUnload() {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
         try {
           await browser.tabs.discard(t.id);
-          unmarkVisited(t.id);
         } catch (_) {}
       }
     }));


### PR DESCRIPTION
## Summary
- keep visited state when tabs are discarded
- preserve tab history during automatic and manual unload

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687197cc7200833182bed4e545ffd5c6