### PR TITLE
Broaden unload helper compatibility with Firefox unload API

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -328,7 +328,7 @@ async function unloadAllTabs() {
   await Promise.all(tabs.filter(t => !t.discarded)
     .map(async t => {
       try {
-        await browser.tabs.discard(t.id);
+        await unloadTabWithFallback(t.id);
       } catch (_) {}
     }));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
@@ -345,7 +345,7 @@ async function checkAutoUnload() {
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
         try {
-          await browser.tabs.discard(t.id);
+          await unloadTabWithFallback(t.id);
           unmarkVisited(t.id);
         } catch (_) {}
       }

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -18,7 +18,7 @@
     ],
   "background": {
 
-    "scripts": ["background.js"]
+    "scripts": ["tab-utils.js", "background.js"]
   },
   "action": {
     "default_title": "KepiTAB Manager",

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -44,6 +44,7 @@
   <div id="context" class="hidden"></div>
   <script src="theme.js"></script>
   <script src="hyperlist.js"></script>
+  <script src="tab-utils.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1396,7 +1396,7 @@ function showContextMenu(e) {
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
       try {
-        await browser.tabs.discard(id);
+        await unloadTabWithFallback(id);
         await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
       } catch (_) {}
       scheduleUpdate();
@@ -1469,7 +1469,7 @@ async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
     try {
-      await browser.tabs.discard(id);
+      await unloadTabWithFallback(id);
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
     } catch (_) {}
   }));
@@ -1480,7 +1480,7 @@ async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.map(async t => {
     try {
-      await browser.tabs.discard(t.id);
+      await unloadTabWithFallback(t.id);
     } catch (_) {}
   }));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });

--- a/mytabs/tab-utils.js
+++ b/mytabs/tab-utils.js
@@ -1,0 +1,102 @@
+(function(global) {
+  'use strict';
+
+  async function unloadTabWithFallback(tabId) {
+    const tabsApi = global && global.browser && global.browser.tabs;
+    if (!tabsApi) {
+      throw new Error('browser.tabs API is unavailable');
+    }
+
+    const waitForUnloadState = async () => {
+      const maxAttempts = 5;
+      const delay = 100;
+
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        let tabInfo = null;
+        try {
+          tabInfo = await tabsApi.get(tabId);
+        } catch (_) {
+          return true;
+        }
+
+        if (!tabInfo) {
+          return true;
+        }
+
+        if (tabInfo.discarded || tabInfo.status === 'unloaded' || tabInfo.unloaded === true) {
+          return true;
+        }
+
+        if (attempt < maxAttempts - 1) {
+          await new Promise(resolve => setTimeout(resolve, delay));
+        }
+      }
+
+      return false;
+    };
+
+    const maybeArgumentError = (error) => {
+      if (!error) {
+        return false;
+      }
+      if (error.name === 'TypeError') {
+        return true;
+      }
+      const message = String(error.message || error);
+      return /tabIds|arguments|requires|is not iterable|sequence/i.test(message);
+    };
+
+    const maybeUnsupportedError = (error) => {
+      if (!error) {
+        return false;
+      }
+      const message = String(error.message || error);
+      return /not implemented|not supported|unsupported|no such function/i.test(message);
+    };
+
+    let unloadAttempted = false;
+    let lastError = null;
+
+    if (typeof tabsApi.unload === 'function') {
+      const callVariants = [
+        () => tabsApi.unload(tabId),
+        () => tabsApi.unload([tabId]),
+        () => tabsApi.unload({ tabIds: [tabId] })
+      ];
+
+      for (let i = 0; i < callVariants.length; i++) {
+        try {
+          unloadAttempted = true;
+          const result = await callVariants[i]();
+          if (await waitForUnloadState()) {
+            return result;
+          }
+        } catch (error) {
+          lastError = error;
+          if (maybeArgumentError(error) && i < callVariants.length - 1) {
+            continue;
+          }
+          if (maybeUnsupportedError(error)) {
+            break;
+          }
+          // For other failures keep lastError for potential reporting below.
+          break;
+        }
+      }
+    }
+
+    if (typeof tabsApi.discard === 'function') {
+      return tabsApi.discard(tabId);
+    }
+
+    if (lastError && unloadAttempted) {
+      throw lastError;
+    }
+
+    throw new Error('Neither browser.tabs.unload nor browser.tabs.discard is available');
+  }
+
+  if (typeof global !== 'undefined') {
+    global.unloadTabWithFallback = unloadTabWithFallback;
+  }
+})(typeof window !== 'undefined' ? window : (typeof self !== 'undefined' ? self : this));


### PR DESCRIPTION
## Summary
- broaden the shared unload helper to try array and object signatures when calling `browser.tabs.unload`
- refine unload state polling and error classification so unsupported browsers fall back to `browser.tabs.discard`

## Testing
- not run (not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68f08ff63a748331bfe831fb8606e981