### PR TITLE
Introduce centralized native tab discard helper

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -323,6 +323,69 @@ async function openFullView() {
   await browser.windows.create(createData);
 }
 
+async function discardNativeTab(tabId, { skipActive = true } = {}) {
+  let tab;
+  try {
+    tab = await browser.tabs.get(tabId);
+  } catch (error) {
+    return { success: false, reason: 'not_found' };
+  }
+
+  if (!tab) {
+    return { success: false, reason: 'not_found' };
+  }
+
+  if (tab.discarded) {
+    unmarkVisited(tabId);
+    return { success: true, reason: 'already_discarded' };
+  }
+
+  if (skipActive && tab.active) {
+    return { success: false, reason: 'active_tab' };
+  }
+
+  const shouldRevert = tab.autoDiscardable === false;
+  if (shouldRevert) {
+    try {
+      await browser.tabs.update(tabId, { autoDiscardable: true });
+    } catch (_) {
+      return { success: false, reason: 'auto_discardable_update_failed' };
+    }
+  }
+
+  let discardResult;
+  try {
+    discardResult = await browser.tabs.discard(tabId);
+  } catch (discardError) {
+    if (shouldRevert) {
+      await browser.tabs.update(tabId, { autoDiscardable: false }).catch(() => {});
+    }
+    return {
+      success: false,
+      reason: discardError && discardError.message ? discardError.message : 'discard_failed'
+    };
+  }
+
+  const candidate = Array.isArray(discardResult)
+    ? discardResult.find(t => t && t.id === tabId)
+    : discardResult;
+  let updated = candidate;
+  if (!updated || !updated.discarded) {
+    updated = await browser.tabs.get(tabId).catch(() => null);
+  }
+
+  if (shouldRevert) {
+    await browser.tabs.update(tabId, { autoDiscardable: false }).catch(() => {});
+  }
+
+  if (updated && updated.discarded) {
+    unmarkVisited(tabId);
+    return { success: true };
+  }
+
+  return { success: false, reason: 'not_discarded' };
+}
+
 async function nativeUnloadTabs(tabIds, { skipActive = true } = {}) {
   const uniqueIds = Array.from(new Set((tabIds || [])
     .map(id => Number(id))
@@ -330,59 +393,8 @@ async function nativeUnloadTabs(tabIds, { skipActive = true } = {}) {
   const results = [];
 
   for (const id of uniqueIds) {
-    try {
-      const tab = await browser.tabs.get(id);
-      if (!tab) {
-        results.push({ tabId: id, success: false, reason: 'not_found' });
-        continue;
-      }
-      if (tab.discarded) {
-        unmarkVisited(id);
-        results.push({ tabId: id, success: true, reason: 'already_discarded' });
-        continue;
-      }
-      if (skipActive && tab.active) {
-        results.push({ tabId: id, success: false, reason: 'active_tab' });
-        continue;
-      }
-
-      let revertAutoDiscardable = false;
-      if (tab.autoDiscardable === false) {
-        try {
-          await browser.tabs.update(id, { autoDiscardable: true });
-          revertAutoDiscardable = true;
-        } catch (updateError) {
-          results.push({ tabId: id, success: false, reason: 'auto_discardable_update_failed' });
-          continue;
-        }
-      }
-
-      try {
-        await browser.tabs.discard(id);
-      } catch (discardError) {
-        if (revertAutoDiscardable) {
-          await browser.tabs.update(id, { autoDiscardable: false }).catch(() => {});
-        }
-        results.push({ tabId: id, success: false, reason: discardError && discardError.message ? discardError.message : 'discard_failed' });
-        continue;
-      }
-
-      const updated = await browser.tabs.get(id).catch(() => null);
-      if (updated && updated.discarded) {
-        unmarkVisited(id);
-        if (revertAutoDiscardable) {
-          await browser.tabs.update(id, { autoDiscardable: false }).catch(() => {});
-        }
-        results.push({ tabId: id, success: true });
-      } else {
-        if (revertAutoDiscardable) {
-          await browser.tabs.update(id, { autoDiscardable: false }).catch(() => {});
-        }
-        results.push({ tabId: id, success: false, reason: 'not_discarded' });
-      }
-    } catch (error) {
-      results.push({ tabId: id, success: false, reason: error && error.message ? error.message : 'discard_failed' });
-    }
+    const result = await discardNativeTab(id, { skipActive });
+    results.push({ tabId: id, ...result });
   }
 
   if (results.some(r => r.success)) {

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -327,7 +327,7 @@ async function discardNativeTab(tabId, { skipActive = true } = {}) {
   let tab;
   try {
     tab = await browser.tabs.get(tabId);
-  } catch (error) {
+  } catch (_) {
     return { success: false, reason: 'not_found' };
   }
 
@@ -344,22 +344,10 @@ async function discardNativeTab(tabId, { skipActive = true } = {}) {
     return { success: false, reason: 'active_tab' };
   }
 
-  const shouldRevert = tab.autoDiscardable === false;
-  if (shouldRevert) {
-    try {
-      await browser.tabs.update(tabId, { autoDiscardable: true });
-    } catch (_) {
-      return { success: false, reason: 'auto_discardable_update_failed' };
-    }
-  }
-
   let discardResult;
   try {
     discardResult = await browser.tabs.discard(tabId);
   } catch (discardError) {
-    if (shouldRevert) {
-      await browser.tabs.update(tabId, { autoDiscardable: false }).catch(() => {});
-    }
     return {
       success: false,
       reason: discardError && discardError.message ? discardError.message : 'discard_failed'
@@ -372,10 +360,6 @@ async function discardNativeTab(tabId, { skipActive = true } = {}) {
   let updated = candidate;
   if (!updated || !updated.discarded) {
     updated = await browser.tabs.get(tabId).catch(() => null);
-  }
-
-  if (shouldRevert) {
-    await browser.tabs.update(tabId, { autoDiscardable: false }).catch(() => {});
   }
 
   if (updated && updated.discarded) {

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -279,8 +279,8 @@ browser.runtime.onMessage.addListener((msg) => {
     return Promise.resolve({ duplicates: Array.from(dupIds) });
   } else if (msg && msg.type === 'getTabState') {
     return Promise.resolve({ tabs: allTabCache, visited: Array.from(visited) });
-  } else if (msg && msg.type === 'unmarkVisited') {
-    unmarkVisited(msg.tabId);
+  } else if (msg && msg.type === 'nativeUnloadTabs') {
+    return nativeUnloadTabs(msg.tabIds, { skipActive: msg && msg.skipActive !== false });
   } else if (msg && msg.type === 'reorderRecent') {
     reorderRecent(msg.ids || [], msg.toId, msg.before);
   } else if (msg && msg.type === 'clearVisitHistory') {
@@ -323,14 +323,56 @@ async function openFullView() {
   await browser.windows.create(createData);
 }
 
+async function nativeUnloadTabs(tabIds, { skipActive = true } = {}) {
+  const uniqueIds = Array.from(new Set((tabIds || [])
+    .map(id => Number(id))
+    .filter(id => Number.isInteger(id))));
+  const results = [];
+
+  for (const id of uniqueIds) {
+    try {
+      const tab = await browser.tabs.get(id);
+      if (!tab) {
+        results.push({ tabId: id, success: false, reason: 'not_found' });
+        continue;
+      }
+      if (tab.discarded) {
+        unmarkVisited(id);
+        results.push({ tabId: id, success: true, reason: 'already_discarded' });
+        continue;
+      }
+      if (skipActive && tab.active) {
+        results.push({ tabId: id, success: false, reason: 'active_tab' });
+        continue;
+      }
+
+      await browser.tabs.discard(id);
+      const updated = await browser.tabs.get(id).catch(() => null);
+      if (updated && updated.discarded) {
+        unmarkVisited(id);
+        results.push({ tabId: id, success: true });
+      } else {
+        results.push({ tabId: id, success: false, reason: 'not_discarded' });
+      }
+    } catch (error) {
+      results.push({ tabId: id, success: false, reason: error && error.message ? error.message : 'discard_failed' });
+    }
+  }
+
+  if (results.some(r => r.success)) {
+    await refreshTabState();
+  }
+
+  return {
+    results,
+    discarded: results.filter(r => r.success).map(r => r.tabId),
+    failed: results.filter(r => !r.success).map(r => r.tabId)
+  };
+}
+
 async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.filter(t => !t.discarded)
-    .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
-    }));
+  await nativeUnloadTabs(tabs.map(t => t.id));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
   visited = new Set();
   recent = [];
@@ -342,14 +384,12 @@ async function checkAutoUnload() {
   const threshold = Date.now() - autoUnloadMinutes * 60000;
   try {
     const tabs = await browser.tabs.query({});
-    await Promise.all(tabs.map(async t => {
-      if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
-        try {
-          await browser.tabs.discard(t.id);
-          unmarkVisited(t.id);
-        } catch (_) {}
-      }
-    }));
+    const candidates = tabs
+      .filter(t => !t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold)
+      .map(t => t.id);
+    if (candidates.length) {
+      await nativeUnloadTabs(candidates, { skipActive: false });
+    }
   } catch (e) {
     console.error('Auto unload failed', e);
   }

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -328,11 +328,11 @@ async function discardNativeTab(tabId, { skipActive = true } = {}) {
   try {
     tab = await browser.tabs.get(tabId);
   } catch (_) {
-    return { success: false, reason: 'not_found' };
+    return { success: false, reason: 'not_found', message: 'Tab not found' };
   }
 
   if (!tab) {
-    return { success: false, reason: 'not_found' };
+    return { success: false, reason: 'not_found', message: 'Tab not found' };
   }
 
   if (tab.discarded) {
@@ -341,7 +341,15 @@ async function discardNativeTab(tabId, { skipActive = true } = {}) {
   }
 
   if (skipActive && tab.active) {
-    return { success: false, reason: 'active_tab' };
+    return { success: false, reason: 'active_tab', message: 'Active tab skipped' };
+  }
+
+  if (tab.audible) {
+    return { success: false, reason: 'audible_tab', message: 'Tab is playing audio' };
+  }
+
+  if (tab.sharingState && (tab.sharingState.camera || tab.sharingState.microphone || tab.sharingState.screen)) {
+    return { success: false, reason: 'streaming_tab', message: 'Tab is sharing media' };
   }
 
   let discardResult;
@@ -350,7 +358,8 @@ async function discardNativeTab(tabId, { skipActive = true } = {}) {
   } catch (discardError) {
     return {
       success: false,
-      reason: discardError && discardError.message ? discardError.message : 'discard_failed'
+      reason: 'discard_failed',
+      message: discardError && discardError.message ? discardError.message : 'Discard failed'
     };
   }
 
@@ -359,7 +368,17 @@ async function discardNativeTab(tabId, { skipActive = true } = {}) {
     : discardResult;
   let updated = candidate;
   if (!updated || !updated.discarded) {
-    updated = await browser.tabs.get(tabId).catch(() => null);
+    try {
+      updated = await browser.tabs.get(tabId);
+    } catch (verifyError) {
+      return {
+        success: false,
+        reason: 'not_discarded',
+        message: verifyError && verifyError.message
+          ? verifyError.message
+          : 'Unable to verify discarded state'
+      };
+    }
   }
 
   if (updated && updated.discarded) {
@@ -367,7 +386,11 @@ async function discardNativeTab(tabId, { skipActive = true } = {}) {
     return { success: true };
   }
 
-  return { success: false, reason: 'not_discarded' };
+  return {
+    success: false,
+    reason: 'not_discarded',
+    message: 'Tab did not enter discarded state'
+  };
 }
 
 async function nativeUnloadTabs(tabIds, { skipActive = true } = {}) {
@@ -378,10 +401,13 @@ async function nativeUnloadTabs(tabIds, { skipActive = true } = {}) {
 
   for (const id of uniqueIds) {
     const result = await discardNativeTab(id, { skipActive });
+    if (!result.success) {
+      console.warn('Failed to discard tab', id, result.reason, result.message);
+    }
     results.push({ tabId: id, ...result });
   }
 
-  if (results.some(r => r.success)) {
+  if (results.length) {
     await refreshTabState();
   }
 
@@ -440,22 +466,41 @@ browser.commands.onCommand.addListener((command) => {
   }
 });
 
+function isDuplicateMenuError(error) {
+  return error && error.message && /Cannot create|already exists/i.test(error.message);
+}
+
+async function createContextMenuSafe(details) {
+  try {
+    await browser.contextMenus.create(details);
+  } catch (error) {
+    if (!isDuplicateMenuError(error)) {
+      console.error('Failed to create context menu', details?.id, error);
+    }
+  }
+}
+
 browser.runtime.onInstalled.addListener(async () => {
   await clearVisitHistory();
-  await browser.contextMenus.create({
+  await createContextMenuSafe({
     id: 'show-version',
     title: `KepiTAB Manager v${browser.runtime.getManifest().version}`,
     contexts: ['browser_action']
   });
-  await browser.contextMenus.create({
+  await createContextMenuSafe({
     id: 'open-full-view',
     title: 'Open Full View',
     contexts: ['browser_action']
   });
-  await browser.contextMenus.create({
+  await createContextMenuSafe({
     id: 'open-options',
     title: 'Options',
     contexts: ['browser_action']
+  });
+  await createContextMenuSafe({
+    id: 'unload-tab-native',
+    title: 'Zwolnij kartę (Unload)',
+    contexts: ['tab']
   });
 });
 
@@ -464,5 +509,19 @@ browser.contextMenus.onClicked.addListener((info) => {
     openFullView();
   } else if (info.menuItemId === 'open-options') {
     browser.runtime.openOptionsPage();
+  } else if (info.menuItemId === 'unload-tab-native' && typeof info.tabId === 'number') {
+    nativeUnloadTabs([info.tabId], { skipActive: true }).catch((err) => {
+      console.error('Context menu unload failed', err);
+    });
   }
+});
+
+createContextMenuSafe({
+  id: 'unload-tab-native',
+  title: 'Zwolnij kartę (Unload)',
+  contexts: ['tab']
+});
+
+browser.windows.onFocusChanged.addListener(() => {
+  refreshTabState();
 });

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -346,12 +346,38 @@ async function nativeUnloadTabs(tabIds, { skipActive = true } = {}) {
         continue;
       }
 
-      await browser.tabs.discard(id);
+      let revertAutoDiscardable = false;
+      if (tab.autoDiscardable === false) {
+        try {
+          await browser.tabs.update(id, { autoDiscardable: true });
+          revertAutoDiscardable = true;
+        } catch (updateError) {
+          results.push({ tabId: id, success: false, reason: 'auto_discardable_update_failed' });
+          continue;
+        }
+      }
+
+      try {
+        await browser.tabs.discard(id);
+      } catch (discardError) {
+        if (revertAutoDiscardable) {
+          await browser.tabs.update(id, { autoDiscardable: false }).catch(() => {});
+        }
+        results.push({ tabId: id, success: false, reason: discardError && discardError.message ? discardError.message : 'discard_failed' });
+        continue;
+      }
+
       const updated = await browser.tabs.get(id).catch(() => null);
       if (updated && updated.discarded) {
         unmarkVisited(id);
+        if (revertAutoDiscardable) {
+          await browser.tabs.update(id, { autoDiscardable: false }).catch(() => {});
+        }
         results.push({ tabId: id, success: true });
       } else {
+        if (revertAutoDiscardable) {
+          await browser.tabs.update(id, { autoDiscardable: false }).catch(() => {});
+        }
         results.push({ tabId: id, success: false, reason: 'not_discarded' });
       }
     } catch (error) {

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -21,6 +21,14 @@
     <input type="text" id="search" placeholder="Search tabs" />
     <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
   </div>
+  <section id="unload-panel" aria-label="Zarządzanie pamięcią">
+    <header class="unload-header">
+      <h2>Zwolnij karty</h2>
+      <button id="unload-selected" type="button" disabled>Zwolnij zaznaczone</button>
+    </header>
+    <div id="unload-messages" class="hidden" role="status" aria-live="polite"></div>
+    <ul id="unload-list" class="unload-list" aria-label="Lista kart do zwolnienia"></ul>
+  </section>
   <div id="error"></div>
   <div id="tabs-wrapper">
     <div id="tabs"></div>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1395,10 +1395,7 @@ function showContextMenu(e) {
     });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
-      try {
-        await browser.tabs.discard(id);
-        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
+      await requestNativeUnload([id]);
       scheduleUpdate();
     });
     // Direct move option removed in favor of flagged move workflow
@@ -1445,6 +1442,22 @@ function getSelectedTabIds() {
   return tabItems.filter(it => !it.separator && it.selected).map(it => it.tab.id);
 }
 
+async function requestNativeUnload(tabIds, options = {}) {
+  if (!Array.isArray(tabIds) || tabIds.length === 0) {
+    return { discarded: [], failed: [] };
+  }
+  try {
+    const response = await browser.runtime.sendMessage({
+      type: 'nativeUnloadTabs',
+      tabIds,
+      skipActive: options.skipActive !== false
+    });
+    return response || { discarded: [], failed: tabIds };
+  } catch (_) {
+    return { discarded: [], failed: tabIds };
+  }
+}
+
 async function bulkClose() {
   const ids = getSelectedTabIds();
   if (ids.length) await browser.tabs.remove(ids);
@@ -1467,23 +1480,19 @@ async function bulkActivate() {
 
 async function bulkDiscard() {
   const ids = getSelectedTabIds();
-  await Promise.all(ids.map(async id => {
-    try {
-      await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-    } catch (_) {}
-  }));
+  if (ids.length) {
+    await requestNativeUnload(ids);
+  }
   scheduleUpdate();
 }
 
 async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.map(async t => {
-    try {
-      await browser.tabs.discard(t.id);
-    } catch (_) {}
-  }));
-  await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
+  const ids = tabs.map(t => t.id);
+  if (ids.length) {
+    await requestNativeUnload(ids, { skipActive: false });
+    await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
+  }
   scheduleUpdate();
 }
 

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -23,6 +23,12 @@ let movePending = null;
 // Persist selection across updates
 let selectedIds = new Set();
 
+const unloadSelection = new Set();
+let unloadListContainer = null;
+let unloadMessageBox = null;
+let unloadButton = null;
+let unloadMessageTimeout = null;
+
 // Cached tab list provided by the background script
 let cachedTabs = null;
 
@@ -211,6 +217,213 @@ function applyHighlights(span, indices) {
   }
   if (last < text.length) {
     span.appendChild(document.createTextNode(text.slice(last)));
+  }
+}
+
+function isTabSharingMedia(tab) {
+  const share = tab && tab.sharingState;
+  return !!(share && (share.camera || share.microphone || share.screen));
+}
+
+function isTabEligibleForUnload(tab) {
+  if (!tab) return false;
+  if (tab.discarded) return false;
+  if (tab.active) return false;
+  if (tab.audible) return false;
+  if (isTabSharingMedia(tab)) return false;
+  return true;
+}
+
+function updateUnloadButtonState() {
+  if (unloadButton) {
+    unloadButton.disabled = unloadSelection.size === 0;
+  }
+}
+
+function hideUnloadMessage() {
+  if (unloadMessageBox) {
+    unloadMessageBox.classList.add('hidden');
+    unloadMessageBox.textContent = '';
+    unloadMessageBox.classList.remove('error', 'success');
+  }
+  if (unloadMessageTimeout) {
+    clearTimeout(unloadMessageTimeout);
+    unloadMessageTimeout = null;
+  }
+}
+
+function showUnloadMessage(text, level = 'info') {
+  if (!unloadMessageBox) return;
+  unloadMessageBox.textContent = text;
+  unloadMessageBox.classList.remove('hidden');
+  unloadMessageBox.classList.toggle('error', level === 'error');
+  unloadMessageBox.classList.toggle('success', level === 'success');
+  if (unloadMessageTimeout) {
+    clearTimeout(unloadMessageTimeout);
+  }
+  unloadMessageTimeout = setTimeout(() => {
+    hideUnloadMessage();
+  }, 4000);
+}
+
+function formatUnloadError(result) {
+  const { reason, message } = result || {};
+  switch (reason) {
+    case 'not_found':
+      return 'Karta nie została znaleziona.';
+    case 'active_tab':
+      return 'Aktywna karta została pominięta.';
+    case 'audible_tab':
+      return 'Karta odtwarza dźwięk.';
+    case 'streaming_tab':
+      return 'Karta udostępnia ekran lub kamerę.';
+    case 'discard_failed':
+      return message || 'Przeglądarka odrzuciła polecenie.';
+    case 'not_discarded':
+      return message || 'Firefox nie potwierdził stanu discarded.';
+    case 'already_discarded':
+      return 'Karta była już zwolniona.';
+    default:
+      return message || 'Nieznany błąd.';
+  }
+}
+
+function ensureUnloadSelection(allTabs) {
+  const ids = new Set((Array.isArray(allTabs) ? allTabs : []).map(t => t.id));
+  for (const id of Array.from(unloadSelection)) {
+    if (!ids.has(id)) {
+      unloadSelection.delete(id);
+    }
+  }
+}
+
+function renderUnloadList(allTabs = []) {
+  if (!unloadListContainer) return;
+  const tabs = Array.isArray(allTabs) ? allTabs : [];
+  ensureUnloadSelection(tabs);
+  unloadListContainer.textContent = '';
+  const fragment = document.createDocumentFragment();
+  let rendered = 0;
+
+  for (const tab of tabs) {
+    if (tab.windowType && tab.windowType !== 'normal') continue;
+    const eligible = isTabEligibleForUnload(tab);
+    const entry = document.createElement('li');
+    entry.className = 'unload-entry';
+    entry.dataset.tabId = String(tab.id);
+    if (tab.discarded) entry.classList.add('faded');
+    if (!eligible) entry.classList.add('disabled');
+    entry.title = tab.url || tab.title || '';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = tab.id;
+    checkbox.checked = eligible && unloadSelection.has(tab.id);
+    checkbox.disabled = !eligible;
+    checkbox.addEventListener('change', () => {
+      const tabId = Number(checkbox.value);
+      if (checkbox.checked) {
+        unloadSelection.add(tabId);
+      } else {
+        unloadSelection.delete(tabId);
+      }
+      updateUnloadButtonState();
+    });
+    entry.appendChild(checkbox);
+
+    let iconEl;
+    if (tab.favIconUrl && !tab.favIconUrl.startsWith('chrome:')) {
+      iconEl = document.createElement('img');
+      iconEl.src = tab.favIconUrl;
+      iconEl.alt = '';
+      iconEl.addEventListener('error', () => {
+        iconEl.replaceWith(createFallbackIcon());
+      }, { once: true });
+    } else {
+      iconEl = createFallbackIcon();
+    }
+    entry.appendChild(iconEl);
+
+    const titleSpan = document.createElement('span');
+    titleSpan.className = 'unload-entry-title';
+    titleSpan.textContent = tab.title || tab.url || 'Bez tytułu';
+    entry.appendChild(titleSpan);
+
+    fragment.appendChild(entry);
+    rendered++;
+
+    if (!eligible) {
+      unloadSelection.delete(tab.id);
+    }
+  }
+
+  if (rendered === 0) {
+    const empty = document.createElement('li');
+    empty.className = 'unload-entry empty';
+    empty.textContent = 'Brak kart do zwolnienia.';
+    empty.setAttribute('aria-disabled', 'true');
+    fragment.appendChild(empty);
+  }
+
+  unloadListContainer.appendChild(fragment);
+  updateUnloadButtonState();
+}
+
+function createFallbackIcon() {
+  const span = document.createElement('span');
+  span.className = 'unload-entry-icon';
+  span.textContent = '🗂️';
+  return span;
+}
+
+async function handleUnloadSelected() {
+  if (!unloadSelection.size) return;
+  hideUnloadMessage();
+  const ids = Array.from(unloadSelection);
+  if (unloadButton) unloadButton.disabled = true;
+  try {
+    const response = await browser.runtime.sendMessage({
+      type: 'nativeUnloadTabs',
+      tabIds: ids,
+      skipActive: true
+    });
+    const results = Array.isArray(response?.results) ? response.results : [];
+    let successCount = 0;
+    const failures = [];
+    for (const result of results) {
+      if (result.success) {
+        successCount += 1;
+      } else {
+        failures.push(result);
+      }
+      if (typeof result.tabId === 'number') {
+        unloadSelection.delete(result.tabId);
+      }
+    }
+    if (failures.length) {
+      const tabMap = new Map((Array.isArray(cachedTabs) ? cachedTabs : []).map(t => [t.id, t]));
+      const parts = failures.map(res => {
+        const tab = tabMap.get(res.tabId);
+        const title = tab?.title || tab?.url || `Karta ${res.tabId}`;
+        return `Nie udało się zwolnić „${title}”: ${formatUnloadError(res)}`;
+      });
+      showUnloadMessage(parts.join(' '), 'error');
+    } else if (successCount > 0) {
+      const plural = (n) => {
+        const abs = Math.abs(n);
+        if (abs === 1) return 'kartę';
+        if (abs % 10 >= 2 && abs % 10 <= 4 && (abs % 100 < 10 || abs % 100 >= 20)) return 'karty';
+        return 'kart';
+      };
+      const text = `Zwolniono ${successCount} ${plural(successCount)}.`;
+      showUnloadMessage(text, 'success');
+    }
+  } catch (error) {
+    console.error('Unload request failed', error);
+    showUnloadMessage('Nie udało się wykonać polecenia zwolnienia kart.', 'error');
+  } finally {
+    updateUnloadButtonState();
+    scheduleUpdate();
   }
 }
 
@@ -874,6 +1087,7 @@ async function update() {
     const activeId = allTabs.find(t => t.active)?.id ?? -1;
     const searchInput = document.getElementById('search');
     const query = searchInput.value.trim();
+    renderUnloadList(allTabs);
     let list;
     if (query) {
       list = applySearchOrder(filterTabs(tabs, query));
@@ -1084,6 +1298,13 @@ async function init() {
               document.getElementById('tabs');
   scrollContainer = document.getElementById('tabs-wrapper') || container;
   easterEgg = document.getElementById('easter-egg');
+  unloadListContainer = document.getElementById('unload-list');
+  unloadMessageBox = document.getElementById('unload-messages');
+  unloadButton = document.getElementById('unload-selected');
+  if (unloadButton) {
+    unloadButton.addEventListener('click', handleUnloadSelected);
+  }
+  updateUnloadButtonState();
   const menuEl = document.getElementById('menu');
   menuEl?.addEventListener('dblclick', showEasterEgg);
   scrollContainer.addEventListener('scroll', saveScroll);
@@ -1227,6 +1448,7 @@ function registerTabEvents() {
   browser.tabs.onActivated.addListener(updateListener);
   browser.tabs.onDetached.addListener(updateListener);
   browser.tabs.onAttached.addListener(updateListener);
+  browser.windows.onFocusChanged.addListener(updateListener);
 }
 
 function unregisterTabEvents() {
@@ -1236,11 +1458,14 @@ function unregisterTabEvents() {
   browser.tabs.onActivated.removeListener(updateListener);
   browser.tabs.onDetached.removeListener(updateListener);
   browser.tabs.onAttached.removeListener(updateListener);
+  browser.windows.onFocusChanged.removeListener(updateListener);
 }
 
 function cleanup() {
   unregisterTabEvents();
   resetTabState();
+  unloadSelection.clear();
+  hideUnloadMessage();
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -163,6 +163,137 @@ body[data-theme="dark"] #easter-egg {
   box-sizing: border-box;
 }
 
+#unload-panel {
+  margin: 0.5em 0;
+  padding: 0.5em;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-hover);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}
+
+body[data-theme="dark"] #unload-panel {
+  background: #2f2f2f;
+}
+
+.unload-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5em;
+}
+
+.unload-header h2 {
+  margin: 0;
+  font-size: 1em;
+}
+
+#unload-selected {
+  padding: 0.3em 0.6em;
+}
+
+#unload-selected:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+#unload-messages {
+  padding: 0.4em 0.6em;
+  border-radius: 4px;
+  font-size: 0.9em;
+  background: rgba(255, 193, 7, 0.2);
+  border: 1px solid rgba(255, 193, 7, 0.4);
+}
+
+body[data-theme="dark"] #unload-messages {
+  background: rgba(255, 193, 7, 0.15);
+  border-color: rgba(255, 193, 7, 0.35);
+}
+
+#unload-messages.success {
+  background: rgba(76, 175, 80, 0.2);
+  border-color: rgba(76, 175, 80, 0.4);
+}
+
+body[data-theme="dark"] #unload-messages.success {
+  background: rgba(76, 175, 80, 0.15);
+  border-color: rgba(76, 175, 80, 0.35);
+}
+
+#unload-messages.error {
+  background: rgba(244, 67, 54, 0.2);
+  border-color: rgba(244, 67, 54, 0.4);
+}
+
+body[data-theme="dark"] #unload-messages.error {
+  background: rgba(244, 67, 54, 0.15);
+  border-color: rgba(244, 67, 54, 0.35);
+}
+
+.unload-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25em;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.unload-entry {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  padding: 0.35em 0.4em;
+  border-radius: 4px;
+  background: var(--color-bg);
+  border: 1px solid transparent;
+}
+
+.unload-entry:hover {
+  border-color: var(--color-border);
+}
+
+.unload-entry.faded {
+  opacity: 0.6;
+}
+
+.unload-entry.disabled {
+  opacity: 0.5;
+}
+
+.unload-entry.empty {
+  justify-content: center;
+  font-style: italic;
+  color: var(--color-muted);
+}
+
+.unload-entry img {
+  width: 16px;
+  height: 16px;
+  border-radius: 2px;
+}
+
+.unload-entry-icon {
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9em;
+}
+
+.unload-entry-title {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 #tabs {
   margin-top: 0;
   max-height: 400px;


### PR DESCRIPTION
## Summary
- add a nativeUnloadTabs helper in the background worker to drive Firefox's tab discard logic and keep cached state current
- expose the helper through runtime messaging for reuse by auto-unload, command, and bulk unload flows
- update popup actions to request native discards so manual actions and bulk unloads yield Firefox's greyed-out tab state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f2d2a03c388331a0c4b2e2300d3ba8