### PR TITLE
feat: enable drag during search

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -19,6 +19,7 @@ This is an open source Firefox add-on for advanced tab management.
 - Sticky menu gains a subtle shadow while scrolling for a professional look.
 - Tab list edges fade in and out while scrolling to signal more content.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.
+- Drag and drop works while filtering tabs using the search box.
 - Bulk assign selected tabs to any Firefox container or move them back to the default container.
 - Pinned and active tabs retain their state and original order when moved between windows or containers.
 - Optionally unloads inactive tabs automatically after a configurable delay.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -756,7 +756,7 @@ function fuzzyScore(pos) {
   return cont * 10 - pos[0];
 }
 
-function filterTabs(tabs, query) {
+function filterTabs(tabs, query, sort = true) {
   const results = [];
   for (const tab of tabs) {
     const title = tab.title || '';
@@ -767,7 +767,9 @@ function filterTabs(tabs, query) {
     const score = fuzzyScore(posTitle || posUrl);
     results.push({ tab, match: posTitle, score });
   }
-  results.sort((a, b) => b.score - a.score);
+  if (sort) {
+    results.sort((a, b) => b.score - a.score);
+  }
   return results;
 }
 
@@ -841,7 +843,7 @@ async function update() {
     const query = searchInput.value.trim();
     let list;
     if (query) {
-      list = filterTabs(tabs, query);
+      list = filterTabs(tabs, query, false);
     } else {
       list = tabs.map(t => ({ tab: t }));
     }


### PR DESCRIPTION
## Summary
- keep original tab order when filtering
- allow drag and drop with active search
- document the capability in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687cceebb8e08331b5a185cef3e04563