### PR TITLE
Improve unload fallback detection for Firefox API

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -328,7 +328,7 @@ async function unloadAllTabs() {
   await Promise.all(tabs.filter(t => !t.discarded)
     .map(async t => {
       try {
-        await browser.tabs.discard(t.id);
+        await unloadTabWithFallback(t.id);
       } catch (_) {}
     }));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
@@ -345,7 +345,7 @@ async function checkAutoUnload() {
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
         try {
-          await browser.tabs.discard(t.id);
+          await unloadTabWithFallback(t.id);
           unmarkVisited(t.id);
         } catch (_) {}
       }

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -18,7 +18,7 @@
     ],
   "background": {
 
-    "scripts": ["background.js"]
+    "scripts": ["tab-utils.js", "background.js"]
   },
   "action": {
     "default_title": "KepiTAB Manager",

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -44,6 +44,7 @@
   <div id="context" class="hidden"></div>
   <script src="theme.js"></script>
   <script src="hyperlist.js"></script>
+  <script src="tab-utils.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1396,7 +1396,7 @@ function showContextMenu(e) {
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
       try {
-        await browser.tabs.discard(id);
+        await unloadTabWithFallback(id);
         await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
       } catch (_) {}
       scheduleUpdate();
@@ -1469,7 +1469,7 @@ async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
     try {
-      await browser.tabs.discard(id);
+      await unloadTabWithFallback(id);
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
     } catch (_) {}
   }));
@@ -1480,7 +1480,7 @@ async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.map(async t => {
     try {
-      await browser.tabs.discard(t.id);
+      await unloadTabWithFallback(t.id);
     } catch (_) {}
   }));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });

--- a/mytabs/tab-utils.js
+++ b/mytabs/tab-utils.js
@@ -1,0 +1,87 @@
+(function(global) {
+  'use strict';
+
+  function hasTabBeenUnloaded(tab) {
+    if (!tab || typeof tab !== 'object') {
+      return false;
+    }
+
+    if (tab.discarded) {
+      return true;
+    }
+
+    const { status } = tab;
+    if (typeof status === 'string' && status.toLowerCase() === 'unloaded') {
+      return true;
+    }
+
+    return false;
+  }
+
+  function resultImpliesUnload(value) {
+    if (Array.isArray(value)) {
+      return value.some(resultImpliesUnload);
+    }
+
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    return hasTabBeenUnloaded(value);
+  }
+
+  async function unloadTabWithFallback(tabId) {
+    const tabsApi = global && global.browser && global.browser.tabs;
+    if (!tabsApi) {
+      throw new Error('browser.tabs API is unavailable');
+    }
+
+    if (typeof tabsApi.unload === 'function') {
+      try {
+        const result = await tabsApi.unload(tabId);
+
+        // Firefox may resolve with a tab-like object. If it reports the tab as
+        // discarded or unloaded we can stop early.
+        if (resultImpliesUnload(result)) {
+          return result;
+        }
+
+        // Some Firefox versions resolve without discarding the tab (for
+        // example, when the feature is behind a pref). Double-check the tab
+        // state before falling back so we retain legacy behaviour.
+        const ensureTabInfo = async () => {
+          try {
+            return await tabsApi.get(tabId);
+          } catch (_) {
+            return null;
+          }
+        };
+
+        let tabInfo = await ensureTabInfo();
+        if (!tabInfo || hasTabBeenUnloaded(tabInfo)) {
+          return result;
+        }
+
+        // Give the browser a moment to update the tab state before assuming
+        // the unload failed.
+        await new Promise(resolve => setTimeout(resolve, 50));
+        tabInfo = await ensureTabInfo();
+        if (!tabInfo || hasTabBeenUnloaded(tabInfo)) {
+          return result;
+        }
+      } catch (error) {
+        // Fall back to discard below if unload fails (e.g., unsupported tab state)
+      }
+    }
+
+    if (typeof tabsApi.discard === 'function') {
+      return tabsApi.discard(tabId);
+    }
+
+    throw new Error('Neither browser.tabs.unload nor browser.tabs.discard is available');
+  }
+
+  if (typeof global !== 'undefined') {
+    global.unloadTabWithFallback = unloadTabWithFallback;
+  }
+})(typeof window !== 'undefined' ? window : (typeof self !== 'undefined' ? self : this));


### PR DESCRIPTION
## Summary
- treat the result of `browser.tabs.unload` as successful when it returns unloaded tab metadata instead of relying solely on the discarded flag
- support boolean and array responses from the unload API when deciding whether to fall back to legacy discarding

## Testing
- not run (not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68f08ff63a748331bfe831fb8606e981