### PR TITLE
Use Firefox native tab unload API when available

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -8,6 +8,40 @@ let recentTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
+async function unloadTabById(tabId) {
+  if (typeof tabId !== 'number') return false;
+
+  const unload = browser.tabs && browser.tabs.unload;
+  if (typeof unload === 'function') {
+    const attempts = [
+      () => unload.call(browser.tabs, tabId)
+    ];
+    // Try object-based signature for forward compatibility.
+    attempts.push(() => unload.call(browser.tabs, { tabId }));
+
+    for (const attempt of attempts) {
+      try {
+        const result = attempt();
+        if (result && typeof result.then === 'function') {
+          await result;
+        }
+        return true;
+      } catch (_) {
+        // Try the next available signature or fallback below.
+      }
+    }
+  }
+
+  if (browser.tabs.discard) {
+    try {
+      await browser.tabs.discard(tabId);
+      return true;
+    } catch (_) {}
+  }
+
+  return false;
+}
+
 async function applyAutoDiscardable() {
   try {
     const tabs = await browser.tabs.query({});
@@ -326,11 +360,7 @@ async function openFullView() {
 async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.filter(t => !t.discarded)
-    .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
-    }));
+    .map(t => unloadTabById(t.id)));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
   visited = new Set();
   recent = [];
@@ -344,10 +374,10 @@ async function checkAutoUnload() {
     const tabs = await browser.tabs.query({});
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
-        try {
-          await browser.tabs.discard(t.id);
+        const unloaded = await unloadTabById(t.id);
+        if (unloaded) {
           unmarkVisited(t.id);
-        } catch (_) {}
+        }
       }
     }));
   } catch (e) {

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -45,6 +45,37 @@ const popupScrollPos = { all: 0, recent: 0, dups: 0 };
 let easterEgg;
 const collapsedWins = new Set();
 
+async function unloadTabWithFallback(tabId) {
+  if (typeof tabId !== 'number') return false;
+
+  const unload = browser.tabs && browser.tabs.unload;
+  if (typeof unload === 'function') {
+    const attempts = [
+      () => unload.call(browser.tabs, tabId)
+    ];
+    attempts.push(() => unload.call(browser.tabs, { tabId }));
+
+    for (const attempt of attempts) {
+      try {
+        const result = attempt();
+        if (result && typeof result.then === 'function') {
+          await result;
+        }
+        return true;
+      } catch (_) {}
+    }
+  }
+
+  if (browser.tabs.discard) {
+    try {
+      await browser.tabs.discard(tabId);
+      return true;
+    } catch (_) {}
+  }
+
+  return false;
+}
+
 function showEasterEgg() {
   if (!easterEgg || easterEgg.classList.contains('visible')) return;
   const hide = () => {
@@ -1395,10 +1426,10 @@ function showContextMenu(e) {
     });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
-      try {
-        await browser.tabs.discard(id);
+      const unloaded = await unloadTabWithFallback(id);
+      if (unloaded) {
         await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
+      }
       scheduleUpdate();
     });
     // Direct move option removed in favor of flagged move workflow
@@ -1468,21 +1499,17 @@ async function bulkActivate() {
 async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
-    try {
-      await browser.tabs.discard(id);
+    const unloaded = await unloadTabWithFallback(id);
+    if (unloaded) {
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-    } catch (_) {}
+    }
   }));
   scheduleUpdate();
 }
 
 async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.map(async t => {
-    try {
-      await browser.tabs.discard(t.id);
-    } catch (_) {}
-  }));
+  await Promise.all(tabs.map(t => unloadTabWithFallback(t.id)));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
   scheduleUpdate();
 }


### PR DESCRIPTION
## Summary
- add helper functions that prefer the new `browser.tabs.unload` API with a graceful fallback to `browser.tabs.discard`
- update background auto-unload and bulk unload routines to use the helper so they mirror Firefox’s native Unload Tab behavior
- adjust popup actions to rely on the helper and only clear visit history when an unload succeeds

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f0b68f59b88331942e0fdde1721cfd