### PR TITLE
Restrict context menu in popup

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1286,8 +1286,8 @@ function showContextMenu(e) {
   const inMenu = e.target.closest('#context');
 
   if (!inTabs) {
+    e.preventDefault();
     if (inMenu) {
-      e.preventDefault();
       hideContextMenu();
       showEasterEgg();
     }

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1282,6 +1282,18 @@ function clearMovePending() {
 
 
 function showContextMenu(e) {
+  const inTabs = e.target.closest('#tabs');
+  const inMenu = e.target.closest('#context');
+
+  if (!inTabs) {
+    if (inMenu) {
+      e.preventDefault();
+      hideContextMenu();
+      showEasterEgg();
+    }
+    return;
+  }
+
   e.preventDefault();
   hideAllTooltips();
   const tabEl = e.target.closest('.tab');
@@ -1343,7 +1355,6 @@ function showContextMenu(e) {
   }
 
   if (!tabEl && !selected.length) {
-    showEasterEgg();
     return;
   }
 

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1286,8 +1286,8 @@ function showContextMenu(e) {
   const inMenu = e.target.closest('#context');
 
   if (!inTabs) {
-    e.preventDefault();
     if (inMenu) {
+      e.preventDefault();
       hideContextMenu();
       showEasterEgg();
     }


### PR DESCRIPTION
## Summary
- limit custom context menu to the tab list
- trigger the hidden Easter egg only when right-clicking on the context menu

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bb88a382c8331b2079b067b45ed26