### PR TITLE
Fix context menu behavior outside tab tiles

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1286,11 +1286,9 @@ function showContextMenu(e) {
   const inMenu = e.target.closest('#context');
 
   if (!inTabs) {
-    if (inMenu) {
-      e.preventDefault();
-      hideContextMenu();
-      showEasterEgg();
-    }
+    e.preventDefault();
+    hideContextMenu();
+    if (inMenu) showEasterEgg();
     return;
   }
 


### PR DESCRIPTION
## Summary
- prevent context menu outside the tab list

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687bd7d8238083318df91adcbc40880c