### PR TITLE
Add spacing in popup counts

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -174,6 +174,11 @@ body[data-theme="dark"] #easter-egg {
 }
 body.popup {
   overflow-x: hidden;
+  /* Add spacing between the tab counts and menu buttons in popup mode */
+  /* Provide visual separation for a cleaner layout */
+}
+body.popup #counts {
+  margin-bottom: 0.5em;
 }
 body.popup #tabs {
   max-height: none;


### PR DESCRIPTION
## Summary
- adjust CSS to increase spacing between counts and menu in popup mode

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b0044bf94833195e69237da50e3ad