### PR TITLE
Adopt Firefox native unload API for tab suspension

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -8,6 +8,22 @@ let recentTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
+async function unloadTab(tabId) {
+  if (browser.tabs && typeof browser.tabs.unload === 'function') {
+    try {
+      await browser.tabs.unload(tabId);
+      return true;
+    } catch (_) {}
+  }
+  if (browser.tabs && typeof browser.tabs.discard === 'function') {
+    try {
+      await browser.tabs.discard(tabId);
+      return true;
+    } catch (_) {}
+  }
+  return false;
+}
+
 async function applyAutoDiscardable() {
   try {
     const tabs = await browser.tabs.query({});
@@ -327,9 +343,7 @@ async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.filter(t => !t.discarded)
     .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
+      await unloadTab(t.id);
     }));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
   visited = new Set();
@@ -344,10 +358,10 @@ async function checkAutoUnload() {
     const tabs = await browser.tabs.query({});
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
-        try {
-          await browser.tabs.discard(t.id);
+        const unloaded = await unloadTab(t.id);
+        if (unloaded) {
           unmarkVisited(t.id);
-        } catch (_) {}
+        }
       }
     }));
   } catch (e) {

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -45,6 +45,22 @@ const popupScrollPos = { all: 0, recent: 0, dups: 0 };
 let easterEgg;
 const collapsedWins = new Set();
 
+async function unloadTab(tabId) {
+  if (browser.tabs && typeof browser.tabs.unload === 'function') {
+    try {
+      await browser.tabs.unload(tabId);
+      return true;
+    } catch (_) {}
+  }
+  if (browser.tabs && typeof browser.tabs.discard === 'function') {
+    try {
+      await browser.tabs.discard(tabId);
+      return true;
+    } catch (_) {}
+  }
+  return false;
+}
+
 function showEasterEgg() {
   if (!easterEgg || easterEgg.classList.contains('visible')) return;
   const hide = () => {
@@ -1395,10 +1411,10 @@ function showContextMenu(e) {
     });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
-      try {
-        await browser.tabs.discard(id);
+      const unloaded = await unloadTab(id);
+      if (unloaded) {
         await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
+      }
       scheduleUpdate();
     });
     // Direct move option removed in favor of flagged move workflow
@@ -1468,20 +1484,18 @@ async function bulkActivate() {
 async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
-    try {
-      await browser.tabs.discard(id);
+    const unloaded = await unloadTab(id);
+    if (unloaded) {
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-    } catch (_) {}
+    }
   }));
   scheduleUpdate();
 }
 
 async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.map(async t => {
-    try {
-      await browser.tabs.discard(t.id);
-    } catch (_) {}
+  await Promise.all(tabs.filter(t => !t.discarded).map(async t => {
+    await unloadTab(t.id);
   }));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
   scheduleUpdate();


### PR DESCRIPTION
## Summary
- add helper functions that prefer `browser.tabs.unload` with a `browser.tabs.discard` fallback
- update background automation to reuse the helper while keeping visited tracking accurate
- migrate popup tab actions to the helper so manual unloads invoke Firefox's native flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f0e1d0169483319d57b77ee73570ba