### PR TITLE
fix: add startup visited tracking

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -85,6 +85,12 @@ browser.storage.local.get([
 browser.runtime.onStartup.addListener(() => {
   visited = new Set();
   browser.storage.local.remove('visited').catch(() => {});
+  browser.tabs.query({ active: true }).then(tabs => {
+    for (const t of tabs) {
+      pushRecent(t.id);
+      markVisited(t.id);
+    }
+  });
 });
 
 // Listen for settings changes


### PR DESCRIPTION
## Summary
- track active tabs on browser startup

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872da622e24833189a09b16ef7c9dd6