### PR TITLE
Adopt Firefox native tab unload API

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -8,6 +8,15 @@ let recentTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
+async function unloadTab(tabId) {
+  if (!tabId) return;
+  if (browser.tabs.unload) {
+    await browser.tabs.unload(tabId);
+  } else {
+    await browser.tabs.discard(tabId);
+  }
+}
+
 async function applyAutoDiscardable() {
   try {
     const tabs = await browser.tabs.query({});
@@ -326,11 +335,7 @@ async function openFullView() {
 async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.filter(t => !t.discarded)
-    .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
-    }));
+    .map(t => unloadTab(t.id).catch(() => {})));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
   visited = new Set();
   recent = [];
@@ -345,7 +350,7 @@ async function checkAutoUnload() {
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
         try {
-          await browser.tabs.discard(t.id);
+          await unloadTab(t.id);
           unmarkVisited(t.id);
         } catch (_) {}
       }

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -45,6 +45,22 @@ const popupScrollPos = { all: 0, recent: 0, dups: 0 };
 let easterEgg;
 const collapsedWins = new Set();
 
+async function unloadTab(tabId) {
+  if (!tabId) return;
+  if (browser.tabs.unload) {
+    await browser.tabs.unload(tabId);
+  } else {
+    await browser.tabs.discard(tabId);
+  }
+}
+
+async function unloadTabAndUnmark(tabId) {
+  try {
+    await unloadTab(tabId);
+    await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId });
+  } catch (_) {}
+}
+
 function showEasterEgg() {
   if (!easterEgg || easterEgg.classList.contains('visible')) return;
   const hide = () => {
@@ -1395,10 +1411,7 @@ function showContextMenu(e) {
     });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
-      try {
-        await browser.tabs.discard(id);
-        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
+      await unloadTabAndUnmark(id);
       scheduleUpdate();
     });
     // Direct move option removed in favor of flagged move workflow
@@ -1467,22 +1480,13 @@ async function bulkActivate() {
 
 async function bulkDiscard() {
   const ids = getSelectedTabIds();
-  await Promise.all(ids.map(async id => {
-    try {
-      await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-    } catch (_) {}
-  }));
+  await Promise.all(ids.map(id => unloadTabAndUnmark(id)));
   scheduleUpdate();
 }
 
 async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.map(async t => {
-    try {
-      await browser.tabs.discard(t.id);
-    } catch (_) {}
-  }));
+  await Promise.all(tabs.map(t => unloadTab(t.id).catch(() => {})));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
   scheduleUpdate();
 }


### PR DESCRIPTION
## Summary
- add helper utilities that prefer the Firefox-native `browser.tabs.unload` API with a fallback to `browser.tabs.discard`
- update popup and background workflows to call the helper so manual, bulk, and automatic unload actions match Firefox behavior

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fbd900b2b083318c15c5573b2e9a8d