### PR TITLE
Reset recent tabs on browser restart

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -2,6 +2,9 @@
 const MAX_RECENT = Infinity;
 const action = browser.browserAction || browser.action;
 
+// Generate a new token on each background script load to detect session restarts
+const SESSION_TOKEN = Date.now().toString();
+
 let recent = [];
 let visited = new Set();
 let recentTimer = null;
@@ -71,20 +74,32 @@ browser.storage.local.get([
   'autoUnload',
   'autoUnloadMinutes',
   'recent',
-  'visited'
-]).then(data => {
+  'visited',
+  'sessionToken'
+]).then(async data => {
   if (typeof data.autoUnload === 'boolean') autoUnload = data.autoUnload;
   if (typeof data.autoUnloadMinutes === 'number') {
     autoUnloadMinutes = data.autoUnloadMinutes;
   }
-  if (Array.isArray(data.recent)) recent = data.recent;
-  if (Array.isArray(data.visited)) visited = new Set(data.visited);
+  const newSession = data.sessionToken !== SESSION_TOKEN;
+  await browser.storage.local.set({ sessionToken: SESSION_TOKEN }).catch(() => {});
+  if (!newSession) {
+    if (Array.isArray(data.recent)) recent = data.recent;
+    if (Array.isArray(data.visited)) visited = new Set(data.visited);
+  } else {
+    recent = [];
+    visited = new Set();
+    await browser.storage.local.remove(['recent', 'visited']).catch(() => {});
+    sendVisitedUpdate();
+  }
 });
 
 // Clear visited state when the browser starts
 browser.runtime.onStartup.addListener(() => {
+  recent = [];
   visited = new Set();
-  browser.storage.local.remove('visited').catch(() => {});
+  browser.storage.local.remove(['recent', 'visited']).catch(() => {});
+  sendVisitedUpdate();
 });
 
 // Listen for settings changes
@@ -307,6 +322,10 @@ browser.commands.onCommand.addListener((command) => {
 });
 
 browser.runtime.onInstalled.addListener(async () => {
+  recent = [];
+  visited = new Set();
+  await browser.storage.local.remove(['recent', 'visited']).catch(() => {});
+  sendVisitedUpdate();
   await browser.contextMenus.create({
     id: 'show-version',
     title: `KepiTAB Manager v${browser.runtime.getManifest().version}`,


### PR DESCRIPTION
## Summary
- create a session token each time the background script starts
- clear `recent` and `visited` if the token changed

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872e99ee1808331996c60356c4c02ad