### PR TITLE
Add native tab unload handling and status feedback

### DIFF
--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -35,6 +35,10 @@
       <button id="bulk-unload-all">Unload All</button>
       <button id="bulk-clear">Clear Selection</button>
     </div>
+    <div id="operation-status" class="hidden" role="status" aria-live="polite">
+      <span class="spinner" aria-hidden="true"></span>
+      <span class="status-text"></span>
+    </div>
     <div id="easter-egg" class="hidden">
       <div class="egg-content">
         <h2>🎉 Hidden Menu 🎉</h2>

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -35,6 +35,10 @@
       <button id="bulk-unload-all">Unload All</button>
       <button id="bulk-clear">Clear Selection</button>
     </div>
+  <div id="operation-status" class="hidden" role="status" aria-live="polite">
+    <span class="spinner" aria-hidden="true"></span>
+    <span class="status-text"></span>
+  </div>
   <div id="easter-egg" class="hidden">
     <div class="egg-content">
       <h2>🎉 Hidden Menu 🎉</h2>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -44,6 +44,11 @@ const fullScrollPos = { all: 0, recent: 0, dups: 0 };
 const popupScrollPos = { all: 0, recent: 0, dups: 0 };
 let easterEgg;
 const collapsedWins = new Set();
+const NON_DISCARDABLE_SCHEMES = /^(about:|moz-extension:|chrome:|resource:|view-source:|devtools:)/i;
+const MAX_NATIVE_UNLOAD_CONCURRENCY = 6;
+let operationStatusEl = null;
+let operationStatusTextEl = null;
+let operationStatusHideTimer = null;
 
 function showEasterEgg() {
   if (!easterEgg || easterEgg.classList.contains('visible')) return;
@@ -180,6 +185,209 @@ function debounce(fn, delay) {
     clearTimeout(timer);
     timer = setTimeout(() => fn(...args), delay);
   };
+}
+
+function normalizeErrorMessage(err) {
+  if (!err) return 'Unknown error';
+  if (typeof err === 'string') {
+    return err.replace(/^Error:\s*/i, '').split('\n')[0].trim() || 'Unknown error';
+  }
+  if (err && typeof err.message === 'string') {
+    return err.message.replace(/^Error:\s*/i, '').split('\n')[0].trim() || 'Unknown error';
+  }
+  try {
+    return String(err).replace(/^Error:\s*/i, '').split('\n')[0].trim() || 'Unknown error';
+  } catch (_) {
+    return 'Unknown error';
+  }
+}
+
+function isSystemTab(tab) {
+  if (!tab || typeof tab.url !== 'string') return false;
+  return NON_DISCARDABLE_SCHEMES.test(tab.url);
+}
+
+function incrementReason(bucket, reason) {
+  if (!reason) return;
+  if (!bucket[reason]) bucket[reason] = 0;
+  bucket[reason]++;
+}
+
+function sumReasonCounts(bucket) {
+  return Object.values(bucket).reduce((acc, count) => acc + count, 0);
+}
+
+function formatReasonSummary(bucket) {
+  const entries = Object.entries(bucket);
+  if (!entries.length) return '';
+  return entries
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([reason, count]) => `${reason} ×${count}`)
+    .join(', ');
+}
+
+function showOperationStatus(state, message, { autoHide = true } = {}) {
+  if (!operationStatusEl) return;
+  if (operationStatusHideTimer) {
+    clearTimeout(operationStatusHideTimer);
+    operationStatusHideTimer = null;
+  }
+  operationStatusEl.classList.remove('hidden', 'is-busy', 'is-error', 'is-success', 'is-info');
+  operationStatusEl.classList.remove('hidden');
+  if (state === 'busy') operationStatusEl.classList.add('is-busy');
+  else if (state === 'error') operationStatusEl.classList.add('is-error');
+  else if (state === 'success') operationStatusEl.classList.add('is-success');
+  else operationStatusEl.classList.add('is-info');
+  if (operationStatusTextEl) operationStatusTextEl.textContent = message;
+  if (state === 'busy') return;
+  if (!autoHide) return;
+  const timeout = state === 'error' ? 7000 : 4500;
+  operationStatusHideTimer = setTimeout(() => {
+    clearOperationStatus();
+  }, timeout);
+}
+
+function clearOperationStatus() {
+  if (!operationStatusEl) return;
+  if (operationStatusHideTimer) {
+    clearTimeout(operationStatusHideTimer);
+    operationStatusHideTimer = null;
+  }
+  operationStatusEl.classList.add('hidden');
+  operationStatusEl.classList.remove('is-busy', 'is-error', 'is-success', 'is-info');
+  if (operationStatusTextEl) operationStatusTextEl.textContent = '';
+}
+
+function isNativeDiscardAvailable() {
+  return !!(browser?.tabs && typeof browser.tabs.discard === 'function');
+}
+
+async function performNativeUnload(rawTabs, { emptyMessage = 'No tabs available to unload.' } = {}) {
+  const summary = {
+    attempted: 0,
+    unloaded: 0,
+    already: 0,
+    skipped: {},
+    failed: {}
+  };
+  if (!isNativeDiscardAvailable()) {
+    showOperationStatus('error', 'Native tab unload requires a newer version of Firefox.', { autoHide: false });
+    return summary;
+  }
+
+  const uniqueTabs = [];
+  const seen = new Set();
+  for (const tab of rawTabs || []) {
+    if (!tab || typeof tab.id !== 'number') {
+      uniqueTabs.push(null);
+      continue;
+    }
+    if (seen.has(tab.id)) continue;
+    seen.add(tab.id);
+    uniqueTabs.push(tab);
+  }
+
+  if (!uniqueTabs.length) {
+    if (emptyMessage) showOperationStatus('info', emptyMessage);
+    return summary;
+  }
+
+  summary.attempted = uniqueTabs.length;
+  const busyLabel = uniqueTabs.length === 1
+    ? 'Unloading 1 tab…'
+    : `Unloading ${uniqueTabs.length} tabs…`;
+  showOperationStatus('busy', busyLabel, { autoHide: false });
+
+  let index = 0;
+  const concurrency = Math.min(MAX_NATIVE_UNLOAD_CONCURRENCY, uniqueTabs.length) || 1;
+
+  async function worker() {
+    while (index < uniqueTabs.length) {
+      const current = uniqueTabs[index++];
+      if (!current || typeof current.id !== 'number') {
+        incrementReason(summary.failed, 'tab not found');
+        continue;
+      }
+      if (current.discarded) {
+        summary.already++;
+        continue;
+      }
+      if (current.active) {
+        incrementReason(summary.skipped, 'active tab');
+        continue;
+      }
+      if (isSystemTab(current)) {
+        incrementReason(summary.skipped, 'system tab');
+        continue;
+      }
+      try {
+        await browser.tabs.discard(current.id);
+        summary.unloaded++;
+        try {
+          await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: current.id });
+        } catch (_) {}
+      } catch (err) {
+        const message = normalizeErrorMessage(err);
+        if (current.pinned && /pinned/i.test(message)) {
+          incrementReason(summary.skipped, 'pinned tab');
+        } else if (/active/i.test(message) && /discard/i.test(message)) {
+          incrementReason(summary.skipped, 'active tab');
+        } else if (/tab not found|no tab/i.test(message)) {
+          incrementReason(summary.failed, 'tab not found');
+        } else if (/permission|blocked|policy/i.test(message)) {
+          incrementReason(summary.failed, message);
+        } else if (/system|privileged/i.test(message)) {
+          incrementReason(summary.skipped, 'system tab');
+        } else {
+          incrementReason(summary.failed, message);
+        }
+      }
+    }
+  }
+
+  const workers = [];
+  for (let i = 0; i < concurrency; i++) {
+    workers.push(worker());
+  }
+  await Promise.all(workers);
+
+  const skippedCount = sumReasonCounts(summary.skipped);
+  const failedCount = sumReasonCounts(summary.failed);
+  const parts = [];
+  if (summary.unloaded) parts.push(`${summary.unloaded} unloaded`);
+  if (summary.already) parts.push(`${summary.already} already unloaded`);
+  if (skippedCount) {
+    const details = formatReasonSummary(summary.skipped);
+    parts.push(`${skippedCount} skipped${details ? ` (${details})` : ''}`);
+  }
+  if (failedCount) {
+    const details = formatReasonSummary(summary.failed);
+    parts.push(`${failedCount} failed${details ? ` (${details})` : ''}`);
+  }
+  if (!parts.length) parts.push('No tabs processed');
+
+  const resultMessage = `Unload result: ${parts.join(', ')}`;
+  const state = failedCount ? 'error' : summary.unloaded ? 'success' : 'info';
+  showOperationStatus(state, resultMessage, { autoHide: !failedCount });
+  if (summary.unloaded || summary.already || skippedCount || failedCount) {
+    scheduleUpdate();
+  }
+  return summary;
+}
+
+async function unloadTabsByIds(ids, options = {}) {
+  if (!Array.isArray(ids) || !ids.length) {
+    return performNativeUnload([], options);
+  }
+  const tabs = await Promise.all(ids.map(async id => {
+    try {
+      return await browser.tabs.get(id);
+    } catch (err) {
+      console.warn('Failed to resolve tab before unloading', err);
+      return null;
+    }
+  }));
+  return performNativeUnload(tabs, options);
 }
 
 function escapeHtml(str) {
@@ -1084,6 +1292,13 @@ async function init() {
               document.getElementById('tabs');
   scrollContainer = document.getElementById('tabs-wrapper') || container;
   easterEgg = document.getElementById('easter-egg');
+  operationStatusEl = document.getElementById('operation-status');
+  operationStatusTextEl = operationStatusEl?.querySelector('.status-text') || null;
+  if (operationStatusEl && !operationStatusTextEl) {
+    operationStatusTextEl = document.createElement('span');
+    operationStatusTextEl.className = 'status-text';
+    operationStatusEl.appendChild(operationStatusTextEl);
+  }
   const menuEl = document.getElementById('menu');
   menuEl?.addEventListener('dblclick', showEasterEgg);
   scrollContainer.addEventListener('scroll', saveScroll);
@@ -1241,6 +1456,7 @@ function unregisterTabEvents() {
 function cleanup() {
   unregisterTabEvents();
   resetTabState();
+  clearOperationStatus();
 }
 
 document.addEventListener('DOMContentLoaded', init);
@@ -1395,11 +1611,7 @@ function showContextMenu(e) {
     });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
-      try {
-        await browser.tabs.discard(id);
-        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
-      scheduleUpdate();
+      await unloadTabsByIds([id], { emptyMessage: 'No tabs available to unload.' });
     });
     // Direct move option removed in favor of flagged move workflow
   }
