### PR TITLE
Add periodic tab state sync for full view

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -235,6 +235,11 @@ browser.runtime.onMessage.addListener((msg) => {
     unmarkVisited(msg.tabId);
   } else if (msg && msg.type === 'reorderRecent') {
     reorderRecent(msg.ids || [], msg.toId, msg.before);
+  } else if (msg && msg.type === 'getTabState') {
+    return browser.tabs.query({ windowType: 'normal' }).then(tabs => ({
+      tabs,
+      visited: Array.from(visited)
+    }));
   }
 });
 
@@ -298,7 +303,19 @@ async function checkAutoUnload() {
   }
 }
 
+async function broadcastTabState() {
+  try {
+    const tabs = await browser.tabs.query({ windowType: 'normal' });
+    browser.runtime.sendMessage({
+      type: 'tabState',
+      tabs,
+      visited: Array.from(visited)
+    }).catch(() => {});
+  } catch (_) {}
+}
+
 setInterval(checkAutoUnload, 60000);
+setInterval(broadcastTabState, 5000);
 
 // Open the multi-column tab manager when the icon is middle-clicked.
 if (action && action.onClicked && action.onClicked.addListener) {

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -45,6 +45,7 @@
     <script src="theme.js"></script>
     <script src="hyperlist.js"></script>
     <script src="popup.js"></script>
+    <script src="fullpage.js"></script>
     <script src="fullwin.js"></script>
     <!-- layout handled via CSS grid -->
   </body>

--- a/mytabs/fullpage.js
+++ b/mytabs/fullpage.js
@@ -1,0 +1,24 @@
+let poller;
+function startPolling() {
+  async function fetchState() {
+    try {
+      const res = await browser.runtime.sendMessage({ type: 'getTabState' });
+      if (res) {
+        if (Array.isArray(res.visited)) {
+          visitedIds = new Set(res.visited);
+        }
+        if (Array.isArray(res.tabs)) {
+          backgroundTabs = res.tabs;
+        }
+        scheduleUpdate();
+      }
+    } catch (e) {}
+  }
+  fetchState();
+  poller = setInterval(fetchState, 5000);
+}
+
+document.addEventListener('DOMContentLoaded', startPolling);
+window.addEventListener('unload', () => {
+  if (poller) clearInterval(poller);
+});

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -19,6 +19,7 @@ let filterContainerId = '';
 let containerCache;
 let targetSelect;
 let visitedIds = new Set();
+let backgroundTabs = [];
 let movePending = null;
 
 let virtualList = null;
@@ -764,7 +765,12 @@ async function update() {
   try {
     const allWins = document.body.classList.contains('full');
     const queryOpts = allWins ? { windowType: 'normal' } : { currentWindow: true, windowType: 'normal' };
-    let allTabs = await browser.tabs.query(queryOpts);
+    let allTabs = [];
+    if (allWins && backgroundTabs.length) {
+      allTabs = backgroundTabs.slice();
+    } else {
+      allTabs = await browser.tabs.query(queryOpts);
+    }
     if (filterContainerId) {
       allTabs = allTabs.filter(t => t.cookieStoreId === filterContainerId);
     }
@@ -822,6 +828,10 @@ browser.runtime.onMessage.addListener((msg) => {
     scheduleUpdate();
   } else if (msg && msg.type === 'duplicatesUpdated') {
     currentDupIds = new Set(msg.duplicates || []);
+    scheduleUpdate();
+  } else if (msg && msg.type === 'tabState') {
+    if (Array.isArray(msg.visited)) visitedIds = new Set(msg.visited);
+    if (Array.isArray(msg.tabs)) backgroundTabs = msg.tabs;
     scheduleUpdate();
   }
 });


### PR DESCRIPTION
## Summary
- broadcast tab state from the background every 5s
- poll for tab state in the extension full page
- use received tab data when rendering in full view

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873febfa194833180390f579fef5889