### PR TITLE
Add visited marking for bulk load

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -11,6 +11,8 @@ This is an open source Firefox add-on for advanced tab management.
 - Perform bulk operations (close, reload, unload, move) on selected tabs, and a
   command to unload all tabs at once. The keyboard shortcut for this command can
   be configured on the Options page.
+- In Full View, the context menu offers **Load Selected** to mark selected
+  tabs as visited without loading them.
 - Each tab row includes a button to quickly close that tab.
 - Smooth hover effects highlight each tab row for a polished interface.
 - Animated view transitions make switching between the **All**, **Recent** and **Duplicates** panels seamless.

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -218,6 +218,8 @@ browser.runtime.onMessage.addListener((msg) => {
     return Promise.resolve({ duplicates: Array.from(dupIds) });
   } else if (msg && msg.type === 'unmarkVisited') {
     unmarkVisited(msg.tabId);
+  } else if (msg && msg.type === 'markVisited') {
+    (msg.ids || []).forEach(markVisited);
   } else if (msg && msg.type === 'reorderRecent') {
     reorderRecent(msg.ids || [], msg.toId, msg.before);
   }

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -14,7 +14,8 @@
       "storage",
       "contextMenus",
       "contextualIdentities",
-      "cookies"
+      "cookies",
+      "history"
     ],
   "background": {
 

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1262,6 +1262,9 @@ function showContextMenu(e) {
   if (selected.length) {
     addItem('Close Selected', bulkClose);
     addItem('Reload Selected', bulkReload);
+    if (document.body.classList.contains('full')) {
+      addItem('Load Selected', bulkLoad);
+    }
     addItem('Unload Selected', bulkDiscard);
     if (MOVE_ENABLED) {
       if (!movePending) addItem('Flag for Move', flagTabsForMove);
@@ -1348,6 +1351,17 @@ async function bulkClose() {
 async function bulkReload() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(id => browser.tabs.reload(id)));
+}
+
+async function bulkLoad() {
+  const ids = getSelectedTabIds();
+  const tabs = await Promise.all(ids.map(id => browser.tabs.get(id)));
+  if (browser.history && browser.history.addUrl) {
+    try {
+      await Promise.all(tabs.map(t => browser.history.addUrl({ url: t.url })));
+    } catch (_) {}
+  }
+  await browser.runtime.sendMessage({ type: 'markVisited', ids }).catch(() => {});
 }
 
 async function bulkDiscard() {


### PR DESCRIPTION
## Summary
- update manifest with `history` permission
- implement background handler for `markVisited`
- modify bulk load to mark visited without loading
- document new behavior in README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872e46cab1c8331bba0f50e022e6c6d