### PR TITLE
feat: allow tab reorder in search

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -19,6 +19,7 @@ This is an open source Firefox add-on for advanced tab management.
 - Sticky menu gains a subtle shadow while scrolling for a professional look.
 - Tab list edges fade in and out while scrolling to signal more content.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.
+- Dragging to reorder works even when the list is filtered by the search box.
 - Bulk assign selected tabs to any Firefox container or move them back to the default container.
 - Pinned and active tabs retain their state and original order when moved between windows or containers.
 - Optionally unloads inactive tabs automatically after a configurable delay.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -767,7 +767,10 @@ function filterTabs(tabs, query) {
     const score = fuzzyScore(posTitle || posUrl);
     results.push({ tab, match: posTitle, score });
   }
-  results.sort((a, b) => b.score - a.score);
+  results.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.tab.index - b.tab.index;
+  });
   return results;
 }
 


### PR DESCRIPTION
## Summary
- keep tab index order when fuzzy scores tie
- document reorder support during search

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687cceebb8e08331b5a185cef3e04563