### PR TITLE
Add ESLint configuration for JavaScript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "overrides": [
+    {
+      "files": ["mytabs/*.js"],
+      "extends": "standard",
+      "env": {
+        "browser": true,
+        "es2021": true
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ Container-related actions require Firefox's container feature and the `contextua
 
 ## Development
 
-Install dev dependencies and run Stylelint to check the stylesheet.
-Configuration is stored in `.stylelintrc.json` and uses the
-`stylelint-order` plugin. Before running the linter, execute
-`npm install` and then run `npm run lint`.
+Install dev dependencies and run Stylelint to check the stylesheet and ESLint to
+validate the JavaScript files. Configuration is stored in `.stylelintrc.json`
+and `.eslintrc.json` and uses the `stylelint-order` plugin. Before running the
+linters, execute `npm install` and then use the commands below.
 
 ```bash
 npm install
 npm run lint
+npm run lint:js
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0",
   "description": "Development tooling",
   "devDependencies": {
+    "eslint": "^8.57.1",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^7.2.1",
     "stylelint": "^15.0.0"
   },
   "dependencies": {
@@ -10,7 +15,8 @@
   },
   "scripts": {
     "lint": "stylelint mytabs/style.css",
-    "postinstall": "npx stylelint --version"
+    "postinstall": "npx stylelint --version",
+    "lint:js": "eslint mytabs/*.js"
   },
   "license": "GPL-3.0-or-later"
 }


### PR DESCRIPTION
## Summary
- add ESLint and standard rules as dev dependencies
- configure ESLint to target `mytabs/*.js`
- provide npm script `lint:js`
- document JavaScript linting in README

## Testing
- `npm run lint`
- `npm run lint:js` *(fails: many lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_6873ce19fe38833180e04ebf8c4fb786