### PR TITLE
Add bulk load action to full view context menu

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -8,7 +8,7 @@ This is an open source Firefox add-on for advanced tab management.
 - Shows a **Recent** panel listing all visited tabs.
 - Highlights duplicate tabs and provides a dedicated **Duplicates** view.
 - Visited tabs appear in **bold** while unvisited tabs are dimmed, making new pages easy to spot.
-- Perform bulk operations (close, reload, unload, move) on selected tabs, and a
+- Perform bulk operations (close, load, reload, unload, move) on selected tabs, and a
   command to unload all tabs at once. The keyboard shortcut for this command can
   be configured on the Options page.
 - Each tab row includes a button to quickly close that tab.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1261,6 +1261,9 @@ function showContextMenu(e) {
 
   if (selected.length) {
     addItem('Close Selected', bulkClose);
+    if (document.body.classList.contains('full')) {
+      addItem('Load Selected', bulkLoad);
+    }
     addItem('Reload Selected', bulkReload);
     addItem('Unload Selected', bulkDiscard);
     if (MOVE_ENABLED) {
@@ -1348,6 +1351,16 @@ async function bulkClose() {
 async function bulkReload() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(id => browser.tabs.reload(id)));
+}
+
+async function bulkLoad() {
+  const ids = getSelectedTabIds();
+  await Promise.all(ids.map(async id => {
+    const tab = await browser.tabs.get(id);
+    if (tab.discarded) {
+      await browser.tabs.reload(id);
+    }
+  }));
 }
 
 async function bulkDiscard() {


### PR DESCRIPTION
## Summary
- allow loading multiple selected tabs via the full view context menu
- document the new load feature

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872e46cab1c8331bba0f50e022e6c6d