### PR TITLE
Add Firefox tab unload helper and refresh UI messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Container-related actions require Firefox's container feature and the `contextualIdentities` permission. Starting with version 0.3 the extension also needs the `cookies` permission so tabs can be opened in a different container. If containers are disabled, the container filter and "Add to Container" buttons will not be shown. Pinned and active tabs keep their state and order when moved between windows or containers.
 
+KepiTAB Manager now leverages Firefox's native tab unload API (`browser.tabs.unload`) whenever it is available, automatically falling back to the legacy `browser.tabs.discard` method on older browser versions.
+
 ## Development
 
 Install dev dependencies and run Stylelint to check the stylesheet.

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -8,6 +8,25 @@ let recentTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
+async function unloadTab(tabId) {
+  if (typeof tabId !== 'number') return false;
+  if (browser.tabs.unload) {
+    try {
+      await browser.tabs.unload(tabId);
+      return true;
+    } catch (e) {
+      // Fallback handled below
+    }
+  }
+  if (browser.tabs.discard) {
+    try {
+      await browser.tabs.discard(tabId);
+      return true;
+    } catch (_) {}
+  }
+  return false;
+}
+
 async function applyAutoDiscardable() {
   try {
     const tabs = await browser.tabs.query({});
@@ -208,6 +227,14 @@ function pushRecent(tabId) {
   scheduleRecentSave();
 }
 
+function removeFromRecent(tabId) {
+  const idx = recent.indexOf(tabId);
+  if (idx !== -1) {
+    recent.splice(idx, 1);
+    scheduleRecentSave();
+  }
+}
+
 function reorderRecent(ids, toId, before) {
   ids = ids.filter(id => id !== toId);
   if (!ids.length) return;
@@ -287,6 +314,24 @@ browser.runtime.onMessage.addListener((msg) => {
     clearVisitHistory();
   } else if (msg && msg.type === 'openFullView') {
     return openFullView();
+  } else if (msg && msg.type === 'unloadTabs') {
+    const ids = Array.isArray(msg.tabIds) ? msg.tabIds : [];
+    const unmark = msg.unmarkVisited !== false;
+    const pruneRecent = Boolean(msg.removeRecent);
+    return (async () => {
+      const results = await Promise.all(ids.map(async id => {
+        const unloaded = await unloadTab(id);
+        if (unloaded) {
+          if (unmark) unmarkVisited(id);
+          if (pruneRecent) removeFromRecent(id);
+        }
+        return unloaded;
+      }));
+      await refreshTabState();
+      return { unloaded: results.filter(Boolean).length };
+    })();
+  } else if (msg && msg.type === 'unloadAllTabs') {
+    return unloadAllTabs().then(() => ({ success: true }));
   }
 });
 
@@ -327,14 +372,17 @@ async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.filter(t => !t.discarded)
     .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
+      const unloaded = await unloadTab(t.id);
+      if (unloaded) {
+        removeFromRecent(t.id);
+        unmarkVisited(t.id);
+      }
     }));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
   visited = new Set();
   recent = [];
   sendVisitedUpdate();
+  await refreshTabState();
 }
 
 async function checkAutoUnload() {
@@ -344,10 +392,11 @@ async function checkAutoUnload() {
     const tabs = await browser.tabs.query({});
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
-        try {
-          await browser.tabs.discard(t.id);
+        const unloaded = await unloadTab(t.id);
+        if (unloaded) {
           unmarkVisited(t.id);
-        } catch (_) {}
+          removeFromRecent(t.id);
+        }
       }
     }));
   } catch (e) {

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -31,8 +31,8 @@
       <button id="bulk-remove-container">Remove from Container</button>
       <button id="bulk-close">Close</button>
       <button id="bulk-reload">Reload</button>
-      <button id="bulk-discard">Unload</button>
-      <button id="bulk-unload-all">Unload All</button>
+      <button id="bulk-discard" title="Use Firefox's native tab unload API when available">Unload (Firefox API)</button>
+      <button id="bulk-unload-all" title="Unload every tab via Firefox's native API when supported">Unload All (Firefox API)</button>
       <button id="bulk-clear">Clear Selection</button>
     </div>
     <div id="easter-egg" class="hidden">

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -31,8 +31,8 @@
       <button id="bulk-remove-container">Remove from Container</button>
       <button id="bulk-close">Close</button>
       <button id="bulk-reload">Reload</button>
-      <button id="bulk-discard">Unload</button>
-      <button id="bulk-unload-all">Unload All</button>
+      <button id="bulk-discard" title="Use Firefox's native tab unload API when available">Unload (Firefox API)</button>
+      <button id="bulk-unload-all" title="Unload every tab via Firefox's native API when supported">Unload All (Firefox API)</button>
       <button id="bulk-clear">Clear Selection</button>
     </div>
   <div id="easter-egg" class="hidden">

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1396,9 +1396,17 @@ function showContextMenu(e) {
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
       try {
-        await browser.tabs.discard(id);
-        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
+        await browser.runtime.sendMessage({
+          type: 'unloadTabs',
+          tabIds: [id],
+          unmarkVisited: true
+        });
+      } catch (e) {
+        try {
+          await browser.tabs.discard(id);
+          await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
+        } catch (_) {}
+      }
       scheduleUpdate();
     });
     // Direct move option removed in favor of flagged move workflow
@@ -1467,23 +1475,40 @@ async function bulkActivate() {
 
 async function bulkDiscard() {
   const ids = getSelectedTabIds();
-  await Promise.all(ids.map(async id => {
-    try {
-      await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-    } catch (_) {}
-  }));
+  if (!ids.length) {
+    scheduleUpdate();
+    return;
+  }
+  try {
+    await browser.runtime.sendMessage({
+      type: 'unloadTabs',
+      tabIds: ids,
+      unmarkVisited: true
+    });
+  } catch (e) {
+    await Promise.all(ids.map(async id => {
+      try {
+        await browser.tabs.discard(id);
+        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
+      } catch (_) {}
+    }));
+  }
   scheduleUpdate();
 }
 
 async function bulkUnloadAll() {
-  const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.map(async t => {
-    try {
-      await browser.tabs.discard(t.id);
-    } catch (_) {}
-  }));
-  await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
+  try {
+    await browser.runtime.sendMessage({ type: 'unloadAllTabs' });
+  } catch (e) {
+    const tabs = await browser.tabs.query({});
+    await Promise.all(tabs.map(async t => {
+      try {
+        await browser.tabs.discard(t.id);
+        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: t.id });
+      } catch (_) {}
+    }));
+    await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
+  }
   scheduleUpdate();
 }
 


### PR DESCRIPTION
## Summary
- add a background helper that prefers `browser.tabs.unload` and falls back to discarding
- route popup unload operations through the helper while keeping visited/recent caches consistent
- update popup/full UI text and documentation to reference Firefox's native unload API

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fbdceb60fc8331a3a04fef05da375a