### PR TITLE
Add load option to full view context menu

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1261,6 +1261,9 @@ function showContextMenu(e) {
 
   if (selected.length) {
     addItem('Close Selected', bulkClose);
+    if (document.body.classList.contains('full')) {
+      addItem('Load Selected', bulkLoad);
+    }
     addItem('Reload Selected', bulkReload);
     addItem('Unload Selected', bulkDiscard);
     if (MOVE_ENABLED) {
@@ -1346,6 +1349,11 @@ async function bulkClose() {
 }
 
 async function bulkReload() {
+  const ids = getSelectedTabIds();
+  await Promise.all(ids.map(id => browser.tabs.reload(id)));
+}
+
+async function bulkLoad() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(id => browser.tabs.reload(id)));
 }


### PR DESCRIPTION
## Summary
- add `Load Selected` option that reloads selected tabs
- show the new option in the context menu when in full window view

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872e46cab1c8331bba0f50e022e6c6d