### PR TITLE
Limit context menu scope

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1063,7 +1063,9 @@ async function init() {
       scrollContainer.scrollLeft += delta * SCROLL_SPEED;
     }, { passive: false });
   }
-  document.addEventListener('contextmenu', showContextMenu);
+  const tabsEl = document.getElementById('tabs');
+  if (tabsEl) tabsEl.addEventListener('contextmenu', showContextMenu);
+  context.addEventListener('contextmenu', showContextMenu);
   container.addEventListener('dragend', clearPlaceholder);
   const { visited = [] } = await browser.storage.local.get('visited');
   visitedIds = new Set(visited);


### PR DESCRIPTION
## Summary
- ensure context menu events are only bound to the tab list element

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687bba026ec48331b0b02eec5536befb