### PR TITLE
fix: refresh filtered reorder list

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -19,6 +19,7 @@ This is an open source Firefox add-on for advanced tab management.
 - Sticky menu gains a subtle shadow while scrolling for a professional look.
 - Tab list edges fade in and out while scrolling to signal more content.
 - Tabs can be reordered via drag and drop, including moving multiple selected tabs at once.
+- Dragging to reorder works even when the list is filtered by the search box.
 - Bulk assign selected tabs to any Firefox container or move them back to the default container.
 - Pinned and active tabs retain their state and original order when moved between windows or containers.
 - Optionally unloads inactive tabs automatically after a configurable delay.

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -257,6 +257,10 @@ browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   refreshTabState();
 });
 
+browser.tabs.onMoved.addListener(() => {
+  refreshTabState();
+});
+
 browser.runtime.onMessage.addListener((msg) => {
   if (msg && msg.type === 'getRecent') {
     return Promise.resolve({ recent });

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -767,7 +767,10 @@ function filterTabs(tabs, query) {
     const score = fuzzyScore(posTitle || posUrl);
     results.push({ tab, match: posTitle, score });
   }
-  results.sort((a, b) => b.score - a.score);
+  results.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.tab.index - b.tab.index;
+  });
   return results;
 }
 
@@ -1187,6 +1190,7 @@ function registerTabEvents() {
   browser.tabs.onActivated.addListener(updateListener);
   browser.tabs.onDetached.addListener(updateListener);
   browser.tabs.onAttached.addListener(updateListener);
+  browser.tabs.onMoved.addListener(updateListener);
 }
 
 function unregisterTabEvents() {
@@ -1196,6 +1200,7 @@ function unregisterTabEvents() {
   browser.tabs.onActivated.removeListener(updateListener);
   browser.tabs.onDetached.removeListener(updateListener);
   browser.tabs.onAttached.removeListener(updateListener);
+  browser.tabs.onMoved.removeListener(updateListener);
 }
 
 function cleanup() {
@@ -1616,6 +1621,7 @@ async function onContainerDrop(e) {
       before
     }).catch(() => {});
   }
+  cachedTabs = null;
   scheduleUpdate();
 }
 


### PR DESCRIPTION
## Summary
- keep list up-to-date when dragging tabs in search view
- update popup event listeners for moved tabs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cceebb8e08331b5a185cef3e04563