### PR TITLE
Fix selection persistence when switching containers

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1528,6 +1528,10 @@ async function bulkAssignToContainer(containerId) {
         pinned: tab.pinned,
         active: tab.active
       });
+      selectedIds.delete(tab.id);
+      if (newTab && newTab.id) {
+        selectedIds.add(newTab.id);
+      }
       try {
         await browser.tabs.remove(tab.id);
       } catch (e) {


### PR DESCRIPTION
## Summary
- update container reassignment to track new tab IDs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68800e58e894833186410fb01b06afea