### PR TITLE
Kamil/main/fix-context-menu-v1.0.1

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1277,6 +1277,7 @@ function clearMovePending() {
 function showContextMenu(e) {
   const tabEl = e.target.closest('.tab');
   if (!tabEl) {
+    e.preventDefault();
     hideContextMenu();
     return;
   }


### PR DESCRIPTION
## Summary
- prevent Firefox native context menu on non-tab elements

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6876c26c10e483319e5359476d5d7651