### PR TITLE
Add popup spacing between search and tabs

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -184,6 +184,10 @@ body.popup #menu {
   /* Add spacing between the search field and menu buttons in popup mode */
   margin-bottom: 0.5em;
 }
+body.popup .search-wrapper {
+  /* Add spacing between the search field and the tabs list in popup mode */
+  margin-bottom: 0.5em;
+}
 body.popup #tabs {
   max-height: none;
   overflow: visible;


### PR DESCRIPTION
## Summary
- improve popup layout by adding spacing below the search bar

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687bb7327e1c83319e80952386f510f8