### PR TITLE
Fix full page state sync

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -12,6 +12,9 @@ let visitedTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
+// Cache of all tabs for the extension page
+let allTabCache = [];
+
 
 // Track duplicate tabs by URL
 const dupMap = new Map();
@@ -69,6 +72,29 @@ function sendVisitedUpdate() {
     .catch(() => {});
 }
 
+async function updateTabCache() {
+  try {
+    allTabCache = await browser.tabs.query({ windowType: 'normal' });
+  } catch (_) {
+    allTabCache = [];
+  }
+}
+
+function sendTabState() {
+  browser.runtime.sendMessage({
+    type: 'tabState',
+    tabs: allTabCache,
+    visited: Array.from(visited)
+  }).catch(() => {});
+}
+
+async function refreshTabState() {
+  await updateTabCache();
+  sendTabState();
+}
+
+setInterval(refreshTabState, 5000);
+
 // Restore persisted data
 browser.storage.local.get([
   'autoUnload',
@@ -92,6 +118,7 @@ browser.storage.local.get([
     await browser.storage.local.remove(['recent', 'visited']).catch(() => {});
     sendVisitedUpdate();
   }
+  refreshTabState();
 });
 
 // Clear visited state when the browser starts
@@ -100,6 +127,7 @@ browser.runtime.onStartup.addListener(() => {
   visited = new Set();
   browser.storage.local.remove(['recent', 'visited']).catch(() => {});
   sendVisitedUpdate();
+  refreshTabState();
 });
 
 // Listen for settings changes
@@ -115,6 +143,7 @@ browser.tabs.query({}).then(tabs => {
   for (const t of tabs) {
     addDuplicate(t.id, t.url);
   }
+  refreshTabState();
 });
 
 // Apply user-defined keyboard shortcuts if supported
@@ -195,10 +224,12 @@ function markVisited(tabId) {
 browser.tabs.onActivated.addListener(info => {
   pushRecent(info.tabId);
   markVisited(info.tabId);
+  refreshTabState();
 });
 
 browser.tabs.onCreated.addListener(tab => {
   addDuplicate(tab.id, tab.url);
+  refreshTabState();
 });
 
 browser.tabs.onRemoved.addListener((tabId) => {
@@ -212,6 +243,7 @@ browser.tabs.onRemoved.addListener((tabId) => {
     sendVisitedUpdate();
   }
   removeDuplicate(tabId);
+  refreshTabState();
 });
 
 browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
@@ -222,6 +254,7 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     removeDuplicate(tabId);
     addDuplicate(tabId, changeInfo.url);
   }
+  refreshTabState();
 });
 
 browser.runtime.onMessage.addListener((msg) => {
@@ -231,6 +264,8 @@ browser.runtime.onMessage.addListener((msg) => {
     return Promise.resolve({ visited: Array.from(visited) });
   } else if (msg && msg.type === 'getDuplicates') {
     return Promise.resolve({ duplicates: Array.from(dupIds) });
+  } else if (msg && msg.type === 'getTabState') {
+    return Promise.resolve({ tabs: allTabCache, visited: Array.from(visited) });
   } else if (msg && msg.type === 'unmarkVisited') {
     unmarkVisited(msg.tabId);
   } else if (msg && msg.type === 'reorderRecent') {

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -21,6 +21,9 @@ let targetSelect;
 let visitedIds = new Set();
 let movePending = null;
 
+// Cached tab list provided by the background script
+let cachedTabs = null;
+
 let virtualList = null;
 let tabItems = [];
 let idIndexMap = new Map();
@@ -764,7 +767,18 @@ async function update() {
   try {
     const allWins = document.body.classList.contains('full');
     const queryOpts = allWins ? { windowType: 'normal' } : { currentWindow: true, windowType: 'normal' };
-    let allTabs = await browser.tabs.query(queryOpts);
+    let allTabs;
+    if (Array.isArray(cachedTabs)) {
+      allTabs = cachedTabs.slice();
+      if (!allWins) {
+        try {
+          const win = await browser.windows.getLastFocused({ windowTypes: ['normal'] });
+          allTabs = allTabs.filter(t => t.windowId === win.id);
+        } catch (_) {}
+      }
+    } else {
+      allTabs = await browser.tabs.query(queryOpts);
+    }
     if (filterContainerId) {
       allTabs = allTabs.filter(t => t.cookieStoreId === filterContainerId);
     }
@@ -822,6 +836,10 @@ browser.runtime.onMessage.addListener((msg) => {
     scheduleUpdate();
   } else if (msg && msg.type === 'duplicatesUpdated') {
     currentDupIds = new Set(msg.duplicates || []);
+    scheduleUpdate();
+  } else if (msg && msg.type === 'tabState') {
+    cachedTabs = Array.isArray(msg.tabs) ? msg.tabs : null;
+    visitedIds = new Set(msg.visited || []);
     scheduleUpdate();
   }
 });
@@ -1039,6 +1057,14 @@ async function init() {
   const { duplicates = [] } = await browser.runtime.sendMessage({ type: 'getDuplicates' });
   currentDupIds = new Set(duplicates);
   await loadOptions();
+  setInterval(async () => {
+    try {
+      const { tabs, visited: v } = await browser.runtime.sendMessage({ type: 'getTabState' });
+      if (Array.isArray(tabs)) cachedTabs = tabs;
+      if (Array.isArray(v)) visitedIds = new Set(v);
+      scheduleUpdate();
+    } catch (_) {}
+  }, 5000);
   registerTabEvents();
   const select = document.getElementById('container-filter');
   let containerIdents = [];


### PR DESCRIPTION
## Summary
- maintain a tab cache in the background script
- periodically send cached tab state to UI
- update popup script to consume `tabState` messages
- poll background for updated tab state when full view is open

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6873febfa194833180390f579fef5889