### PR TITLE
Add bulk load in context menu

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -11,6 +11,8 @@ This is an open source Firefox add-on for advanced tab management.
 - Perform bulk operations (close, reload, unload, move) on selected tabs, and a
   command to unload all tabs at once. The keyboard shortcut for this command can
   be configured on the Options page.
+- In Full View, the context menu offers **Load Selected** to restore unloaded
+  tabs without activating them.
 - Each tab row includes a button to quickly close that tab.
 - Smooth hover effects highlight each tab row for a polished interface.
 - Animated view transitions make switching between the **All**, **Recent** and **Duplicates** panels seamless.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1262,6 +1262,9 @@ function showContextMenu(e) {
   if (selected.length) {
     addItem('Close Selected', bulkClose);
     addItem('Reload Selected', bulkReload);
+    if (document.body.classList.contains('full')) {
+      addItem('Load Selected', bulkLoad);
+    }
     addItem('Unload Selected', bulkDiscard);
     if (MOVE_ENABLED) {
       if (!movePending) addItem('Flag for Move', flagTabsForMove);
@@ -1346,6 +1349,11 @@ async function bulkClose() {
 }
 
 async function bulkReload() {
+  const ids = getSelectedTabIds();
+  await Promise.all(ids.map(id => browser.tabs.reload(id)));
+}
+
+async function bulkLoad() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(id => browser.tabs.reload(id)));
 }


### PR DESCRIPTION
## Summary
- add `Load Selected` action in full view context menu
- document new bulk loading option in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872e46cab1c8331bba0f50e022e6c6d