### PR TITLE
Add collapsible window sections in Full View

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -35,7 +35,7 @@ This is an open source Firefox add-on for advanced tab management.
   - Hold **Ctrl** and use the mouse wheel to change the interface scale. The selected scale is saved and reflected in the Options page.
   - Hovering a tab's icon in the popup or Full View shows a custom tooltip with the tab title and URL, truncated for brevity. If the tab belongs to a container, the tooltip also displays the container name.
   - The columns can extend wider than the window and a horizontal scrollbar appears when needed.
-  - Tabs from each window are separated by labeled dividers with extra spacing for clarity.
+  - Tabs from each window are separated by labeled dividers with extra spacing for clarity, and each section can be collapsed by clicking its divider.
   - A colored dot indicates the tab's container.
   - Options page lets you choose theme, tile width, tile scale, font scale, close button scale and the overall UI scale and toggle features such as
   the Recent and Duplicates panels, the Move command and automatic unloading of inactive tabs.

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -36,6 +36,7 @@ let currentVisited = new Set();
 let currentWinMap = null;
 let currentQuery = '';
 let searchOrder = null;
+const collapsedWins = new Set();
 // Scroll position to restore after certain operations
 let pendingScroll = null;
 // Remember horizontal scroll for each view in full window
@@ -574,12 +575,37 @@ function createTabRow(tab, isDuplicate, activeId, isVisited, item) {
   return row;
 }
 
-function createWindowSeparator(label) {
+function createWindowSeparator(label, winId) {
   const div = document.createElement('div');
   div.className = 'window-separator';
-  div.textContent = label.toUpperCase();
   div.tabIndex = -1;
+  div.dataset.windowId = winId;
+  const arrow = document.createElement('span');
+  arrow.className = 'window-toggle';
+  arrow.textContent = collapsedWins.has(winId) ? '\u25B6' : '\u25BC';
+  const text = document.createElement('span');
+  text.textContent = label.toUpperCase();
+  div.appendChild(arrow);
+  div.appendChild(text);
+  div.addEventListener('click', () => toggleWindow(winId));
   return div;
+}
+
+function setWindowCollapsed(winId, collapse) {
+  const sep = container.querySelector(`.window-separator[data-window-id="${winId}"]`);
+  if (!sep) return;
+  let el = sep.nextElementSibling;
+  while (el && !el.classList.contains('window-separator')) {
+    el.style.display = collapse ? 'none' : '';
+    el = el.nextElementSibling;
+  }
+  const arrow = sep.querySelector('.window-toggle');
+  if (arrow) arrow.textContent = collapse ? '\u25B6' : '\u25BC';
+  if (collapse) collapsedWins.add(winId); else collapsedWins.delete(winId);
+}
+
+function toggleWindow(winId) {
+  setWindowCollapsed(winId, !collapsedWins.has(winId));
 }
 
 function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
@@ -605,7 +631,7 @@ function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
     }
     const orderedIds = Array.from(groups.keys()).sort((a, b) => (winMap.get(a) ?? 0) - (winMap.get(b) ?? 0));
     for (const winId of orderedIds) {
-      tabItems.push({ separator: true, label: `Window ${winMap.get(winId)}`, el: null });
+      tabItems.push({ separator: true, label: `Window ${winMap.get(winId)}`, winId, el: null });
       for (const entry of groups.get(winId)) {
         const tab = entry.tab ?? entry;
         const item = { tab, match: entry.match, selected: selectedIds.has(tab.id), el: null };
@@ -618,7 +644,7 @@ function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
     for (const entry of list) {
       const tab = entry.tab ?? entry;
       if (full && tab.windowId !== lastWin) {
-        tabItems.push({ separator: true, label: `Window ${winMap.get(tab.windowId)}`, el: null });
+        tabItems.push({ separator: true, label: `Window ${winMap.get(tab.windowId)}`, winId: tab.windowId, el: null });
         lastWin = tab.windowId;
       }
       const item = { tab, match: entry.match, selected: selectedIds.has(tab.id), el: null };
@@ -664,7 +690,7 @@ function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
     for (const item of tabItems) {
       let el;
       if (item.separator) {
-        el = createWindowSeparator(item.label);
+        el = createWindowSeparator(item.label, item.winId);
       } else {
         el = createTabRow(
           item.tab,
@@ -719,6 +745,9 @@ function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
     }
   }
   adjustGridWidth();
+  if (document.body.classList.contains('full')) {
+    for (const winId of collapsedWins) setWindowCollapsed(winId, true);
+  }
 }
 
 function generateRow(index) {

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -341,6 +341,12 @@ body.popup .tab > div {
   height: calc(var(--tile-height) * 0.9);
   margin: 0.5em 0;
   box-sizing: border-box;
+  cursor: pointer;
+}
+
+.window-toggle {
+  margin-right: 0.5em;
+  pointer-events: none;
 }
 button {
   padding: 0.3em 0.6em;


### PR DESCRIPTION
## Summary
- enable per-window collapsing with clickable dividers
- style dividers for interactive toggling
- document collapsible window sections in Full View

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892305520e08331b9def10d0b468beb