### PR TITLE
Improve tab unload helper reliability

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -328,7 +328,7 @@ async function unloadAllTabs() {
   await Promise.all(tabs.filter(t => !t.discarded)
     .map(async t => {
       try {
-        await browser.tabs.discard(t.id);
+        await unloadTabWithFallback(t.id);
       } catch (_) {}
     }));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
@@ -345,7 +345,7 @@ async function checkAutoUnload() {
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
         try {
-          await browser.tabs.discard(t.id);
+          await unloadTabWithFallback(t.id);
           unmarkVisited(t.id);
         } catch (_) {}
       }

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -45,6 +45,7 @@
 
     <script src="theme.js"></script>
     <script src="hyperlist.js"></script>
+    <script src="tab-utils.js"></script>
     <script src="popup.js"></script>
     <script src="fullwin.js"></script>
     <!-- layout handled via CSS grid -->

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -18,7 +18,7 @@
     ],
   "background": {
 
-    "scripts": ["background.js"]
+    "scripts": ["tab-utils.js", "background.js"]
   },
   "action": {
     "default_title": "KepiTAB Manager",

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -44,6 +44,7 @@
   <div id="context" class="hidden"></div>
   <script src="theme.js"></script>
   <script src="hyperlist.js"></script>
+  <script src="tab-utils.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1396,7 +1396,7 @@ function showContextMenu(e) {
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
       try {
-        await browser.tabs.discard(id);
+        await unloadTabWithFallback(id);
         await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
       } catch (_) {}
       scheduleUpdate();
@@ -1469,7 +1469,7 @@ async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
     try {
-      await browser.tabs.discard(id);
+      await unloadTabWithFallback(id);
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
     } catch (_) {}
   }));
@@ -1480,7 +1480,7 @@ async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.map(async t => {
     try {
-      await browser.tabs.discard(t.id);
+      await unloadTabWithFallback(t.id);
     } catch (_) {}
   }));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });

--- a/mytabs/sidebar.html
+++ b/mytabs/sidebar.html
@@ -13,6 +13,7 @@
   <div id="tabs"></div>
 
   <script src="theme.js"></script>
+  <script src="tab-utils.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/mytabs/tab-utils.js
+++ b/mytabs/tab-utils.js
@@ -1,0 +1,61 @@
+(function(global) {
+  'use strict';
+
+  function resolveGlobalTabsApi(context) {
+    if (!context || !context.browser || !context.browser.tabs) {
+      throw new Error('browser.tabs API is unavailable');
+    }
+    return context.browser.tabs;
+  }
+
+  async function hasTabBeenDiscarded(tabsApi, tabId) {
+    try {
+      const tab = await tabsApi.get(tabId);
+      return !tab || tab.discarded === true;
+    } catch (_) {
+      // Treat lookup failures (e.g., tab closed) as a success case.
+      return true;
+    }
+  }
+
+  function isIdInArrayCandidate(candidate, tabId) {
+    return Array.isArray(candidate) && candidate.includes(tabId);
+  }
+
+  async function unloadTabWithFallback(tabId) {
+    const tabsApi = resolveGlobalTabsApi(global);
+
+    let unloadError = null;
+    if (typeof tabsApi.unload === 'function') {
+      try {
+        const result = await tabsApi.unload(tabId);
+        const succeeded = await hasTabBeenDiscarded(tabsApi, tabId)
+          || (result && typeof result === 'object'
+            && (
+              isIdInArrayCandidate(result.unloadedTabIds, tabId)
+              || isIdInArrayCandidate(result.unloadedTabs, tabId)
+              || (Array.isArray(result.notUnloadedTabIds) && !result.notUnloadedTabIds.includes(tabId))
+            ));
+        if (succeeded) {
+          return result;
+        }
+      } catch (error) {
+        unloadError = error;
+      }
+    }
+
+    if (typeof tabsApi.discard === 'function') {
+      return tabsApi.discard(tabId);
+    }
+
+    if (unloadError) {
+      throw unloadError;
+    }
+
+    throw new Error('Neither browser.tabs.unload nor browser.tabs.discard is available');
+  }
+
+  if (typeof global !== 'undefined') {
+    global.unloadTabWithFallback = unloadTabWithFallback;
+  }
+})(typeof window !== 'undefined' ? window : (typeof self !== 'undefined' ? self : this));


### PR DESCRIPTION
## Summary
- verify tab unload attempts succeed before falling back and surface original errors when discard is unavailable
- load the shared helper in all tab manager surfaces so unload actions always resolve

## Testing
- not run (not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68f08ff63a748331bfe831fb8606e981