### PR TITLE
Adjust unload helper to rely on Firefox API behavior

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -328,7 +328,7 @@ async function unloadAllTabs() {
   await Promise.all(tabs.filter(t => !t.discarded)
     .map(async t => {
       try {
-        await browser.tabs.discard(t.id);
+        await unloadTabWithFallback(t.id);
       } catch (_) {}
     }));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
@@ -345,7 +345,7 @@ async function checkAutoUnload() {
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
         try {
-          await browser.tabs.discard(t.id);
+          await unloadTabWithFallback(t.id);
           unmarkVisited(t.id);
         } catch (_) {}
       }

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -18,7 +18,7 @@
     ],
   "background": {
 
-    "scripts": ["background.js"]
+    "scripts": ["tab-utils.js", "background.js"]
   },
   "action": {
     "default_title": "KepiTAB Manager",

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -44,6 +44,7 @@
   <div id="context" class="hidden"></div>
   <script src="theme.js"></script>
   <script src="hyperlist.js"></script>
+  <script src="tab-utils.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1396,7 +1396,7 @@ function showContextMenu(e) {
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
       try {
-        await browser.tabs.discard(id);
+        await unloadTabWithFallback(id);
         await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
       } catch (_) {}
       scheduleUpdate();
@@ -1469,7 +1469,7 @@ async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
     try {
-      await browser.tabs.discard(id);
+      await unloadTabWithFallback(id);
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
     } catch (_) {}
   }));
@@ -1480,7 +1480,7 @@ async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.map(async t => {
     try {
-      await browser.tabs.discard(t.id);
+      await unloadTabWithFallback(t.id);
     } catch (_) {}
   }));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });

--- a/mytabs/tab-utils.js
+++ b/mytabs/tab-utils.js
@@ -1,0 +1,55 @@
+(function(global) {
+  'use strict';
+
+  async function unloadTabWithFallback(tabId) {
+    const tabsApi = global && global.browser && global.browser.tabs;
+    if (!tabsApi) {
+      throw new Error('browser.tabs API is unavailable');
+    }
+
+    if (typeof tabsApi.unload === 'function') {
+      const maybeArgumentError = (error) => {
+        if (!error) return false;
+        if (error.name === 'TypeError') return true;
+        const message = String(error.message || error);
+        return /tabIds|arguments|requires/i.test(message);
+      };
+
+      const isUnsupportedError = (error) => {
+        if (!error) return false;
+        const message = String(error.message || error);
+        return /unavailable|not supported|not implemented|unsupported/i.test(message);
+      };
+
+      const callVariants = [
+        () => tabsApi.unload(tabId),
+        () => tabsApi.unload([tabId])
+      ];
+
+      for (let i = 0; i < callVariants.length; i++) {
+        try {
+          return await callVariants[i]();
+        } catch (error) {
+          if (i < callVariants.length - 1 && maybeArgumentError(error)) {
+            continue;
+          }
+          if (isUnsupportedError(error)) {
+            break;
+          }
+          // Fall back to discard below if unload fails (e.g., unsupported tab state)
+          break;
+        }
+      }
+    }
+
+    if (typeof tabsApi.discard === 'function') {
+      return tabsApi.discard(tabId);
+    }
+
+    throw new Error('Neither browser.tabs.unload nor browser.tabs.discard is available');
+  }
+
+  if (typeof global !== 'undefined') {
+    global.unloadTabWithFallback = unloadTabWithFallback;
+  }
+})(typeof window !== 'undefined' ? window : (typeof self !== 'undefined' ? self : this));


### PR DESCRIPTION
## Summary
- simplify the shared unload helper to trust successful browser.tabs.unload resolutions
- keep the fallback to browser.tabs.discard only for explicit failures or unsupported environments

## Testing
- not run (not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68f08ff63a748331bfe831fb8606e981