### PR TITLE
Use Firefox native tab unload API

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -8,6 +8,19 @@ let recentTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
+async function unloadTab(tabId) {
+  try {
+    if (browser.tabs.unload) {
+      await browser.tabs.unload(tabId);
+    } else {
+      await browser.tabs.discard(tabId);
+    }
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
 async function applyAutoDiscardable() {
   try {
     const tabs = await browser.tabs.query({});
@@ -327,9 +340,7 @@ async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.filter(t => !t.discarded)
     .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
+      await unloadTab(t.id);
     }));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
   visited = new Set();
@@ -344,10 +355,9 @@ async function checkAutoUnload() {
     const tabs = await browser.tabs.query({});
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
-        try {
-          await browser.tabs.discard(t.id);
+        if (await unloadTab(t.id)) {
           unmarkVisited(t.id);
-        } catch (_) {}
+        }
       }
     }));
   } catch (e) {

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -45,6 +45,19 @@ const popupScrollPos = { all: 0, recent: 0, dups: 0 };
 let easterEgg;
 const collapsedWins = new Set();
 
+async function unloadTabById(tabId) {
+  try {
+    if (browser.tabs.unload) {
+      await browser.tabs.unload(tabId);
+    } else {
+      await browser.tabs.discard(tabId);
+    }
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
 function showEasterEgg() {
   if (!easterEgg || easterEgg.classList.contains('visible')) return;
   const hide = () => {
@@ -1396,8 +1409,9 @@ function showContextMenu(e) {
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
       try {
-        await browser.tabs.discard(id);
-        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
+        if (await unloadTabById(id)) {
+          await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id }).catch(() => {});
+        }
       } catch (_) {}
       scheduleUpdate();
     });
@@ -1469,8 +1483,9 @@ async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
     try {
-      await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
+      if (await unloadTabById(id)) {
+        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id }).catch(() => {});
+      }
     } catch (_) {}
   }));
   scheduleUpdate();
@@ -1480,7 +1495,7 @@ async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.map(async t => {
     try {
-      await browser.tabs.discard(t.id);
+      await unloadTabById(t.id);
     } catch (_) {}
   }));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });


### PR DESCRIPTION
## Summary
- add shared helpers to prefer `browser.tabs.unload` with a `browser.tabs.discard` fallback
- update popup and background unload flows to use the helper and keep visit tracking consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fbd900b2b083318c15c5573b2e9a8d