### PR TITLE
Fix visited tabs state initialization

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -85,6 +85,7 @@ browser.storage.local.get([
 browser.runtime.onStartup.addListener(() => {
   visited = new Set();
   browser.storage.local.remove('visited').catch(() => {});
+  sendVisitedUpdate();
 });
 
 // Listen for settings changes
@@ -307,6 +308,9 @@ browser.commands.onCommand.addListener((command) => {
 });
 
 browser.runtime.onInstalled.addListener(async () => {
+  visited = new Set();
+  await browser.storage.local.remove('visited').catch(() => {});
+  sendVisitedUpdate();
   await browser.contextMenus.create({
     id: 'show-version',
     title: `KepiTAB Manager v${browser.runtime.getManifest().version}`,


### PR DESCRIPTION
## Summary
- reset visited tabs state when the extension starts
- remove persisted visited data on install/startup

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872e99ee1808331996c60356c4c02ad