### PR TITLE
Fix visited state persistence on startup

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -78,7 +78,8 @@ browser.storage.local.get([
     autoUnloadMinutes = data.autoUnloadMinutes;
   }
   if (Array.isArray(data.recent)) recent = data.recent;
-  if (Array.isArray(data.visited)) visited = new Set(data.visited);
+  // Always start with a clean visited set to avoid stale state between sessions
+  browser.storage.local.remove('visited').catch(() => {});
 });
 
 // Clear visited state when the browser starts


### PR DESCRIPTION
## Summary
- prevent stale visited data from being loaded

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872e99ee1808331996c60356c4c02ad