### PR TITLE
Add version display in options page

### DIFF
--- a/mytabs/options.html
+++ b/mytabs/options.html
@@ -47,6 +47,7 @@
   <label>Duplicates View Shortcut: <input type="text" id="key-view-dups" placeholder="Shift+D"></label> <button type="button" class="default-btn" data-for="key-view-dups">Default</button>
   <br>
   <button id="save">Save</button>
+  <div id="addon-version" class="version-info"></div>
   <script src="theme.js"></script>
   <script src="options.js"></script>
 </body>

--- a/mytabs/options.js
+++ b/mytabs/options.js
@@ -353,3 +353,12 @@ browser.storage.onChanged.addListener((changes, area) => {
 });
 
 load();
+function displayVersion() {
+  const el = document.getElementById('addon-version');
+  if (el) {
+    const version = browser.runtime.getManifest().version;
+    el.textContent = `Version ${version}`;
+  }
+}
+
+displayVersion();

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -633,3 +633,10 @@ body.full #counts.scrolled {
 #tabs.view-transition {
   animation: view-fade 0.3s ease-out;
 }
+
+.version-info {
+  text-align: center;
+  margin-top: 0.5em;
+  color: var(--color-muted);
+  font-size: 0.9em;
+}


### PR DESCRIPTION
## Summary
- show add-on version from manifest on options page
- style version display element for subtle presentation
- load version dynamically using `browser.runtime.getManifest()`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6883240949cc8331a7f4356dc2d37a96