### PR TITLE
feat: consolidate full-view search results by window

### DIFF
--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -604,7 +604,7 @@ function renderTabs(list, activeId, dupIds, visitedIds, winMap, query = '') {
   const full = document.body.classList.contains('full') && winMap;
   tabItems = [];
   idIndexMap = new Map();
-  if (full && view === 'recent') {
+  if (full && (view === 'recent' || query)) {
     const groups = new Map();
     for (const entry of list) {
       const tab = entry.tab ?? entry;


### PR DESCRIPTION
## Summary
- group full-view search results under their existing windows to avoid repeated separators

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689233e5f2188331b585c48aaac100c6