### PR TITLE
Kamil/main/fix-visited-mark-v1.0.2

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -9,8 +9,6 @@ let visitedTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
-// Ensure previous session visit data does not persist
-browser.storage.local.remove('visited').catch(() => {});
 
 // Track duplicate tabs by URL
 const dupMap = new Map();
@@ -68,25 +66,21 @@ function sendVisitedUpdate() {
     .catch(() => {});
 }
 
-// Clear session-specific data from previous runs
+// Restore persisted data
 browser.storage.local.get([
   'autoUnload',
   'autoUnloadMinutes',
-  'recent'
+  'recent','visited'
 ]).then(data => {
   if (typeof data.autoUnload === 'boolean') autoUnload = data.autoUnload;
   if (typeof data.autoUnloadMinutes === 'number') {
     autoUnloadMinutes = data.autoUnloadMinutes;
   }
   if (Array.isArray(data.recent)) recent = data.recent;
+  if (Array.isArray(data.visited)) visited = new Set(data.visited);
 });
 
-// Reset visited tabs on each startup to avoid stale highlighting
-browser.runtime.onStartup.addListener(() => {
-  visited = new Set();
-  browser.storage.local.remove('visited').catch(() => {});
-});
-
+// Listen for settings changes
 browser.storage.onChanged.addListener((changes, area) => {
   if (area === 'local') {
     if (changes.autoUnload) autoUnload = changes.autoUnload.newValue;
@@ -199,9 +193,7 @@ browser.tabs.onRemoved.addListener((tabId) => {
 });
 
 browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (changeInfo.discarded === true) {
-    unmarkVisited(tabId);
-  } else if (changeInfo.discarded === false && tab && tab.active) {
+  if (changeInfo.discarded === false && tab && tab.active) {
     markVisited(tabId);
   }
   if (changeInfo.url) {
@@ -263,7 +255,6 @@ async function unloadAllTabs() {
     .map(async t => {
       try {
         await browser.tabs.discard(t.id);
-        unmarkVisited(t.id);
       } catch (_) {}
     }));
 }
@@ -277,7 +268,6 @@ async function checkAutoUnload() {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
         try {
           await browser.tabs.discard(t.id);
-          unmarkVisited(t.id);
         } catch (_) {}
       }
     }));

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1295,7 +1295,6 @@ function showContextMenu(e) {
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
       await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
       scheduleUpdate();
     });
     // Direct move option removed in favor of flagged move workflow
@@ -1355,7 +1354,6 @@ async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
     await browser.tabs.discard(id);
-    await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
   }));
   scheduleUpdate();
 }
@@ -1364,7 +1362,6 @@ async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.map(async t => {
     await browser.tabs.discard(t.id);
-    await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: t.id });
   }));
   scheduleUpdate();
 }


### PR DESCRIPTION
## Summary
- restore visited data from local storage
- keep visited state when unloading tabs
- remove calls unmarking visited when discarding tabs

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687197cc7200833182bed4e545ffd5c6