### PR TITLE
Implement native unload handling for tabs

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -8,6 +8,17 @@ let recentTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
+const NON_DISCARDABLE_SCHEMES = new Set([
+  'about',
+  'moz-extension',
+  'chrome',
+  'resource',
+  'file',
+  'view-source',
+  'data',
+  'blob'
+]);
+
 async function applyAutoDiscardable() {
   try {
     const tabs = await browser.tabs.query({});
@@ -191,6 +202,176 @@ function unmarkVisited(tabId) {
   }
 }
 
+function isDiscardSupported() {
+  return typeof browser?.tabs?.discard === 'function';
+}
+
+function isDiscardableUrl(url = '') {
+  try {
+    const schemeMatch = /^([a-z0-9+.-]+):/i.exec(url);
+    if (!schemeMatch) return true;
+    const scheme = schemeMatch[1].toLowerCase();
+    return !NON_DISCARDABLE_SCHEMES.has(scheme);
+  } catch (_) {
+    return true;
+  }
+}
+
+async function findReplacementTab(windowId, activeId, idsToDiscard) {
+  try {
+    const tabs = await browser.tabs.query({ windowId });
+    let candidate = null;
+    for (const tab of tabs) {
+      if (tab.id === activeId) continue;
+      if (idsToDiscard.has(tab.id)) continue;
+      if (tab.discarded) continue;
+      candidate = tab;
+      break;
+    }
+    if (!candidate) {
+      for (const tab of tabs) {
+        if (tab.id === activeId) continue;
+        if (tab.discarded) continue;
+        candidate = tab;
+        break;
+      }
+    }
+    if (!candidate) {
+      candidate = tabs.find(t => t.id !== activeId) || null;
+    }
+    return candidate || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function buildTabInfo(tab) {
+  return {
+    id: tab.id,
+    windowId: tab.windowId,
+    title: tab.title || '',
+    url: tab.url || ''
+  };
+}
+
+function normalizeSummary(summary) {
+  const base = summary || {};
+  base.counts = base.counts || { unloaded: 0, already: 0, skipped: 0, failed: 0 };
+  base.details = base.details || { unloaded: [], already: [], skipped: [], failed: [] };
+  return base;
+}
+
+async function processNativeUnload(options = {}) {
+  if (!isDiscardSupported()) {
+    return { unsupported: true };
+  }
+
+  let tabs = [];
+  const scope = options.scope;
+  if (Array.isArray(options.tabIds) && options.tabIds.length) {
+    const ids = Array.from(new Set(options.tabIds)).filter(id => typeof id === 'number');
+    const resolved = await Promise.all(ids.map(id => browser.tabs.get(id).catch(() => null)));
+    tabs = resolved.filter(Boolean);
+  } else if (scope === 'all') {
+    try {
+      tabs = await browser.tabs.query({});
+    } catch (_) {
+      tabs = [];
+    }
+  } else if (options.target === 'active') {
+    try {
+      const query = typeof options.windowId === 'number'
+        ? { windowId: options.windowId, active: true }
+        : { currentWindow: true, active: true };
+      const activeTabs = await browser.tabs.query(query);
+      tabs = activeTabs.slice(0, 1);
+    } catch (_) {
+      tabs = [];
+    }
+  }
+
+  const uniqueTabs = [];
+  const seen = new Set();
+  for (const tab of tabs) {
+    if (!tab || seen.has(tab.id)) continue;
+    seen.add(tab.id);
+    uniqueTabs.push(tab);
+  }
+
+  const summary = normalizeSummary({});
+  if (!uniqueTabs.length) {
+    return summary;
+  }
+
+  const idsToDiscard = new Set(uniqueTabs.map(t => t.id));
+
+  if (options.switchActive) {
+    const handledWindows = new Set();
+    for (const tab of uniqueTabs) {
+      if (!tab.active || handledWindows.has(tab.windowId)) continue;
+      handledWindows.add(tab.windowId);
+      const replacement = await findReplacementTab(tab.windowId, tab.id, idsToDiscard);
+      if (replacement) {
+        try {
+          await browser.tabs.update(replacement.id, { active: true });
+          tab.active = false;
+        } catch (e) {
+          console.warn('Failed to activate replacement tab', e);
+        }
+      }
+    }
+  }
+
+  for (const tab of uniqueTabs) {
+    const info = buildTabInfo(tab);
+    if (tab.discarded) {
+      summary.counts.already += 1;
+      summary.details.already.push({ ...info, reason: 'already unloaded' });
+      continue;
+    }
+    if (tab.active) {
+      summary.counts.skipped += 1;
+      summary.details.skipped.push({ ...info, reason: 'active tab' });
+      continue;
+    }
+    if (tab.pinned) {
+      summary.counts.skipped += 1;
+      summary.details.skipped.push({ ...info, reason: 'pinned' });
+      continue;
+    }
+    if (!isDiscardableUrl(tab.url)) {
+      summary.counts.skipped += 1;
+      summary.details.skipped.push({ ...info, reason: 'unsupported scheme' });
+      continue;
+    }
+    try {
+      await browser.tabs.discard(tab.id);
+      summary.counts.unloaded += 1;
+      summary.details.unloaded.push({ ...info });
+      unmarkVisited(tab.id);
+    } catch (error) {
+      const message = error?.message || 'unknown error';
+      const msgLower = message.toLowerCase();
+      if (msgLower.includes('active')) {
+        summary.counts.skipped += 1;
+        summary.details.skipped.push({ ...info, reason: 'active tab' });
+      } else if (msgLower.includes('pinned')) {
+        summary.counts.skipped += 1;
+        summary.details.skipped.push({ ...info, reason: 'pinned' });
+      } else if (msgLower.includes('permission') || msgLower.includes('not allowed')) {
+        summary.counts.failed += 1;
+        summary.details.failed.push({ ...info, reason: 'permission denied' });
+      } else {
+        summary.counts.failed += 1;
+        summary.details.failed.push({ ...info, reason: message });
+      }
+    }
+  }
+
+  await refreshTabState();
+  return summary;
+}
+
 function scheduleRecentSave() {
   if (!recentTimer) {
     recentTimer = setTimeout(() => {
@@ -279,6 +460,14 @@ browser.runtime.onMessage.addListener((msg) => {
     return Promise.resolve({ duplicates: Array.from(dupIds) });
   } else if (msg && msg.type === 'getTabState') {
     return Promise.resolve({ tabs: allTabCache, visited: Array.from(visited) });
+  } else if (msg && msg.type === 'unloadTabs') {
+    return processNativeUnload({
+      tabIds: msg.tabIds,
+      scope: msg.scope,
+      target: msg.target,
+      switchActive: !!msg.switchActive,
+      windowId: typeof msg.windowId === 'number' ? msg.windowId : undefined
+    });
   } else if (msg && msg.type === 'unmarkVisited') {
     unmarkVisited(msg.tabId);
   } else if (msg && msg.type === 'reorderRecent') {
@@ -324,17 +513,13 @@ async function openFullView() {
 }
 
 async function unloadAllTabs() {
-  const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.filter(t => !t.discarded)
-    .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
-    }));
-  await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
-  visited = new Set();
-  recent = [];
-  sendVisitedUpdate();
+  const summary = await processNativeUnload({ scope: 'all' });
+  if (summary && !summary.unsupported) {
+    await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
+    visited = new Set();
+    recent = [];
+    sendVisitedUpdate();
+  }
 }
 
 async function checkAutoUnload() {

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -21,6 +21,10 @@
       <input type="text" id="search" placeholder="Search tabs" />
       <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
     </div>
+    <div id="operation-status" class="hidden" role="status" aria-live="polite">
+      <span class="spinner hidden" aria-hidden="true"></span>
+      <span class="status-text"></span>
+    </div>
     <div id="error"></div>
     <div id="tabs-wrapper" class="tab-grid-wrapper">
       <div id="tabs" class="tab-grid"></div>

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -21,6 +21,10 @@
     <input type="text" id="search" placeholder="Search tabs" />
     <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
   </div>
+  <div id="operation-status" class="hidden" role="status" aria-live="polite">
+    <span class="spinner hidden" aria-hidden="true"></span>
+    <span class="status-text"></span>
+  </div>
   <div id="error"></div>
   <div id="tabs-wrapper">
     <div id="tabs"></div>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -45,6 +45,11 @@ const popupScrollPos = { all: 0, recent: 0, dups: 0 };
 let easterEgg;
 const collapsedWins = new Set();
 
+let statusEl = null;
+let statusSpinnerEl = null;
+let statusTextEl = null;
+let statusHideTimer = null;
+
 function showEasterEgg() {
   if (!easterEgg || easterEgg.classList.contains('visible')) return;
   const hide = () => {
@@ -122,6 +127,154 @@ function triggerViewAnimation() {
   el.classList.remove('view-transition');
   void el.offsetWidth;
   el.classList.add('view-transition');
+}
+
+function initStatusElements() {
+  statusEl = document.getElementById('operation-status');
+  statusSpinnerEl = statusEl?.querySelector('.spinner') || null;
+  statusTextEl = statusEl?.querySelector('.status-text') || null;
+  if (statusEl) {
+    statusEl.setAttribute('title', 'Click to dismiss');
+    statusEl.addEventListener('click', hideOperationStatus);
+  }
+}
+
+function resetStatusClasses() {
+  if (!statusEl) return;
+  statusEl.classList.remove('status-success', 'status-warning', 'status-error', 'status-info', 'status-loading');
+}
+
+function hideOperationStatus() {
+  if (!statusEl) return;
+  clearTimeout(statusHideTimer);
+  statusHideTimer = null;
+  statusEl.classList.add('hidden');
+}
+
+function showOperationLoading(message) {
+  if (!statusEl) return;
+  clearTimeout(statusHideTimer);
+  resetStatusClasses();
+  statusEl.classList.remove('hidden');
+  statusEl.classList.add('status-loading');
+  if (statusSpinnerEl) statusSpinnerEl.classList.remove('hidden');
+  if (statusTextEl) statusTextEl.textContent = message;
+}
+
+function showOperationMessage(message, type = 'info', options = {}) {
+  if (!statusEl) return;
+  clearTimeout(statusHideTimer);
+  resetStatusClasses();
+  statusEl.classList.remove('hidden');
+  statusEl.classList.add(`status-${type}`);
+  if (statusSpinnerEl) statusSpinnerEl.classList.add('hidden');
+  if (statusTextEl) statusTextEl.textContent = message;
+  if (!options.persist) {
+    statusHideTimer = setTimeout(() => {
+      statusEl?.classList.add('hidden');
+      statusHideTimer = null;
+    }, options.timeout || 5000);
+  }
+}
+
+function summarizeReasons(items = []) {
+  if (!Array.isArray(items) || !items.length) return '';
+  const counts = new Map();
+  for (const item of items) {
+    const reason = (item?.reason || 'unknown').toString();
+    counts.set(reason, (counts.get(reason) || 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([reason, count]) => {
+      const label = reason.charAt(0).toUpperCase() + reason.slice(1);
+      return count > 1 ? `${label} ×${count}` : label;
+    })
+    .join(', ');
+}
+
+function determineStatusType(counts = {}) {
+  if (!counts) return 'info';
+  if (counts.failed > 0) return 'error';
+  if (counts.unloaded > 0 || counts.already > 0) {
+    return counts.skipped > 0 ? 'warning' : 'success';
+  }
+  return counts.skipped > 0 ? 'info' : 'info';
+}
+
+function formatUnloadSummary(counts = {}, details = {}) {
+  const parts = [];
+  parts.push(`Unloaded: ${counts.unloaded || 0}`);
+  if (counts.already) {
+    parts.push(`Already unloaded: ${counts.already}`);
+  }
+  if (counts.skipped) {
+    const reasons = summarizeReasons(details.skipped);
+    parts.push(`Skipped: ${counts.skipped}${reasons ? ` (${reasons})` : ''}`);
+  }
+  if (counts.failed) {
+    const reasons = summarizeReasons(details.failed);
+    parts.push(`Failed: ${counts.failed}${reasons ? ` (${reasons})` : ''}`);
+  }
+  if (!parts.length) return 'No tabs processed.';
+  return parts.join(' • ');
+}
+
+async function requestNativeUnload(options = {}) {
+  const payload = { type: 'unloadTabs' };
+  if (Array.isArray(options.tabIds) && options.tabIds.length) {
+    payload.tabIds = Array.from(new Set(options.tabIds.filter(id => typeof id === 'number')));
+  } else if (options.scope) {
+    payload.scope = options.scope;
+  } else if (options.defaultToActive) {
+    payload.target = 'active';
+  } else {
+    showOperationMessage('No tabs selected to unload.', 'info');
+    return null;
+  }
+
+  if (options.switchActive) payload.switchActive = true;
+  if (typeof options.windowId === 'number') payload.windowId = options.windowId;
+
+  if (payload.target === 'active' && typeof payload.windowId !== 'number') {
+    try {
+      const currentWin = await browser.windows.getCurrent();
+      if (currentWin && typeof currentWin.id === 'number') payload.windowId = currentWin.id;
+    } catch (_) {}
+  }
+
+  showOperationLoading(options.loadingMessage || 'Unloading tabs…');
+
+  let response;
+  try {
+    response = await browser.runtime.sendMessage(payload);
+  } catch (error) {
+    showOperationMessage(`Failed to request tab unload: ${error?.message || error}`, 'error', { persist: true });
+    return null;
+  }
+
+  if (!response) {
+    showOperationMessage('No response from background script.', 'error', { persist: true });
+    return null;
+  }
+  if (response.unsupported) {
+    showOperationMessage('Native tab unload requires a newer version of Firefox.', 'error', { persist: true });
+    return response;
+  }
+
+  const counts = response.counts || {};
+  const details = response.details || {};
+  const summary = formatUnloadSummary(counts, details);
+  const type = determineStatusType(counts);
+  const persist = type === 'error';
+  showOperationMessage(summary, type, { persist });
+
+  const handledIds = new Set();
+  (details.unloaded || []).forEach(it => handledIds.add(it.id));
+  (details.already || []).forEach(it => handledIds.add(it.id));
+  handledIds.forEach(id => selectedIds.delete(id));
+
+  scheduleUpdate();
+  return response;
 }
 
 function updateViewButtons() {
@@ -1084,6 +1237,7 @@ async function init() {
               document.getElementById('tabs');
   scrollContainer = document.getElementById('tabs-wrapper') || container;
   easterEgg = document.getElementById('easter-egg');
+  initStatusElements();
   const menuEl = document.getElementById('menu');
   menuEl?.addEventListener('dblclick', showEasterEgg);
   scrollContainer.addEventListener('scroll', saveScroll);
@@ -1241,6 +1395,7 @@ function unregisterTabEvents() {
 function cleanup() {
   unregisterTabEvents();
   resetTabState();
+  hideOperationStatus();
 }
 
 document.addEventListener('DOMContentLoaded', init);
@@ -1395,11 +1550,12 @@ function showContextMenu(e) {
     });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
-      try {
-        await browser.tabs.discard(id);
-        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
-      scheduleUpdate();
+      await requestNativeUnload({
+        tabIds: [id],
+        windowId: Number.isFinite(win) ? win : undefined,
+        switchActive: tabEl?.classList?.contains('active'),
+        loadingMessage: 'Unloading tab…'
+      });
     });
     // Direct move option removed in favor of flagged move workflow
   }
@@ -1467,24 +1623,45 @@ async function bulkActivate() {
 
 async function bulkDiscard() {
   const ids = getSelectedTabIds();
-  await Promise.all(ids.map(async id => {
+  if (ids.length) {
+    let windowId;
+    let switchActive = false;
+    if (ids.length === 1) {
+      const entry = tabItems.find(it => it.tab && it.tab.id === ids[0]);
+      if (entry && entry.tab) {
+        windowId = entry.tab.windowId;
+        switchActive = !!entry.tab.active;
+      }
+    }
+    await requestNativeUnload({
+      tabIds: ids,
+      windowId,
+      switchActive,
+      loadingMessage: ids.length > 1 ? 'Unloading selected tabs…' : 'Unloading tab…'
+    });
+  } else {
+    let currentWinId;
     try {
-      await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
+      const win = await browser.windows.getCurrent();
+      if (win && typeof win.id === 'number') currentWinId = win.id;
     } catch (_) {}
-  }));
-  scheduleUpdate();
+    await requestNativeUnload({
+      defaultToActive: true,
+      windowId: currentWinId,
+      switchActive: true,
+      loadingMessage: 'Unloading current tab…'
+    });
+  }
 }
 
 async function bulkUnloadAll() {
-  const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.map(async t => {
-    try {
-      await browser.tabs.discard(t.id);
-    } catch (_) {}
-  }));
-  await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
-  scheduleUpdate();
+  const response = await requestNativeUnload({
+    scope: 'all',
+    loadingMessage: 'Unloading all tabs…'
+  });
+  if (response && !response.unsupported) {
+    await browser.runtime.sendMessage({ type: 'clearVisitHistory' }).catch(() => {});
+  }
 }
 
 async function bulkMove() {

--- a/mytabs/sidebar.html
+++ b/mytabs/sidebar.html
@@ -9,6 +9,10 @@
     <input type="text" id="search" placeholder="Search tabs" />
     <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
   </div>
+  <div id="operation-status" class="hidden" role="status" aria-live="polite">
+    <span class="spinner hidden" aria-hidden="true"></span>
+    <span class="status-text"></span>
+  </div>
   <div id="error"></div>
   <div id="tabs"></div>
 

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -140,6 +140,25 @@ body[data-theme="dark"] #easter-egg {
   position: relative;
 }
 
+.spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-text);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.spinner.hidden {
+  display: none;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .clear-btn {
   position: absolute;
   top: 50%;
@@ -199,6 +218,67 @@ body.popup #tabs-wrapper {
   scrollbar-gutter: stable;
   box-sizing: border-box;
   position: relative;
+}
+
+#operation-status {
+  margin: 0.4em 0;
+  padding: 0.4em 0.6em;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  font-size: 0.85em;
+  background: var(--color-hover);
+  border-left: 4px solid var(--color-border);
+  cursor: pointer;
+}
+
+#operation-status.hidden {
+  display: none;
+}
+
+#operation-status.status-success {
+  background: rgba(46, 139, 87, 0.12);
+  border-left-color: #2e8b57;
+}
+
+#operation-status.status-warning {
+  background: rgba(255, 165, 0, 0.15);
+  border-left-color: #cc8400;
+}
+
+#operation-status.status-error {
+  background: rgba(220, 20, 60, 0.15);
+  border-left-color: #cc143c;
+}
+
+#operation-status.status-info {
+  background: rgba(70, 130, 180, 0.12);
+  border-left-color: #2b6cb0;
+}
+
+#operation-status.status-loading {
+  opacity: 0.85;
+}
+
+body[data-theme="dark"] #operation-status.status-success {
+  background: rgba(46, 139, 87, 0.25);
+  border-left-color: #64d7a2;
+}
+
+body[data-theme="dark"] #operation-status.status-warning {
+  background: rgba(255, 165, 0, 0.2);
+  border-left-color: #ffb347;
+}
+
+body[data-theme="dark"] #operation-status.status-error {
+  background: rgba(220, 20, 60, 0.25);
+  border-left-color: #ff6f91;
+}
+
+body[data-theme="dark"] #operation-status.status-info {
+  background: rgba(70, 130, 180, 0.25);
+  border-left-color: #7fb7ff;
 }
 body.popup #tabs-wrapper::before,
 body.popup #tabs-wrapper::after {


### PR DESCRIPTION
## Summary
- add a background-native unload processor that mirrors Firefox tab discards and reports per-tab outcomes
- update the popup workflows to route unload actions through the native handler and display aggregated status feedback
- add shared status markup and styling so popup, full, and sidebar views surface unload progress and results

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fc7993de708331aec45304478f449b