### PR TITLE
Ensure startup tabs populate recent history

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -129,7 +129,17 @@ browser.runtime.onStartup.addListener(async () => {
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
   visited = new Set();
   recent = [];
+  try {
+    const activeTabs = await browser.tabs.query({ windowType: 'normal', active: true });
+    for (const tab of activeTabs) {
+      pushRecent(tab.id);
+      markVisited(tab.id);
+    }
+  } catch (e) {
+    console.error('Failed to seed active tabs after startup', e);
+  }
   sendVisitedUpdate();
+  refreshTabState();
 });
 
 // Listen for settings changes


### PR DESCRIPTION
## Summary
- seed the recent and visited caches with active tabs after startup resets
- refresh the shared tab state so restored tabs immediately appear as visited

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbffbb4c708331a064c2d9ca8078c6