### PR TITLE
Integrate Firefox native Unload Tab support

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -8,6 +8,20 @@ let recentTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
+async function unloadTabById(tabId) {
+  try {
+    if (browser.tabs && typeof browser.tabs.unload === 'function') {
+      await browser.tabs.unload(tabId);
+      return true;
+    }
+    if (browser.tabs && typeof browser.tabs.discard === 'function') {
+      await browser.tabs.discard(tabId);
+      return true;
+    }
+  } catch (_) {}
+  return false;
+}
+
 async function applyAutoDiscardable() {
   try {
     const tabs = await browser.tabs.query({});
@@ -325,12 +339,9 @@ async function openFullView() {
 
 async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.filter(t => !t.discarded)
-    .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
-    }));
+  await Promise.all(tabs
+    .filter(t => !t.discarded)
+    .map(t => unloadTabById(t.id)));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
   visited = new Set();
   recent = [];
@@ -344,10 +355,9 @@ async function checkAutoUnload() {
     const tabs = await browser.tabs.query({});
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
-        try {
-          await browser.tabs.discard(t.id);
+        if (await unloadTabById(t.id)) {
           unmarkVisited(t.id);
-        } catch (_) {}
+        }
       }
     }));
   } catch (e) {

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -45,6 +45,20 @@ const popupScrollPos = { all: 0, recent: 0, dups: 0 };
 let easterEgg;
 const collapsedWins = new Set();
 
+async function unloadTab(tabId) {
+  try {
+    if (browser.tabs && typeof browser.tabs.unload === 'function') {
+      await browser.tabs.unload(tabId);
+      return true;
+    }
+    if (browser.tabs && typeof browser.tabs.discard === 'function') {
+      await browser.tabs.discard(tabId);
+      return true;
+    }
+  } catch (_) {}
+  return false;
+}
+
 function showEasterEgg() {
   if (!easterEgg || easterEgg.classList.contains('visible')) return;
   const hide = () => {
@@ -1395,10 +1409,9 @@ function showContextMenu(e) {
     });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
-      try {
-        await browser.tabs.discard(id);
+      if (await unloadTab(id)) {
         await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
+      }
       scheduleUpdate();
     });
     // Direct move option removed in favor of flagged move workflow
@@ -1468,21 +1481,16 @@ async function bulkActivate() {
 async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
-    try {
-      await browser.tabs.discard(id);
+    if (await unloadTab(id)) {
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-    } catch (_) {}
+    }
   }));
   scheduleUpdate();
 }
 
 async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.map(async t => {
-    try {
-      await browser.tabs.discard(t.id);
-    } catch (_) {}
-  }));
+  await Promise.all(tabs.map(t => unloadTab(t.id)));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
   scheduleUpdate();
 }


### PR DESCRIPTION
## Summary
- add a helper to prefer Firefox's native tab unload API while retaining discard as a fallback
- update automatic, bulk, and single-tab unload flows to leverage the shared helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f0b68f59b88331942e0fdde1721cfd