### PR TITLE
Reset visited state each session

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -70,14 +70,14 @@ function sendVisitedUpdate() {
 browser.storage.local.get([
   'autoUnload',
   'autoUnloadMinutes',
-  'recent','visited'
+  'recent'
 ]).then(data => {
   if (typeof data.autoUnload === 'boolean') autoUnload = data.autoUnload;
   if (typeof data.autoUnloadMinutes === 'number') {
     autoUnloadMinutes = data.autoUnloadMinutes;
   }
   if (Array.isArray(data.recent)) recent = data.recent;
-  if (Array.isArray(data.visited)) visited = new Set(data.visited);
+  visited = new Set();
 });
 
 // Listen for settings changes
@@ -154,12 +154,11 @@ function reorderRecent(ids, toId, before) {
 }
 
 function scheduleVisitedSave() {
-  if (!visitedTimer) {
-    visitedTimer = setTimeout(() => {
-      visitedTimer = null;
-      browser.storage.local.set({ visited: Array.from(visited) });
-    }, 500);
-  }
+  // Visited tabs are tracked only for the current session, so no persistence is needed.
+  if (visitedTimer) return;
+  visitedTimer = setTimeout(() => {
+    visitedTimer = null;
+  }, 500);
 }
 
 function markVisited(tabId) {

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1034,7 +1034,7 @@ async function init() {
   }
   document.addEventListener('contextmenu', showContextMenu);
   container.addEventListener('dragend', clearPlaceholder);
-  const { visited = [] } = await browser.storage.local.get('visited');
+  const { visited = [] } = await browser.runtime.sendMessage({ type: 'getVisited' });
   visitedIds = new Set(visited);
   const { duplicates = [] } = await browser.runtime.sendMessage({ type: 'getDuplicates' });
   currentDupIds = new Set(duplicates);


### PR DESCRIPTION
## Summary
- clear stored visited tab data on startup
- only track visited tabs in memory
- query visited tabs from background script in popup

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872badb3f2c833184673509a0de92bf