### PR TITLE
Ensure visited tabs persist for session only

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -70,7 +70,8 @@ function sendVisitedUpdate() {
 browser.storage.local.get([
   'autoUnload',
   'autoUnloadMinutes',
-  'recent','visited'
+  'recent',
+  'visited'
 ]).then(data => {
   if (typeof data.autoUnload === 'boolean') autoUnload = data.autoUnload;
   if (typeof data.autoUnloadMinutes === 'number') {
@@ -78,6 +79,12 @@ browser.storage.local.get([
   }
   if (Array.isArray(data.recent)) recent = data.recent;
   if (Array.isArray(data.visited)) visited = new Set(data.visited);
+});
+
+// Clear visited state when the browser starts
+browser.runtime.onStartup.addListener(() => {
+  visited = new Set();
+  browser.storage.local.remove('visited').catch(() => {});
 });
 
 // Listen for settings changes


### PR DESCRIPTION
## Summary
- restore loading and saving `visited` tab IDs in local storage
- clear the stored `visited` list when the browser starts
- use local storage in the popup for the initial visited state

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872badb3f2c833184673509a0de92bf