### PR TITLE
fix: preserve manual order after search reorder

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -19,6 +19,7 @@ This is an open source Firefox add-on for advanced tab management.
 - Sticky menu gains a subtle shadow while scrolling for a professional look.
 - Tab list edges fade in and out while scrolling to signal more content.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.
+- Dragging to reorder works even when the list is filtered by the search box; the order updates instantly.
 - Bulk assign selected tabs to any Firefox container or move them back to the default container.
 - Pinned and active tabs retain their state and original order when moved between windows or containers.
 - Optionally unloads inactive tabs automatically after a configurable delay.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -35,6 +35,7 @@ let currentActiveId = -1;
 let currentVisited = new Set();
 let currentWinMap = null;
 let currentQuery = '';
+let searchOrder = null;
 // Scroll position to restore after certain operations
 let pendingScroll = null;
 // Remember horizontal scroll for each view in full window
@@ -145,6 +146,7 @@ function setView(newView) {
   view = newView;
   updateViewButtons();
   triggerViewAnimation();
+  searchOrder = null;
   scheduleUpdate();
 }
 
@@ -767,8 +769,28 @@ function filterTabs(tabs, query) {
     const score = fuzzyScore(posTitle || posUrl);
     results.push({ tab, match: posTitle, score });
   }
-  results.sort((a, b) => b.score - a.score);
+  results.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.tab.index - b.tab.index;
+  });
   return results;
+}
+
+function applySearchOrder(list) {
+  if (!searchOrder || !currentQuery) return list;
+  const map = new Map(list.map(it => [it.tab.id, it]));
+  const ordered = [];
+  for (const id of searchOrder) {
+    const item = map.get(id);
+    if (item) {
+      ordered.push(item);
+      map.delete(id);
+    }
+  }
+  for (const item of list) {
+    if (map.has(item.tab.id)) ordered.push(item);
+  }
+  return ordered;
 }
 
 function findDuplicates(tabs) {
@@ -841,7 +863,7 @@ async function update() {
     const query = searchInput.value.trim();
     let list;
     if (query) {
-      list = filterTabs(tabs, query);
+      list = applySearchOrder(filterTabs(tabs, query));
     } else {
       list = tabs.map(t => ({ tab: t }));
     }
@@ -895,6 +917,7 @@ function updateClearButton() {
 
 searchBox.addEventListener('input', () => {
   updateClearButton();
+  searchOrder = null;
   scheduleUpdate();
 });
 
@@ -904,6 +927,7 @@ clearBtn?.addEventListener('click', () => {
   if (searchBox.value) {
     searchBox.value = '';
     updateClearButton();
+    searchOrder = null;
     scheduleUpdate();
   }
 });
@@ -1615,6 +1639,21 @@ async function onContainerDrop(e) {
       toId,
       before
     }).catch(() => {});
+  }
+  if (currentQuery) {
+    if (!searchOrder) {
+      searchOrder = tabItems.filter(it => !it.separator).map(it => it.tab.id);
+    }
+    let pos = searchOrder.indexOf(toId);
+    if (!before) pos++;
+    for (const id of ids) {
+      const idx = searchOrder.indexOf(id);
+      if (idx >= 0) {
+        searchOrder.splice(idx, 1);
+        if (idx < pos) pos--;
+      }
+    }
+    searchOrder.splice(pos, 0, ...ids);
   }
   scheduleUpdate();
 }


### PR DESCRIPTION
## Summary
- preserve user-defined tab order in filtered views
- reset manual sort when the query or view changes
- update documentation about instant order update

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cceebb8e08331b5a185cef3e04563