### PR TITLE
Improve tab unload helper compatibility

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -328,7 +328,7 @@ async function unloadAllTabs() {
   await Promise.all(tabs.filter(t => !t.discarded)
     .map(async t => {
       try {
-        await browser.tabs.discard(t.id);
+        await unloadTabWithFallback(t.id);
       } catch (_) {}
     }));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
@@ -345,7 +345,7 @@ async function checkAutoUnload() {
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
         try {
-          await browser.tabs.discard(t.id);
+          await unloadTabWithFallback(t.id);
           unmarkVisited(t.id);
         } catch (_) {}
       }

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -18,7 +18,7 @@
     ],
   "background": {
 
-    "scripts": ["background.js"]
+    "scripts": ["tab-utils.js", "background.js"]
   },
   "action": {
     "default_title": "KepiTAB Manager",

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -44,6 +44,7 @@
   <div id="context" class="hidden"></div>
   <script src="theme.js"></script>
   <script src="hyperlist.js"></script>
+  <script src="tab-utils.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1396,7 +1396,7 @@ function showContextMenu(e) {
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
       try {
-        await browser.tabs.discard(id);
+        await unloadTabWithFallback(id);
         await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
       } catch (_) {}
       scheduleUpdate();
@@ -1469,7 +1469,7 @@ async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
     try {
-      await browser.tabs.discard(id);
+      await unloadTabWithFallback(id);
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
     } catch (_) {}
   }));
@@ -1480,7 +1480,7 @@ async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.map(async t => {
     try {
-      await browser.tabs.discard(t.id);
+      await unloadTabWithFallback(t.id);
     } catch (_) {}
   }));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });

--- a/mytabs/tab-utils.js
+++ b/mytabs/tab-utils.js
@@ -1,0 +1,110 @@
+(function(global) {
+  'use strict';
+
+  const root = typeof global !== 'undefined' ? global : typeof globalThis !== 'undefined' ? globalThis : undefined;
+
+  function getTabsApi() {
+    const globalObject = root || (typeof self !== 'undefined' ? self : undefined);
+    if (!globalObject) {
+      return undefined;
+    }
+    if (globalObject.browser && globalObject.browser.tabs) {
+      return globalObject.browser.tabs;
+    }
+    if (globalObject.chrome && globalObject.chrome.tabs) {
+      return globalObject.chrome.tabs;
+    }
+    return undefined;
+  }
+
+  async function tryTabsCall(fn, tabId) {
+    if (typeof fn !== 'function') {
+      throw new Error('The provided tabs API function is not callable');
+    }
+
+    const attempts = [
+      () => fn.call(null, tabId),
+      () => fn.call(null, [tabId]),
+      () => fn.call(null, { tabIds: [tabId] }),
+      () => fn.call(null, { tabId })
+    ];
+
+    let lastError;
+    for (const invoke of attempts) {
+      try {
+        return await invoke();
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    throw lastError || new Error('Unknown error invoking tabs API');
+  }
+
+  function didUnloadTab(result, tabId) {
+    if (typeof result === 'undefined' || result === null) {
+      return true;
+    }
+    if (Array.isArray(result)) {
+      return result.some(tab => tab && tab.id === tabId);
+    }
+    if (typeof result === 'object') {
+      if (typeof result.id === 'number') {
+        return result.id === tabId;
+      }
+      if (Array.isArray(result.tabs)) {
+        return result.tabs.some(tab => tab && tab.id === tabId);
+      }
+    }
+    return false;
+  }
+
+  async function ensureDiscardedState(tabsApi, tabId) {
+    try {
+      const tab = await tabsApi.get(tabId);
+      if (tab && (tab.discarded === true || tab.status === 'unloaded')) {
+        return true;
+      }
+    } catch (_) {
+      // Ignore lookup errors and fall back to discard below
+    }
+    return false;
+  }
+
+  async function unloadTabWithFallback(tabId) {
+    const tabsApi = getTabsApi();
+    if (!tabsApi) {
+      throw new Error('browser.tabs API is unavailable');
+    }
+
+    let unloadError;
+    if (typeof tabsApi.unload === 'function') {
+      try {
+        const result = await tryTabsCall(tabsApi.unload.bind(tabsApi), tabId);
+        if (didUnloadTab(result, tabId)) {
+          return;
+        }
+        if (await ensureDiscardedState(tabsApi, tabId)) {
+          return;
+        }
+      } catch (error) {
+        unloadError = error;
+      }
+    }
+
+    if (typeof tabsApi.discard === 'function') {
+      try {
+        await tryTabsCall(tabsApi.discard.bind(tabsApi), tabId);
+        return;
+      } catch (discardError) {
+        throw discardError;
+      }
+    }
+
+    throw unloadError || new Error('Neither browser.tabs.unload nor browser.tabs.discard is available');
+  }
+
+  if (root) {
+    root.unloadTabWithFallback = unloadTabWithFallback;
+  }
+})(typeof window !== 'undefined' ? window : typeof self !== 'undefined' ? self : this);


### PR DESCRIPTION
## Summary
- enhance the shared tab unload helper to support multiple argument signatures for the new API
- verify unload success and fall back to discard, including explicit state checks, when unload fails
- expose the helper on the detected global object for broader context compatibility

## Testing
- not run (not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68f08ff63a748331bfe831fb8606e981