### PR TITLE
Fix context menu outside tab list

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1286,8 +1286,8 @@ function showContextMenu(e) {
   const inMenu = e.target.closest('#context');
 
   if (!inTabs) {
+    e.preventDefault();
     if (inMenu) {
-      e.preventDefault();
       hideContextMenu();
       showEasterEgg();
     }


### PR DESCRIPTION
## Summary
- prevent the custom context menu from showing outside of the tab list

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bba026ec48331b0b02eec5536befb