### PR TITLE
Adopt Firefox native tab unload handling

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -18,19 +18,44 @@ async function applyAutoDiscardable() {
 }
 
 async function unloadTabWithFallback(tabId) {
+  let restoreAutoDiscardable = false;
+  let tabInfo;
+  if (browser.tabs && typeof browser.tabs.get === 'function') {
+    try {
+      tabInfo = await browser.tabs.get(tabId);
+      if (tabInfo && tabInfo.autoDiscardable === false && !tabInfo.discarded) {
+        await browser.tabs.update(tabId, { autoDiscardable: true });
+        restoreAutoDiscardable = true;
+      }
+    } catch (_) {}
+  }
+
+  let unloaded = !!(tabInfo && tabInfo.discarded);
+  if (unloaded) {
+    restoreAutoDiscardable = false;
+  }
   if (browser.tabs && typeof browser.tabs.unload === 'function') {
     try {
-      await browser.tabs.unload(tabId);
-      return true;
+      if (!unloaded) {
+        await browser.tabs.unload(tabId);
+        unloaded = true;
+      }
     } catch (_) {}
   }
-  if (browser.tabs && typeof browser.tabs.discard === 'function') {
+  if (!unloaded && browser.tabs && typeof browser.tabs.discard === 'function') {
     try {
       await browser.tabs.discard(tabId);
-      return true;
+      unloaded = true;
     } catch (_) {}
   }
-  return false;
+
+  if (!unloaded && restoreAutoDiscardable) {
+    try {
+      await browser.tabs.update(tabId, { autoDiscardable: false });
+    } catch (_) {}
+  }
+
+  return unloaded;
 }
 
 // Cache of all tabs for the extension page

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -17,6 +17,22 @@ async function applyAutoDiscardable() {
   } catch (_) {}
 }
 
+async function unloadTabWithFallback(tabId) {
+  if (browser.tabs && typeof browser.tabs.unload === 'function') {
+    try {
+      await browser.tabs.unload(tabId);
+      return true;
+    } catch (_) {}
+  }
+  if (browser.tabs && typeof browser.tabs.discard === 'function') {
+    try {
+      await browser.tabs.discard(tabId);
+      return true;
+    } catch (_) {}
+  }
+  return false;
+}
+
 // Cache of all tabs for the extension page
 let allTabCache = [];
 
@@ -326,11 +342,7 @@ async function openFullView() {
 async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.filter(t => !t.discarded)
-    .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
-    }));
+    .map(t => unloadTabWithFallback(t.id)));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
   visited = new Set();
   recent = [];
@@ -344,10 +356,10 @@ async function checkAutoUnload() {
     const tabs = await browser.tabs.query({});
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
-        try {
-          await browser.tabs.discard(t.id);
+        const unloaded = await unloadTabWithFallback(t.id);
+        if (unloaded) {
           unmarkVisited(t.id);
-        } catch (_) {}
+        }
       }
     }));
   } catch (e) {

--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -17,39 +17,176 @@ async function applyAutoDiscardable() {
   } catch (_) {}
 }
 
