### PR TITLE
Fix security icon error

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -476,7 +476,7 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
 
 
   const iconCell = document.createElement('div');
-  if (tab.favIconUrl) {
+  if (tab.favIconUrl && !tab.favIconUrl.startsWith('chrome:')) {
     const icon = document.createElement('img');
     icon.className = 'tab-icon';
     icon.src = tab.favIconUrl;


### PR DESCRIPTION
## Summary
- skip invalid `chrome:` icon URLs to avoid CSP errors

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d442ab86c8331a1012b492dfa911b