### PR TITLE
Refine tab unload helper fallback detection

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -328,7 +328,7 @@ async function unloadAllTabs() {
   await Promise.all(tabs.filter(t => !t.discarded)
     .map(async t => {
       try {
-        await browser.tabs.discard(t.id);
+        await unloadTabWithFallback(t.id);
       } catch (_) {}
     }));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
@@ -345,7 +345,7 @@ async function checkAutoUnload() {
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
         try {
-          await browser.tabs.discard(t.id);
+          await unloadTabWithFallback(t.id);
           unmarkVisited(t.id);
         } catch (_) {}
       }

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -18,7 +18,7 @@
     ],
   "background": {
 
-    "scripts": ["background.js"]
+    "scripts": ["tab-utils.js", "background.js"]
   },
   "action": {
     "default_title": "KepiTAB Manager",

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -44,6 +44,7 @@
   <div id="context" class="hidden"></div>
   <script src="theme.js"></script>
   <script src="hyperlist.js"></script>
+  <script src="tab-utils.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1396,7 +1396,7 @@ function showContextMenu(e) {
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
       try {
-        await browser.tabs.discard(id);
+        await unloadTabWithFallback(id);
         await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
       } catch (_) {}
       scheduleUpdate();
@@ -1469,7 +1469,7 @@ async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
     try {
-      await browser.tabs.discard(id);
+      await unloadTabWithFallback(id);
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
     } catch (_) {}
   }));
@@ -1480,7 +1480,7 @@ async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.map(async t => {
     try {
-      await browser.tabs.discard(t.id);
+      await unloadTabWithFallback(t.id);
     } catch (_) {}
   }));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });

--- a/mytabs/tab-utils.js
+++ b/mytabs/tab-utils.js
@@ -1,0 +1,77 @@
+(function(global) {
+  'use strict';
+
+  function getTabsApi(scope) {
+    if (!scope || !scope.browser || !scope.browser.tabs) {
+      throw new Error('browser.tabs API is unavailable');
+    }
+    return scope.browser.tabs;
+  }
+
+  async function wasTabDiscarded(tabsApi, tabId, unloadResult) {
+    if (Array.isArray(unloadResult)) {
+      if (unloadResult.some(tab => tab && tab.id === tabId && tab.discarded)) {
+        return true;
+      }
+      if (unloadResult.length > 0) {
+        return true;
+      }
+    } else if (unloadResult && typeof unloadResult === 'object') {
+      if (typeof unloadResult.discarded === 'boolean') {
+        return unloadResult.discarded;
+      }
+      if (typeof unloadResult.success === 'boolean') {
+        return unloadResult.success;
+      }
+      if (typeof unloadResult.id === 'number' && unloadResult.id === tabId) {
+        return true;
+      }
+    }
+
+    try {
+      const tab = await tabsApi.get(tabId);
+      return !tab || !!tab.discarded;
+    } catch (_) {
+      // If the tab can no longer be retrieved, assume it was successfully unloaded.
+      return true;
+    }
+  }
+
+  async function unloadTabWithFallback(tabId) {
+    const tabsApi = getTabsApi(global);
+
+    let unloadError;
+    if (typeof tabsApi.unload === 'function') {
+      try {
+        const result = await tabsApi.unload(tabId);
+        if (await wasTabDiscarded(tabsApi, tabId, result)) {
+          return;
+        }
+      } catch (error) {
+        unloadError = error;
+      }
+    }
+
+    if (typeof tabsApi.discard === 'function') {
+      try {
+        await tabsApi.discard(tabId);
+        return;
+      } catch (discardError) {
+        if (unloadError) {
+          discardError.previousError = unloadError;
+        }
+        throw discardError;
+      }
+    }
+
+    if (unloadError) {
+      throw unloadError;
+    }
+
+    throw new Error('Neither browser.tabs.unload nor browser.tabs.discard is available');
+  }
+
+  if (typeof global !== 'undefined') {
+    global.unloadTabWithFallback = unloadTabWithFallback;
+  }
+})(typeof window !== 'undefined' ? window : (typeof self !== 'undefined' ? self : this));


### PR DESCRIPTION
## Summary
- enhance the shared tab unload helper to verify whether tabs were actually discarded when using browser.tabs.unload
- ensure the helper falls back to browser.tabs.discard when unload reports success without unloading

## Testing
- not run (not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68f08ff63a748331bfe831fb8606e981