### PR TITLE
Kamil/main/fix-scroll-restore-v1.0.1

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -131,7 +131,7 @@ function updateViewButtons() {
 
 function setView(newView) {
   if (document.body.classList.contains('full') && scrollContainer) {
-    fullScrollPos[view] = scrollContainer.scrollTop;
+    fullScrollPos[view] = scrollContainer.scrollLeft;
     pendingScroll = fullScrollPos[newView] || 0;
   }
   view = newView;
@@ -284,7 +284,7 @@ const saveScroll = debounce(() => {
   if (!scrollContainer) return;
   if (document.body.classList.contains('full')) {
     browser.storage.local.set({ scrollLeftFull: scrollContainer.scrollLeft });
-    fullScrollPos[view] = scrollContainer.scrollTop;
+    fullScrollPos[view] = scrollContainer.scrollLeft;
   } else {
     browser.storage.local.set({ scrollTop: scrollContainer.scrollTop });
   }


### PR DESCRIPTION
## Summary
- preserve horizontal scroll position for ALL/RECENT/DUPLICATES views when switching tabs in full mode

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687a83783890833184d1039375070f72