### PR TITLE
Adopt Firefox native tab unload API

### DIFF
--- a/mytabs/README.md
+++ b/mytabs/README.md
@@ -11,6 +11,8 @@ This is an open source Firefox add-on for advanced tab management.
 - Perform bulk operations (close, reload, unload, move) on selected tabs, and a
   command to unload all tabs at once. The keyboard shortcut for this command can
   be configured on the Options page.
+- Integrates with Firefox's native **Unload Tab** capability when available so the
+  add-on mirrors the browser's built-in behavior.
 - In Full View, the context menu offers **Activate Selected** to load all
   highlighted tabs at once.
 - Each tab row includes a button to quickly close that tab.

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -1,6 +1,21 @@
 // No cap on stored tabs so the Recent panel lists every visited tab
 const MAX_RECENT = Infinity;
 const action = browser.browserAction || browser.action;
+const supportsNativeTabUnload = typeof browser?.tabs?.unload === 'function';
+
+async function unloadTab(tabId) {
+  if (supportsNativeTabUnload) {
+    try {
+      await browser.tabs.unload(tabId);
+      return true;
+    } catch (_) {}
+  }
+  try {
+    await browser.tabs.discard(tabId);
+    return true;
+  } catch (_) {}
+  return false;
+}
 
 let recent = [];
 let visited = new Set();
@@ -326,11 +341,7 @@ async function openFullView() {
 async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.filter(t => !t.discarded)
-    .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
-    }));
+    .map(t => unloadTab(t.id)));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
   visited = new Set();
   recent = [];
@@ -344,10 +355,9 @@ async function checkAutoUnload() {
     const tabs = await browser.tabs.query({});
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
-        try {
-          await browser.tabs.discard(t.id);
+        if (await unloadTab(t.id)) {
           unmarkVisited(t.id);
-        } catch (_) {}
+        }
       }
     }));
   } catch (e) {

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -22,6 +22,21 @@ let visitedIds = new Set();
 let movePending = null;
 // Persist selection across updates
 let selectedIds = new Set();
+const supportsNativeTabUnload = typeof browser?.tabs?.unload === 'function';
+
+async function unloadTabById(tabId) {
+  if (supportsNativeTabUnload) {
+    try {
+      await browser.tabs.unload(tabId);
+      return true;
+    } catch (_) {}
+  }
+  try {
+    await browser.tabs.discard(tabId);
+    return true;
+  } catch (_) {}
+  return false;
+}
 
 // Cached tab list provided by the background script
 let cachedTabs = null;
@@ -1395,10 +1410,11 @@ function showContextMenu(e) {
     });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
-      try {
-        await browser.tabs.discard(id);
-        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
+      if (await unloadTabById(id)) {
+        try {
+          await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
+        } catch (_) {}
+      }
       scheduleUpdate();
     });
     // Direct move option removed in favor of flagged move workflow
@@ -1468,21 +1484,18 @@ async function bulkActivate() {
 async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
-    try {
-      await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-    } catch (_) {}
+    if (await unloadTabById(id)) {
+      try {
+        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
+      } catch (_) {}
+    }
   }));
   scheduleUpdate();
 }
 
 async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.map(async t => {
-    try {
-      await browser.tabs.discard(t.id);
-    } catch (_) {}
-  }));
+  await Promise.all(tabs.map(t => unloadTabById(t.id)));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
   scheduleUpdate();
 }


### PR DESCRIPTION
## Summary
- prefer Firefox's native tab unload API with a safe fallback to discard for background automation
- reuse the same helper for popup tab actions so manual unloads mirror the browser feature
- document the alignment with Firefox's Unload Tab capability in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0e1d0169483319d57b77ee73570ba