### PR TITLE
Adopt Firefox native tab unload API

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -323,12 +323,19 @@ async function openFullView() {
   await browser.windows.create(createData);
 }
 
+async function unloadTabById(tabId) {
+  if (browser.tabs.unload && typeof browser.tabs.unload === 'function') {
+    return browser.tabs.unload(tabId);
+  }
+  return browser.tabs.discard(tabId);
+}
+
 async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.filter(t => !t.discarded)
     .map(async t => {
       try {
-        await browser.tabs.discard(t.id);
+        await unloadTabById(t.id);
       } catch (_) {}
     }));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
@@ -345,7 +352,7 @@ async function checkAutoUnload() {
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
         try {
-          await browser.tabs.discard(t.id);
+          await unloadTabById(t.id);
           unmarkVisited(t.id);
         } catch (_) {}
       }

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -26,6 +26,13 @@ let selectedIds = new Set();
 // Cached tab list provided by the background script
 let cachedTabs = null;
 
+async function unloadTab(tabId) {
+  if (browser.tabs.unload && typeof browser.tabs.unload === 'function') {
+    return browser.tabs.unload(tabId);
+  }
+  return browser.tabs.discard(tabId);
+}
+
 let virtualList = null;
 let tabItems = [];
 let idIndexMap = new Map();
@@ -1396,7 +1403,7 @@ function showContextMenu(e) {
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
       try {
-        await browser.tabs.discard(id);
+        await unloadTab(id);
         await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
       } catch (_) {}
       scheduleUpdate();
@@ -1469,7 +1476,7 @@ async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
     try {
-      await browser.tabs.discard(id);
+      await unloadTab(id);
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
     } catch (_) {}
   }));
@@ -1480,7 +1487,7 @@ async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.map(async t => {
     try {
-      await browser.tabs.discard(t.id);
+      await unloadTab(t.id);
     } catch (_) {}
   }));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });


### PR DESCRIPTION
## Summary
- add helpers that call `browser.tabs.unload` when available and fall back to `browser.tabs.discard`
- use the new helper across background auto-unload logic and popup actions to mirror Firefox's native unload behavior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f0e1d0169483319d57b77ee73570ba