### PR TITLE
Fix context menu visibility

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1277,6 +1277,7 @@ function clearMovePending() {
 function showContextMenu(e) {
   const tabEl = e.target.closest('.tab');
   if (!tabEl) {
+    e.preventDefault();
     hideContextMenu();
     return;
   }

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1275,9 +1275,13 @@ function clearMovePending() {
 
 
 function showContextMenu(e) {
+  const tabEl = e.target.closest('.tab');
+  if (!tabEl) {
+    hideContextMenu();
+    return;
+  }
   e.preventDefault();
   hideAllTooltips();
-  const tabEl = e.target.closest('.tab');
   context.innerHTML = '';
 
   const selected = getSelectedTabIds();


### PR DESCRIPTION
## Summary
- restrict custom context menu to tab right-clicks

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68765327e3a08331806ed7d611cba562