### PR TITLE
Preserve scroll position per view in full window

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -35,6 +35,8 @@ let currentWinMap = null;
 let currentQuery = '';
 // Scroll position to restore after certain operations
 let pendingScroll = null;
+// Remember vertical scroll for each view in full window
+const fullScrollPos = { all: 0, recent: 0, dups: 0 };
 let easterEgg;
 
 function showEasterEgg() {
@@ -128,6 +130,10 @@ function updateViewButtons() {
 }
 
 function setView(newView) {
+  if (document.body.classList.contains('full') && scrollContainer) {
+    fullScrollPos[view] = scrollContainer.scrollTop;
+    pendingScroll = fullScrollPos[newView] || 0;
+  }
   view = newView;
   updateViewButtons();
   triggerViewAnimation();
@@ -278,6 +284,7 @@ const saveScroll = debounce(() => {
   if (!scrollContainer) return;
   if (document.body.classList.contains('full')) {
     browser.storage.local.set({ scrollLeftFull: scrollContainer.scrollLeft });
+    fullScrollPos[view] = scrollContainer.scrollTop;
   } else {
     browser.storage.local.set({ scrollTop: scrollContainer.scrollTop });
   }


### PR DESCRIPTION
## Summary
- remember vertical scroll for each view
- keep previous position when switching tabs in full view

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6878ca451e848331958cba1829731ad7