### PR TITLE
Improve reliability of tab unload handling

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -323,12 +323,55 @@ async function openFullView() {
   await browser.windows.create(createData);
 }
 
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function confirmTabDiscarded(tabId, attempts = 3, waitMs = 100) {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const tab = await browser.tabs.get(tabId);
+      if (!tab || tab.discarded) {
+        return true;
+      }
+    } catch (_) {
+      return true;
+    }
+    await delay(waitMs);
+  }
+  return false;
+}
+
+async function tryNativeUnload(tabId) {
+  if (browser.tabs.unload && typeof browser.tabs.unload === 'function') {
+    try {
+      await browser.tabs.unload(tabId);
+      if (await confirmTabDiscarded(tabId)) {
+        return true;
+      }
+    } catch (_) {}
+  }
+  return false;
+}
+
+async function unloadTabById(tabId) {
+  if (await tryNativeUnload(tabId)) {
+    return true;
+  }
+  try {
+    await browser.tabs.discard(tabId);
+    return await confirmTabDiscarded(tabId);
+  } catch (_) {
+    return false;
+  }
+}
+
 async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.filter(t => !t.discarded)
     .map(async t => {
       try {
-        await browser.tabs.discard(t.id);
+        await unloadTabById(t.id);
       } catch (_) {}
     }));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
@@ -345,8 +388,9 @@ async function checkAutoUnload() {
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
         try {
-          await browser.tabs.discard(t.id);
-          unmarkVisited(t.id);
+          if (await unloadTabById(t.id)) {
+            unmarkVisited(t.id);
+          }
         } catch (_) {}
       }
     }));

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -26,6 +26,42 @@ let selectedIds = new Set();
 // Cached tab list provided by the background script
 let cachedTabs = null;
 
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function confirmTabDiscarded(tabId, attempts = 3, waitMs = 100) {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const tab = await browser.tabs.get(tabId);
+      if (!tab || tab.discarded) {
+        return true;
+      }
+    } catch (_) {
+      return true;
+    }
+    await delay(waitMs);
+  }
+  return false;
+}
+
+async function unloadTab(tabId) {
+  if (browser.tabs.unload && typeof browser.tabs.unload === 'function') {
+    try {
+      await browser.tabs.unload(tabId);
+      if (await confirmTabDiscarded(tabId)) {
+        return true;
+      }
+    } catch (_) {}
+  }
+  try {
+    await browser.tabs.discard(tabId);
+    return await confirmTabDiscarded(tabId);
+  } catch (_) {
+    return false;
+  }
+}
+
 let virtualList = null;
 let tabItems = [];
 let idIndexMap = new Map();
@@ -1396,8 +1432,9 @@ function showContextMenu(e) {
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
       try {
-        await browser.tabs.discard(id);
-        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
+        if (await unloadTab(id)) {
+          await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
+        }
       } catch (_) {}
       scheduleUpdate();
     });
@@ -1469,8 +1506,9 @@ async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
     try {
-      await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
+      if (await unloadTab(id)) {
+        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
+      }
     } catch (_) {}
   }));
   scheduleUpdate();
@@ -1480,7 +1518,7 @@ async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.map(async t => {
     try {
-      await browser.tabs.discard(t.id);
+      await unloadTab(t.id);
     } catch (_) {}
   }));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });


### PR DESCRIPTION
## Summary
- add shared helpers that verify whether a tab was actually discarded after requesting an unload
- fall back to `browser.tabs.discard` when the native unload API does not change the tab state
- only clear visited bookkeeping when an unload succeeds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f0e1d0169483319d57b77ee73570ba