### PR TITLE
Fix context menu hidden menu trigger

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1219,6 +1219,12 @@ window.addEventListener('resize', () => {
 
 // custom context menu
 const context = document.getElementById('context');
+context.addEventListener('contextmenu', (e) => {
+  if (!context.classList.contains('visible')) return;
+  e.preventDefault();
+  e.stopPropagation();
+  showEasterEgg();
+});
 async function movePendingTo(targetEl, evt) {
   const ids = movePending;
   if (!ids || !ids.length) return;
@@ -1329,10 +1335,6 @@ function showContextMenu(e) {
     // Direct move option removed in favor of flagged move workflow
   }
 
-  if (!tabEl && !selected.length) {
-    showEasterEgg();
-    return;
-  }
 
   addItem('Unload All Tabs', bulkUnloadAll);
   addItem('Options', () => browser.runtime.openOptionsPage());


### PR DESCRIPTION
## Summary
- avoid showing hidden menu when right-clicking empty space
- show hidden menu only when right-clicking the context menu

## Testing
- `npm install`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68757150998483319186370396b96ac1