@@ -1467,13 +1679,27 @@ async function bulkActivate() {
 
 async function bulkDiscard() {
   const ids = getSelectedTabIds();
-  await Promise.all(ids.map(async id => {
+  if (ids.length) {
+    await unloadTabsByIds(ids, { emptyMessage: 'No selected tabs available to unload.' });
+    return;
+  }
+  let activeTab = null;
+  if (currentActiveId !== -1) {
     try {
-      await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
+      activeTab = await browser.tabs.get(currentActiveId);
     } catch (_) {}
-  }));
-  scheduleUpdate();
+  }
+  if (!activeTab) {
+    try {
+      const [active] = await browser.tabs.query({ active: true, currentWindow: true, windowType: 'normal' });
+      if (active) activeTab = active;
+    } catch (_) {}
+  }
+  if (activeTab) {
+    await performNativeUnload([activeTab], { emptyMessage: 'Active tab cannot be unloaded.' });
+  } else {
+    showOperationStatus('info', 'No tabs available to unload.');
+  }
 }
 
 async function bulkUnloadAll() {

--- a/mytabs/sidebar.html
+++ b/mytabs/sidebar.html
@@ -10,6 +10,10 @@
     <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
   </div>
   <div id="error"></div>
+  <div id="operation-status" class="hidden" role="status" aria-live="polite">
+    <span class="spinner" aria-hidden="true"></span>
+    <span class="status-text"></span>
+  </div>
   <div id="tabs"></div>
 
   <script src="theme.js"></script>

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -378,6 +378,62 @@ button:hover {
 .hidden {
   display: none;
 }
+#operation-status {
+  margin-top: 0.5em;
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  padding: 0.4em 0.6em;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--color-text);
+  font-size: 0.9em;
+  transition: opacity 0.2s ease;
+}
+#operation-status .status-text {
+  flex: 1;
+}
+#operation-status .spinner {
+  width: 1em;
+  height: 1em;
+  border: 2px solid transparent;
+  border-top-color: var(--color-text);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  display: none;
+}
+#operation-status.is-busy .spinner {
+  display: inline-block;
+}
+#operation-status.is-success {
+  background: rgba(46, 204, 113, 0.2);
+  border-color: rgba(46, 204, 113, 0.4);
+}
+#operation-status.is-error {
+  background: rgba(231, 76, 60, 0.2);
+  border-color: rgba(231, 76, 60, 0.4);
+}
+#operation-status.is-info {
+  background: rgba(52, 152, 219, 0.2);
+  border-color: rgba(52, 152, 219, 0.4);
+}
+body[data-theme="dark"] #operation-status {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+body[data-theme="dark"] #operation-status.is-success {
+  background: rgba(46, 204, 113, 0.25);
+  border-color: rgba(46, 204, 113, 0.45);
+}
+body[data-theme="dark"] #operation-status.is-error {
+  background: rgba(231, 76, 60, 0.3);
+  border-color: rgba(231, 76, 60, 0.5);
+}
+body[data-theme="dark"] #operation-status.is-info {
+  background: rgba(52, 152, 219, 0.25);
+  border-color: rgba(52, 152, 219, 0.45);
+}
 #easter-egg {
   position: fixed;
   top: 50%;
@@ -635,6 +691,12 @@ body.full #counts.scrolled {
   to {
     opacity: 1;
     transform: none;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a shared operation status element to the popup, full, and sidebar surfaces so unload actions can surface progress and results
- implement a native tab unload workflow that batches requests, respects Firefox limitations, and reports unloaded/skipped/failed counts
- route popup and context menu unload actions through the native workflow and update messaging when no tabs are eligible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fc7993de708331aec45304478f449b