### PR TITLE
fix: update filtered tab list after reorder

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -19,6 +19,7 @@ This is an open source Firefox add-on for advanced tab management.
 - Sticky menu gains a subtle shadow while scrolling for a professional look.
 - Tab list edges fade in and out while scrolling to signal more content.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.
+- Dragging to reorder works even when the list is filtered by the search box.
 - Bulk assign selected tabs to any Firefox container or move them back to the default container.
 - Pinned and active tabs retain their state and original order when moved between windows or containers.
 - Optionally unloads inactive tabs automatically after a configurable delay.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -767,7 +767,10 @@ function filterTabs(tabs, query) {
     const score = fuzzyScore(posTitle || posUrl);
     results.push({ tab, match: posTitle, score });
   }
-  results.sort((a, b) => b.score - a.score);
+  results.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.tab.index - b.tab.index;
+  });
   return results;
 }
 
@@ -1272,6 +1275,7 @@ async function movePendingTo(targetEl, evt) {
   }
   movePending = null;
   tabItems.forEach(it => it.el?.classList.remove('move-pending'));
+  cachedTabs = null;
   scheduleUpdate();
 }
 
@@ -1447,6 +1451,7 @@ async function bulkMove() {
       await browser.tabs.move(tab.id, { windowId: other.id, index: -1 });
     }
   }
+  cachedTabs = null;
   scheduleUpdate();
 }
 
@@ -1616,6 +1621,7 @@ async function onContainerDrop(e) {
       before
     }).catch(() => {});
   }
+  cachedTabs = null;
   scheduleUpdate();
 }
 


### PR DESCRIPTION
## Summary
- clear cached tab data after moving tabs
- ensure filtered lists refresh to show new order

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cceebb8e08331b5a185cef3e04563