### PR TITLE
Add full view option to browser action context menu

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -384,6 +384,11 @@ browser.runtime.onInstalled.addListener(async () => {
     contexts: ['browser_action']
   });
   await browser.contextMenus.create({
+    id: 'open-full-view',
+    title: 'Open Full View',
+    contexts: ['browser_action']
+  });
+  await browser.contextMenus.create({
     id: 'open-options',
     title: 'Options',
     contexts: ['browser_action']
@@ -391,6 +396,10 @@ browser.runtime.onInstalled.addListener(async () => {
 });
 
 browser.contextMenus.onClicked.addListener((info) => {
+  if (info.menuItemId === 'open-full-view') {
+    openFullView();
+    return;
+  }
   if (info.menuItemId === 'open-options') {
     browser.runtime.openOptionsPage();
   }


### PR DESCRIPTION
## Summary
- add a browser action context menu entry that opens the full tab manager view
- invoke the existing full-view logic when the new context menu option is clicked

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6effe183c83319449222154e7d841