### PR TITLE
Reset visited tabs on startup

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -66,6 +66,15 @@ function sendVisitedUpdate() {
     .catch(() => {});
 }
 
+function resetVisited() {
+  visited = new Set();
+  browser.storage.local.remove('visited');
+  sendVisitedUpdate();
+}
+
+browser.runtime.onStartup.addListener(resetVisited);
+browser.runtime.onInstalled.addListener(resetVisited);
+
 // Restore persisted data
 browser.storage.local.get([
   'autoUnload',


### PR DESCRIPTION
## Summary
- reset stored `visited` list on browser startup or installation

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872badb3f2c833184673509a0de92bf