### PR TITLE
Add full view toggle to browser action context menu

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -384,6 +384,11 @@ browser.runtime.onInstalled.addListener(async () => {
     contexts: ['browser_action']
   });
   await browser.contextMenus.create({
+    id: 'open-full-view',
+    title: 'Open Full View',
+    contexts: ['browser_action']
+  });
+  await browser.contextMenus.create({
     id: 'open-options',
     title: 'Options',
     contexts: ['browser_action']
@@ -391,7 +396,9 @@ browser.runtime.onInstalled.addListener(async () => {
 });
 
 browser.contextMenus.onClicked.addListener((info) => {
-  if (info.menuItemId === 'open-options') {
+  if (info.menuItemId === 'open-full-view') {
+    openFullView();
+  } else if (info.menuItemId === 'open-options') {
     browser.runtime.openOptionsPage();
   }
 });

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -285,6 +285,8 @@ browser.runtime.onMessage.addListener((msg) => {
     reorderRecent(msg.ids || [], msg.toId, msg.before);
   } else if (msg && msg.type === 'clearVisitHistory') {
     clearVisitHistory();
+  } else if (msg && msg.type === 'openFullView') {
+    return openFullView();
   }
 });
 

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1409,6 +1409,7 @@ function showContextMenu(e) {
   }
 
   addItem('Unload All Tabs', bulkUnloadAll);
+  addItem('Open Full View', () => browser.runtime.sendMessage({ type: 'openFullView' }));
   addItem('Options', () => browser.runtime.openOptionsPage());
 
   context.style.left = e.pageX + 'px';


### PR DESCRIPTION
## Summary
- add a browser action context menu item that opens the extension's full view
- invoke the existing full view logic when the new context menu item is selected

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6effe183c83319449222154e7d841