+async function activateSiblingTab(tabInfo) {
+  try {
+    const siblings = await browser.tabs.query({ windowId: tabInfo.windowId });
+    if (!Array.isArray(siblings) || siblings.length < 2) {
+      return false;
+    }
+
+    const sorted = siblings
+      .filter(t => t && t.id !== tabInfo.id)
+      .sort((a, b) => a.index - b.index);
+
+    if (!sorted.length) {
+      return false;
+    }
+
+    const reversed = [...sorted].reverse();
+    let candidate = sorted.find(t => t.index > tabInfo.index && !t.discarded);
+    if (!candidate) {
+      candidate = reversed.find(t => t.index < tabInfo.index && !t.discarded);
+    }
+    if (!candidate) {
+      candidate = sorted.find(t => !t.discarded);
+    }
+    if (!candidate) {
+      candidate = sorted.find(t => t.index > tabInfo.index) || reversed.find(t => t.index < tabInfo.index) || sorted[0];
+    }
+
+    await browser.tabs.update(candidate.id, { active: true });
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+async function confirmDiscarded(tabId) {
+  try {
+    const refreshed = await browser.tabs.get(tabId);
+    return !!(refreshed && refreshed.discarded);
+  } catch (_) {
+    return false;
+  }
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function tryTabsUnload(tabId) {
+  if (!browser.tabs || typeof browser.tabs.unload !== 'function') {
+    return false;
+  }
+
+  try {
+    const result = await browser.tabs.unload(tabId);
+    let success = await confirmDiscarded(tabId);
+    if (!success && Array.isArray(result)) {
+      success = result.some(t => t && (t.id === tabId || t.tabId === tabId || t.discarded));
+    }
+    return success;
+  } catch (err) {
+    if (err && typeof browser.tabs.unload === 'function') {
+      try {
+        const secondTry = await browser.tabs.unload([tabId]);
+        let success = await confirmDiscarded(tabId);
+        if (!success && Array.isArray(secondTry)) {
+          success = secondTry.some(t => t && (t.id === tabId || t.tabId === tabId || t.discarded));
+        }
+        return success;
+      } catch (_) {}
+    }
+  }
+
+  return false;
+}
+
+async function tryTabsDiscard(tabId) {
+  if (!browser.tabs || typeof browser.tabs.discard !== 'function') {
+    return false;
+  }
+
+  try {
+    const result = await browser.tabs.discard(tabId);
+    let success = await confirmDiscarded(tabId);
+    if (!success && Array.isArray(result)) {
+      success = result.some(t => t && (t.id === tabId || t.tabId === tabId || t.discarded));
+    }
+    return success;
+  } catch (err) {
+    try {
+      const secondTry = await browser.tabs.discard([tabId]);
+      let success = await confirmDiscarded(tabId);
+      if (!success && Array.isArray(secondTry)) {
+        success = secondTry.some(t => t && (t.id === tabId || t.tabId === tabId || t.discarded));
+      }
+      return success;
+    } catch (_) {}
+  }
+
+  return false;
+}
+
 async function unloadTabWithFallback(tabId) {
-  let restoreAutoDiscardable = false;
+  if (!browser.tabs || typeof browser.tabs.get !== 'function') {
+    return false;
+  }
+
   let tabInfo;
-  if (browser.tabs && typeof browser.tabs.get === 'function') {
+  try {
+    tabInfo = await browser.tabs.get(tabId);
+  } catch (_) {
+    return false;
+  }
+
+  if (!tabInfo) {
+    return false;
+  }
+
+  let restoreAutoDiscardable = false;
+  if (tabInfo.autoDiscardable === false && !tabInfo.discarded) {
+    try {
+      await browser.tabs.update(tabId, { autoDiscardable: true });
+      restoreAutoDiscardable = true;
+      tabInfo = await browser.tabs.get(tabId);
+    } catch (_) {}
+  }
+
+  if (tabInfo && tabInfo.active && !tabInfo.discarded) {
+    const switched = await activateSiblingTab(tabInfo);
+    if (!switched) {
+      if (restoreAutoDiscardable) {
+        try {
+          await browser.tabs.update(tabId, { autoDiscardable: false });
+        } catch (_) {}
+      }
+      return false;
+    }
+
     try {
       tabInfo = await browser.tabs.get(tabId);
-      if (tabInfo && tabInfo.autoDiscardable === false && !tabInfo.discarded) {
-        await browser.tabs.update(tabId, { autoDiscardable: true });
-        restoreAutoDiscardable = true;
+    } catch (_) {
+      tabInfo = null;
+    }
+    let retries = 5;
+    while (tabInfo && tabInfo.active && retries-- > 0) {
+      await delay(50);
+      try {
+        tabInfo = await browser.tabs.get(tabId);
+      } catch (_) {
+        tabInfo = null;
       }
-    } catch (_) {}
+    }
+    if (tabInfo && tabInfo.active) {
+      if (restoreAutoDiscardable) {
+        try {
+          await browser.tabs.update(tabId, { autoDiscardable: false });
+        } catch (_) {}
+      }
+      return false;
+    }
   }
 
   let unloaded = !!(tabInfo && tabInfo.discarded);
-  if (unloaded) {
-    restoreAutoDiscardable = false;
+  if (!unloaded) {
+    unloaded = await tryTabsUnload(tabId);
   }
-  if (browser.tabs && typeof browser.tabs.unload === 'function') {
-    try {
-      if (!unloaded) {
-        await browser.tabs.unload(tabId);
-        unloaded = true;
-      }
-    } catch (_) {}
-  }
-  if (!unloaded && browser.tabs && typeof browser.tabs.discard === 'function') {
-    try {
-      await browser.tabs.discard(tabId);
-      unloaded = true;
-    } catch (_) {}
+  if (!unloaded) {
+    unloaded = await tryTabsDiscard(tabId);
   }
 
-  if (!unloaded && restoreAutoDiscardable) {
+  if (restoreAutoDiscardable) {
     try {
       await browser.tabs.update(tabId, { autoDiscardable: false });
     } catch (_) {}

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1395,10 +1395,7 @@ function showContextMenu(e) {
     });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
-      try {
-        await browser.tabs.discard(id);
-        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
+      await unloadTabWithFallback(id);
       scheduleUpdate();
     });
     // Direct move option removed in favor of flagged move workflow
@@ -1456,6 +1453,28 @@ async function bulkReload() {
   await Promise.all(ids.map(id => browser.tabs.reload(id)));
 }
 
+async function unloadTabWithFallback(tabId, { notifyVisited = true } = {}) {
+  let unloaded = false;
+  if (browser.tabs && typeof browser.tabs.unload === 'function') {
+    try {
+      await browser.tabs.unload(tabId);
+      unloaded = true;
+    } catch (_) {}
+  }
+  if (!unloaded && browser.tabs && typeof browser.tabs.discard === 'function') {
+    try {
+      await browser.tabs.discard(tabId);
+      unloaded = true;
+    } catch (_) {}
+  }
+  if (unloaded && notifyVisited) {
+    try {
+      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId });
+    } catch (_) {}
+  }
+  return unloaded;
+}
+
 async function bulkActivate() {
   const tabs = await Promise.all(
     getSelectedTabIds().map(id => browser.tabs.get(id))
@@ -1467,22 +1486,13 @@ async function bulkActivate() {
 
 async function bulkDiscard() {
   const ids = getSelectedTabIds();
-  await Promise.all(ids.map(async id => {
-    try {
-      await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-    } catch (_) {}
-  }));
+  await Promise.all(ids.map(id => unloadTabWithFallback(id)));
   scheduleUpdate();
 }
 
 async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.map(async t => {
-    try {
-      await browser.tabs.discard(t.id);
-    } catch (_) {}
-  }));
+  await Promise.all(tabs.map(t => unloadTabWithFallback(t.id, { notifyVisited: false })));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
   scheduleUpdate();
 }

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1454,11 +1454,28 @@ async function bulkReload() {
 }
 
 async function unloadTabWithFallback(tabId, { notifyVisited = true } = {}) {
-  let unloaded = false;
+  let tabInfo;
+  let restoreAutoDiscardable = false;
+  if (browser.tabs && typeof browser.tabs.get === 'function') {
+    try {
+      tabInfo = await browser.tabs.get(tabId);
+      if (tabInfo && tabInfo.autoDiscardable === false && !tabInfo.discarded) {
+        await browser.tabs.update(tabId, { autoDiscardable: true });
+        restoreAutoDiscardable = true;
+      }
+    } catch (_) {}
+  }
+
+  let unloaded = !!(tabInfo && tabInfo.discarded);
+  if (unloaded) {
+    restoreAutoDiscardable = false;
+  }
   if (browser.tabs && typeof browser.tabs.unload === 'function') {
     try {
-      await browser.tabs.unload(tabId);
-      unloaded = true;
+      if (!unloaded) {
+        await browser.tabs.unload(tabId);
+        unloaded = true;
+      }
     } catch (_) {}
   }
   if (!unloaded && browser.tabs && typeof browser.tabs.discard === 'function') {
@@ -1467,6 +1484,13 @@ async function unloadTabWithFallback(tabId, { notifyVisited = true } = {}) {
       unloaded = true;
     } catch (_) {}
   }
+
+  if (!unloaded && restoreAutoDiscardable) {
+    try {
+      await browser.tabs.update(tabId, { autoDiscardable: false });
+    } catch (_) {}
+  }
+
   if (unloaded && notifyVisited) {
     try {
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId });

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1453,49 +1453,197 @@ async function bulkReload() {
   await Promise.all(ids.map(id => browser.tabs.reload(id)));
 }
 
+function unmarkVisitedLocal(tabId) {
+  if (visitedIds.delete(tabId)) {
+    currentVisited.delete(tabId);
+    if (typeof scheduleUpdate === 'function') {
+      scheduleUpdate();
+    }
+  }
+}
+
+async function activateSiblingTab(tabInfo) {
+  try {
+    const siblings = await browser.tabs.query({ windowId: tabInfo.windowId });
+    if (!Array.isArray(siblings) || siblings.length < 2) {
+      return false;
+    }
+
+    const sorted = siblings
+      .filter(t => t && t.id !== tabInfo.id)
+      .sort((a, b) => a.index - b.index);
+
+    if (!sorted.length) {
+      return false;
+    }
+
+    const reversed = [...sorted].reverse();
+    let candidate = sorted.find(t => t.index > tabInfo.index && !t.discarded);
+    if (!candidate) {
+      candidate = reversed.find(t => t.index < tabInfo.index && !t.discarded);
+    }
+    if (!candidate) {
+      candidate = sorted.find(t => !t.discarded);
+    }
+    if (!candidate) {
+      candidate = sorted.find(t => t.index > tabInfo.index) || reversed.find(t => t.index < tabInfo.index) || sorted[0];
+    }
+
+    await browser.tabs.update(candidate.id, { active: true });
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+async function confirmDiscarded(tabId) {
+  try {
+    const refreshed = await browser.tabs.get(tabId);
+    return !!(refreshed && refreshed.discarded);
+  } catch (_) {
+    return false;
+  }
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function tryTabsUnload(tabId) {
+  if (!browser.tabs || typeof browser.tabs.unload !== 'function') {
+    return false;
+  }
+
+  try {
+    const result = await browser.tabs.unload(tabId);
+    let success = await confirmDiscarded(tabId);
+    if (!success && Array.isArray(result)) {
+      success = result.some(t => t && (t.id === tabId || t.tabId === tabId || t.discarded));
+    }
+    return success;
+  } catch (err) {
+    if (err && typeof browser.tabs.unload === 'function') {
+      try {
+        const secondTry = await browser.tabs.unload([tabId]);
+        let success = await confirmDiscarded(tabId);
+        if (!success && Array.isArray(secondTry)) {
+          success = secondTry.some(t => t && (t.id === tabId || t.tabId === tabId || t.discarded));
+        }
+        return success;
+      } catch (_) {}
+    }
+  }
+
+  return false;
+}
+
+async function tryTabsDiscard(tabId) {
+  if (!browser.tabs || typeof browser.tabs.discard !== 'function') {
+    return false;
+  }
+
+  try {
+    const result = await browser.tabs.discard(tabId);
+    let success = await confirmDiscarded(tabId);
+    if (!success && Array.isArray(result)) {
+      success = result.some(t => t && (t.id === tabId || t.tabId === tabId || t.discarded));
+    }
+    return success;
+  } catch (err) {
+    try {
+      const secondTry = await browser.tabs.discard([tabId]);
+      let success = await confirmDiscarded(tabId);
+      if (!success && Array.isArray(secondTry)) {
+        success = secondTry.some(t => t && (t.id === tabId || t.tabId === tabId || t.discarded));
+      }
+      return success;
+    } catch (_) {}
+  }
+
+  return false;
+}
+
 async function unloadTabWithFallback(tabId, { notifyVisited = true } = {}) {
+  if (!browser.tabs || typeof browser.tabs.get !== 'function') {
+    return false;
+  }
+
   let tabInfo;
+  try {
+    tabInfo = await browser.tabs.get(tabId);
+  } catch (_) {
+    return false;
+  }
+
+  if (!tabInfo) {
+    return false;
+  }
+
   let restoreAutoDiscardable = false;
-  if (browser.tabs && typeof browser.tabs.get === 'function') {
+  if (tabInfo.autoDiscardable === false && !tabInfo.discarded) {
+    try {
+      await browser.tabs.update(tabId, { autoDiscardable: true });
+      restoreAutoDiscardable = true;
+      tabInfo = await browser.tabs.get(tabId);
+    } catch (_) {}
+  }
+
+  if (tabInfo && tabInfo.active && !tabInfo.discarded) {
+    const switched = await activateSiblingTab(tabInfo);
+    if (!switched) {
+      if (restoreAutoDiscardable) {
+        try {
+          await browser.tabs.update(tabId, { autoDiscardable: false });
+        } catch (_) {}
+      }
+      return false;
+    }
+
     try {
       tabInfo = await browser.tabs.get(tabId);
-      if (tabInfo && tabInfo.autoDiscardable === false && !tabInfo.discarded) {
-        await browser.tabs.update(tabId, { autoDiscardable: true });
-        restoreAutoDiscardable = true;
+    } catch (_) {
+      tabInfo = null;
+    }
+    let retries = 5;
+    while (tabInfo && tabInfo.active && retries-- > 0) {
+      await delay(50);
+      try {
+        tabInfo = await browser.tabs.get(tabId);
+      } catch (_) {
+        tabInfo = null;
       }
-    } catch (_) {}
+    }
+    if (tabInfo && tabInfo.active) {
+      if (restoreAutoDiscardable) {
+        try {
+          await browser.tabs.update(tabId, { autoDiscardable: false });
+        } catch (_) {}
+      }
+      return false;
+    }
   }
 
   let unloaded = !!(tabInfo && tabInfo.discarded);
-  if (unloaded) {
-    restoreAutoDiscardable = false;
+  if (!unloaded) {
+    unloaded = await tryTabsUnload(tabId);
   }
-  if (browser.tabs && typeof browser.tabs.unload === 'function') {
-    try {
-      if (!unloaded) {
-        await browser.tabs.unload(tabId);
-        unloaded = true;
-      }
-    } catch (_) {}
-  }
-  if (!unloaded && browser.tabs && typeof browser.tabs.discard === 'function') {
-    try {
-      await browser.tabs.discard(tabId);
-      unloaded = true;
-    } catch (_) {}
+  if (!unloaded) {
+    unloaded = await tryTabsDiscard(tabId);
   }
 
-  if (!unloaded && restoreAutoDiscardable) {
+  if (restoreAutoDiscardable) {
     try {
       await browser.tabs.update(tabId, { autoDiscardable: false });
     } catch (_) {}
   }
 
   if (unloaded && notifyVisited) {
+    unmarkVisitedLocal(tabId);
     try {
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId });
     } catch (_) {}
   }
+
   return unloaded;
 }
 


### PR DESCRIPTION
## Summary
- add a shared helper that prefers `browser.tabs.unload` and falls back to `browser.tabs.discard`
- update popup actions to use the helper so manual and bulk unload operations leverage Firefox's native behavior
- reuse the helper in background auto-unload logic to keep visit tracking in sync

## Testing
- not run (extension code)

------
https://chatgpt.com/codex/tasks/task_e_68fbd900b2b083318c15c5573b2e9a8d