### PR TITLE
Add background unload API integration for native tab discard

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -2,6 +2,63 @@
 const MAX_RECENT = Infinity;
 const action = browser.browserAction || browser.action;
 
+async function unloadTabs(tabIds, { allowActive = false } = {}) {
+  if (!Array.isArray(tabIds) || !tabIds.length) {
+    return { results: [] };
+  }
+
+  const results = [];
+
+  for (const tabId of tabIds) {
+    const result = { tabId, success: false };
+
+    try {
+      const tab = await browser.tabs.get(tabId).catch(() => null);
+      if (!tab) {
+        result.error = 'not_found';
+        results.push(result);
+        continue;
+      }
+
+      if (tab.discarded) {
+        result.success = true;
+        results.push(result);
+        continue;
+      }
+
+      if (!allowActive && tab.active) {
+        result.error = 'active_tab';
+        results.push(result);
+        continue;
+      }
+
+      let restoreAutoDiscardable = false;
+      if (tab.autoDiscardable === false) {
+        restoreAutoDiscardable = true;
+        await browser.tabs.update(tabId, { autoDiscardable: true });
+      }
+
+      await browser.tabs.discard(tabId);
+
+      if (restoreAutoDiscardable) {
+        try {
+          await browser.tabs.update(tabId, { autoDiscardable: false });
+        } catch (_) {}
+      }
+
+      unmarkVisited(tabId);
+      result.success = true;
+    } catch (error) {
+      result.error = error && error.message ? error.message : 'unknown_error';
+      console.error('Failed to unload tab', tabId, error);
+    }
+
+    results.push(result);
+  }
+
+  return { results };
+}
+
 let recent = [];
 let visited = new Set();
 let recentTimer = null;
@@ -281,6 +338,9 @@ browser.runtime.onMessage.addListener((msg) => {
     return Promise.resolve({ tabs: allTabCache, visited: Array.from(visited) });
   } else if (msg && msg.type === 'unmarkVisited') {
     unmarkVisited(msg.tabId);
+  } else if (msg && msg.type === 'unloadTabs') {
+    const tabIds = Array.isArray(msg.tabIds) ? msg.tabIds : [];
+    return unloadTabs(tabIds, { allowActive: Boolean(msg.allowActive) });
   } else if (msg && msg.type === 'reorderRecent') {
     reorderRecent(msg.ids || [], msg.toId, msg.before);
   } else if (msg && msg.type === 'clearVisitHistory') {
@@ -325,12 +385,8 @@ async function openFullView() {
 
 async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.filter(t => !t.discarded)
-    .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
-    }));
+  const ids = tabs.filter(t => !t.discarded).map(t => t.id);
+  await unloadTabs(ids);
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
   visited = new Set();
   recent = [];
@@ -342,14 +398,12 @@ async function checkAutoUnload() {
   const threshold = Date.now() - autoUnloadMinutes * 60000;
   try {
     const tabs = await browser.tabs.query({});
-    await Promise.all(tabs.map(async t => {
-      if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
-        try {
-          await browser.tabs.discard(t.id);
-          unmarkVisited(t.id);
-        } catch (_) {}
-      }
-    }));
+    const ids = tabs
+      .filter(t => !t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold)
+      .map(t => t.id);
+    if (ids.length) {
+      await unloadTabs(ids);
+    }
   } catch (e) {
     console.error('Auto unload failed', e);
   }
@@ -395,6 +449,11 @@ browser.runtime.onInstalled.addListener(async () => {
     title: 'Options',
     contexts: ['browser_action']
   });
+  await browser.contextMenus.create({
+    id: 'unload-tab',
+    title: 'Unload Tab',
+    contexts: ['tab']
+  });
 });
 
 browser.contextMenus.onClicked.addListener((info) => {
@@ -402,5 +461,7 @@ browser.contextMenus.onClicked.addListener((info) => {
     openFullView();
   } else if (info.menuItemId === 'open-options') {
     browser.runtime.openOptionsPage();
+  } else if (info.menuItemId === 'unload-tab' && typeof info.tabId === 'number') {
+    unloadTabs([info.tabId], { allowActive: true }).catch(() => {});
   }
 });

--- a/mytabs/manifest.json
+++ b/mytabs/manifest.json
@@ -17,8 +17,7 @@
       "cookies"
     ],
   "background": {
-
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
   "action": {
     "default_title": "KepiTAB Manager",

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1395,10 +1395,7 @@ function showContextMenu(e) {
     });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
-      try {
-        await browser.tabs.discard(id);
-        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
+      await requestUnload([id], true);
       scheduleUpdate();
     });
     // Direct move option removed in favor of flagged move workflow
@@ -1451,6 +1448,24 @@ async function bulkClose() {
   scheduleUpdate();
 }
 
+async function requestUnload(tabIds, allowActive = false) {
+  if (!Array.isArray(tabIds) || !tabIds.length) {
+    return { results: [] };
+  }
+
+  try {
+    const response = await browser.runtime.sendMessage({
+      type: 'unloadTabs',
+      tabIds,
+      allowActive
+    });
+    return response || { results: [] };
+  } catch (error) {
+    console.error('Failed to request tab unload', error);
+    return { results: [] };
+  }
+}
+
 async function bulkReload() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(id => browser.tabs.reload(id)));
@@ -1467,22 +1482,13 @@ async function bulkActivate() {
 
 async function bulkDiscard() {
   const ids = getSelectedTabIds();
-  await Promise.all(ids.map(async id => {
-    try {
-      await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-    } catch (_) {}
-  }));
+  await requestUnload(ids, true);
   scheduleUpdate();
 }
 
 async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.map(async t => {
-    try {
-      await browser.tabs.discard(t.id);
-    } catch (_) {}
-  }));
+  await requestUnload(tabs.map(t => t.id), true);
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
   scheduleUpdate();
 }


### PR DESCRIPTION
## Summary
- add a background unloadTabs helper that preserves native discarded state handling
- route popup actions and a new tab context menu option through the helper to unload tabs
- switch the manifest background definition to a Manifest V3 service worker

## Testing
- not run (extension-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f2d2a03c388331a0c4b2e2300d3ba8