### PR TITLE
fix: show full view shortcut in action tooltip

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -154,7 +154,7 @@ browser.tabs.query({}).then(tabs => {
       try { await browser.commands.update({ name: 'unload-all-tabs', shortcut: keyUnloadAll }); } catch (_) {}
     }
     if (action && action.setTitle) {
-      action.setTitle({ title: `KepiTAB Manager (${keyOpenPopup})` });
+      action.setTitle({ title: `KepiTAB Manager (${keyOpenFull})` });
     }
   } catch (e) {
     console.error('Failed to apply shortcuts', e);


### PR DESCRIPTION
## Summary
- reference full view keybinding in extension action title

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a85b8cfc9083319cb2a4d8f04d3211