### PR TITLE
Restore tab unload behavior when autoDiscardable is disabled

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -17,6 +17,48 @@ async function applyAutoDiscardable() {
   } catch (_) {}
 }
 
+async function unloadTabWithFallback(tabId) {
+  if (!browser.tabs) return false;
+
+  let tab = null;
+  try {
+    tab = await browser.tabs.get(tabId);
+    if (tab?.discarded) {
+      return true;
+    }
+  } catch (_) {}
+
+  let restoreAutoDiscardable = false;
+  if (tab && tab.autoDiscardable === false) {
+    try {
+      await browser.tabs.update(tabId, { autoDiscardable: true });
+      restoreAutoDiscardable = true;
+    } catch (_) {}
+  }
+
+  let unloaded = false;
+  if (typeof browser.tabs.unload === 'function') {
+    try {
+      await browser.tabs.unload(tabId);
+      unloaded = true;
+    } catch (_) {}
+  }
+  if (!unloaded && typeof browser.tabs.discard === 'function') {
+    try {
+      await browser.tabs.discard(tabId);
+      unloaded = true;
+    } catch (_) {}
+  }
+
+  if (restoreAutoDiscardable) {
+    try {
+      await browser.tabs.update(tabId, { autoDiscardable: false });
+    } catch (_) {}
+  }
+
+  return unloaded;
+}
+
 // Cache of all tabs for the extension page
 let allTabCache = [];
 
@@ -326,11 +368,7 @@ async function openFullView() {
 async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.filter(t => !t.discarded)
-    .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
-    }));
+    .map(t => unloadTabWithFallback(t.id)));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
   visited = new Set();
   recent = [];
@@ -344,10 +382,10 @@ async function checkAutoUnload() {
     const tabs = await browser.tabs.query({});
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
-        try {
-          await browser.tabs.discard(t.id);
+        const unloaded = await unloadTabWithFallback(t.id);
+        if (unloaded) {
           unmarkVisited(t.id);
-        } catch (_) {}
+        }
       }
     }));
   } catch (e) {

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -1395,10 +1395,7 @@ function showContextMenu(e) {
     });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
-      try {
-        await browser.tabs.discard(id);
-        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
+      await unloadTabWithFallback(id);
       scheduleUpdate();
     });
     // Direct move option removed in favor of flagged move workflow
@@ -1456,6 +1453,57 @@ async function bulkReload() {
   await Promise.all(ids.map(id => browser.tabs.reload(id)));
 }
 
+async function unloadTabWithFallback(tabId, { notifyVisited = true } = {}) {
+  if (!browser.tabs) return false;
+
+  let tab = null;
+  try {
+    tab = await browser.tabs.get(tabId);
+    if (tab?.discarded) {
+      if (notifyVisited) {
+        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId });
+      }
+      return true;
+    }
+  } catch (_) {}
+
+  let restoreAutoDiscardable = false;
+  if (tab && tab.autoDiscardable === false) {
+    try {
+      await browser.tabs.update(tabId, { autoDiscardable: true });
+      restoreAutoDiscardable = true;
+    } catch (_) {}
+  }
+
+  let unloaded = false;
+  if (typeof browser.tabs.unload === 'function') {
+    try {
+      await browser.tabs.unload(tabId);
+      unloaded = true;
+    } catch (_) {}
+  }
+  if (!unloaded && typeof browser.tabs.discard === 'function') {
+    try {
+      await browser.tabs.discard(tabId);
+      unloaded = true;
+    } catch (_) {}
+  }
+
+  if (restoreAutoDiscardable) {
+    try {
+      await browser.tabs.update(tabId, { autoDiscardable: false });
+    } catch (_) {}
+  }
+
+  if (unloaded && notifyVisited) {
+    try {
+      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId });
+    } catch (_) {}
+  }
+
+  return unloaded;
+}
+
 async function bulkActivate() {
   const tabs = await Promise.all(
     getSelectedTabIds().map(id => browser.tabs.get(id))
@@ -1467,22 +1515,13 @@ async function bulkActivate() {
 
 async function bulkDiscard() {
   const ids = getSelectedTabIds();
-  await Promise.all(ids.map(async id => {
-    try {
-      await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-    } catch (_) {}
-  }));
+  await Promise.all(ids.map(id => unloadTabWithFallback(id)));
   scheduleUpdate();
 }
 
 async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.map(async t => {
-    try {
-      await browser.tabs.discard(t.id);
-    } catch (_) {}
-  }));
+  await Promise.all(tabs.map(t => unloadTabWithFallback(t.id, { notifyVisited: false })));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
   scheduleUpdate();
 }


### PR DESCRIPTION
## Summary
- update the shared unload helper to temporarily re-enable autoDiscardable before invoking Firefox's unload APIs so tabs adopt the native unloaded state
- reuse the same logic in the popup helper so already-discarded tabs are short-circuited and visit tracking remains consistent

## Testing
- not run (extension code)

------
https://chatgpt.com/codex/tasks/task_e_68fbd900b2b083318c15c5573b2e9a8d