### PR TITLE
Bump addon version to 1.1.1

### DIFF
--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "KepiTAB Manager",
 
-  "version": "1.1.0",
+  "version": "1.1.1",
 
   "browser_specific_settings": { "gecko": { "id": "kepi@addon" } },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kepi-tab",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Development tooling",
   "devDependencies": {
     "stylelint": "^15.0.0"


### PR DESCRIPTION
## Summary
- update package.json
- bump manifest version

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687cf5a6cfe08331b5ddf94bf66c6712