### PR TITLE
Prefer Firefox tab unload API

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -8,6 +8,28 @@ let recentTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
+async function tryUnloadTab(tabId) {
+  if (typeof browser.tabs.unload === 'function') {
+    try {
+      await browser.tabs.unload(tabId);
+      return true;
+    } catch (_) {}
+  }
+  try {
+    await browser.tabs.discard(tabId);
+    return true;
+  } catch (_) {}
+  return false;
+}
+
+async function unloadTab(tabId, { unmark = false } = {}) {
+  const success = await tryUnloadTab(tabId);
+  if (success && unmark) {
+    unmarkVisited(tabId);
+  }
+  return success;
+}
+
 async function applyAutoDiscardable() {
   try {
     const tabs = await browser.tabs.query({});
@@ -325,12 +347,9 @@ async function openFullView() {
 
 async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.filter(t => !t.discarded)
-    .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
-    }));
+  await Promise.all(tabs
+    .filter(t => !t.discarded)
+    .map(t => unloadTab(t.id)));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
   visited = new Set();
   recent = [];
@@ -344,10 +363,7 @@ async function checkAutoUnload() {
     const tabs = await browser.tabs.query({});
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
-        try {
-          await browser.tabs.discard(t.id);
-          unmarkVisited(t.id);
-        } catch (_) {}
+        await unloadTab(t.id, { unmark: true });
       }
     }));
   } catch (e) {

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -45,6 +45,30 @@ const popupScrollPos = { all: 0, recent: 0, dups: 0 };
 let easterEgg;
 const collapsedWins = new Set();
 
+async function tryUnloadTab(tabId) {
+  if (typeof browser.tabs.unload === 'function') {
+    try {
+      await browser.tabs.unload(tabId);
+      return true;
+    } catch (_) {}
+  }
+  try {
+    await browser.tabs.discard(tabId);
+    return true;
+  } catch (_) {}
+  return false;
+}
+
+async function unloadTab(tabId, { notifyVisited = true } = {}) {
+  const success = await tryUnloadTab(tabId);
+  if (success && notifyVisited) {
+    try {
+      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId });
+    } catch (_) {}
+  }
+  return success;
+}
+
 function showEasterEgg() {
   if (!easterEgg || easterEgg.classList.contains('visible')) return;
   const hide = () => {
@@ -1395,10 +1419,7 @@ function showContextMenu(e) {
     });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
-      try {
-        await browser.tabs.discard(id);
-        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
+      await unloadTab(id);
       scheduleUpdate();
     });
     // Direct move option removed in favor of flagged move workflow
@@ -1467,22 +1488,13 @@ async function bulkActivate() {
 
 async function bulkDiscard() {
   const ids = getSelectedTabIds();
-  await Promise.all(ids.map(async id => {
-    try {
-      await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-    } catch (_) {}
-  }));
+  await Promise.all(ids.map(id => unloadTab(id)));
   scheduleUpdate();
 }
 
 async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.map(async t => {
-    try {
-      await browser.tabs.discard(t.id);
-    } catch (_) {}
-  }));
+  await Promise.all(tabs.map(t => unloadTab(t.id, { notifyVisited: false })));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
   scheduleUpdate();
 }


### PR DESCRIPTION
## Summary
- add helpers that prefer the Firefox `browser.tabs.unload` API with a discard fallback
- update popup bulk and single tab actions to reuse the new unload helper and maintain visited state
- switch background bulk and automatic unload workflows to the new helper logic

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fbd900b2b083318c15c5573b2e9a8d