### PR TITLE
Add margin between menu and search in popup

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -180,6 +180,10 @@ body.popup {
 body.popup #counts {
   margin-bottom: 0.5em;
 }
+body.popup #menu {
+  /* Add spacing between the search field and menu buttons in popup mode */
+  margin-bottom: 0.5em;
+}
 body.popup #tabs {
   max-height: none;
   overflow: visible;


### PR DESCRIPTION
## Summary
- add margin below popup menu to separate it from the search field

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687b41738ec48331ab2299a7417fc7d0