### PR TITLE
fix: improve popup bulk action spacing

### DIFF
--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -484,10 +484,13 @@ body[data-theme="dark"] .tab-tooltip.left::after {
 
 #bulk-actions {
   margin-top: 0.5em;
-  text-align: right;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+  justify-content: flex-end;
 }
 #bulk-actions button {
-  margin-left: 0.2em;
+  margin-left: 0;
 }
 
 


### PR DESCRIPTION
## Summary
- increase spacing between container dropdown and bulk action buttons in popup

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a85fdd39c88331a8cb3b27c8b86fcd