### PR TITLE
Implement native unload workflow for selected tabs

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -8,6 +8,9 @@ let recentTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
+const SAFE_ABOUT_PAGES = new Set(['about:blank', 'about:newtab', 'about:home']);
+const SPECIAL_TAB_SCHEMES = /^(?:chrome:|resource:|moz-extension:|view-source:|javascript:|data:|jar:)/i;
+
 async function applyAutoDiscardable() {
   try {
     const tabs = await browser.tabs.query({});
@@ -82,6 +85,113 @@ async function clearVisitHistory() {
   visited = new Set();
   await browser.storage.local.remove(['recent', 'visited']).catch(() => {});
   sendVisitedUpdate();
+}
+
+function isSpecialTab(tab) {
+  if (!tab || typeof tab.url !== 'string') {
+    return false;
+  }
+  const url = tab.url.trim().toLowerCase();
+  if (!url) return false;
+  if (url.startsWith('about:')) {
+    return !SAFE_ABOUT_PAGES.has(url);
+  }
+  return SPECIAL_TAB_SCHEMES.test(url);
+}
+
+async function performNativeUnload({ tabs = [], tabIds = [], options = {} } = {}) {
+  if (!browser.tabs || typeof browser.tabs.discard !== 'function') {
+    return { supported: false };
+  }
+
+  const summary = {
+    supported: true,
+    unloaded: [],
+    already: [],
+    skipped: [],
+    failed: []
+  };
+
+  const seen = new Set();
+  const queue = [];
+
+  const enqueueTab = (tab) => {
+    if (!tab || typeof tab.id !== 'number') return;
+    if (seen.has(tab.id)) return;
+    seen.add(tab.id);
+    queue.push(tab);
+  };
+
+  if (Array.isArray(tabs)) {
+    for (const tab of tabs) enqueueTab(tab);
+  }
+
+  if (Array.isArray(tabIds)) {
+    for (const id of tabIds) {
+      if (seen.has(id)) continue;
+      try {
+        const tab = await browser.tabs.get(id);
+        enqueueTab(tab);
+      } catch (e) {
+        summary.failed.push({ id, title: '', reason: e && e.message ? e.message : 'tab not found' });
+      }
+    }
+  }
+
+  const { skipActive = true, clearHistory = false } = options || {};
+  const unmarkIndividually = !clearHistory;
+
+  for (let i = 0; i < queue.length; i++) {
+    const tab = queue[i];
+    if (!tab || typeof tab.id !== 'number') continue;
+
+    if (tab.discarded) {
+      summary.already.push({ id: tab.id, title: tab.title || '', reason: 'already unloaded' });
+      continue;
+    }
+
+    if (skipActive && tab.active) {
+      summary.skipped.push({ id: tab.id, title: tab.title || '', reason: 'active tab' });
+      continue;
+    }
+
+    if (isSpecialTab(tab)) {
+      summary.skipped.push({ id: tab.id, title: tab.title || '', reason: 'special page' });
+      continue;
+    }
+
+    try {
+      await browser.tabs.discard(tab.id);
+      if (unmarkIndividually) {
+        unmarkVisited(tab.id);
+      }
+      summary.unloaded.push({ id: tab.id, title: tab.title || '', reason: 'unloaded' });
+    } catch (e) {
+      const message = e && e.message ? e.message : 'unknown error';
+      const lower = message.toLowerCase();
+      if (tab.pinned && (lower.includes('pinned') || lower.includes('pin '))) {
+        summary.skipped.push({ id: tab.id, title: tab.title || '', reason: 'pinned tab' });
+      } else if (lower.includes('special')) {
+        summary.skipped.push({ id: tab.id, title: tab.title || '', reason: 'special page' });
+      } else {
+        summary.failed.push({ id: tab.id, title: tab.title || '', reason: message });
+      }
+    }
+
+    if (i % 10 === 9) {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+  }
+
+  if (clearHistory) {
+    await clearVisitHistory();
+  }
+
+  if (queue.length) {
+    await refreshTabState();
+  }
+
+  return summary;
 }
 
 async function updateTabCache() {
@@ -285,6 +395,14 @@ browser.runtime.onMessage.addListener((msg) => {
     reorderRecent(msg.ids || [], msg.toId, msg.before);
   } else if (msg && msg.type === 'clearVisitHistory') {
     clearVisitHistory();
+  } else if (msg && msg.type === 'unloadTabsNative') {
+    if (msg.scope === 'all') {
+      return browser.tabs.query({}).then(tabs =>
+        performNativeUnload({ tabs, options: msg.options || {} })
+      );
+    }
+    const tabIds = Array.isArray(msg.tabIds) ? msg.tabIds : [];
+    return performNativeUnload({ tabIds, options: msg.options || {} });
   } else if (msg && msg.type === 'openFullView') {
     return openFullView();
   }
@@ -325,16 +443,7 @@ async function openFullView() {
 
 async function unloadAllTabs() {
   const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.filter(t => !t.discarded)
-    .map(async t => {
-      try {
-        await browser.tabs.discard(t.id);
-      } catch (_) {}
-    }));
-  await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
-  visited = new Set();
-  recent = [];
-  sendVisitedUpdate();
+  await performNativeUnload({ tabs, options: { clearHistory: true } });
 }
 
 async function checkAutoUnload() {

--- a/mytabs/full.html
+++ b/mytabs/full.html
@@ -22,6 +22,7 @@
       <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
     </div>
     <div id="error"></div>
+    <div id="action-status" class="status-message" aria-live="polite"></div>
     <div id="tabs-wrapper" class="tab-grid-wrapper">
       <div id="tabs" class="tab-grid"></div>
     </div>

--- a/mytabs/popup.html
+++ b/mytabs/popup.html
@@ -22,6 +22,7 @@
     <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
   </div>
   <div id="error"></div>
+  <div id="action-status" class="status-message" aria-live="polite"></div>
   <div id="tabs-wrapper">
     <div id="tabs"></div>
   </div>

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -23,6 +23,8 @@ let movePending = null;
 // Persist selection across updates
 let selectedIds = new Set();
 
+let actionStatusTimer = null;
+
 // Cached tab list provided by the background script
 let cachedTabs = null;
 
@@ -44,6 +46,93 @@ const fullScrollPos = { all: 0, recent: 0, dups: 0 };
 const popupScrollPos = { all: 0, recent: 0, dups: 0 };
 let easterEgg;
 const collapsedWins = new Set();
+
+function getActionStatusEl() {
+  return document.getElementById('action-status');
+}
+
+function clearActionStatus() {
+  const el = getActionStatusEl();
+  if (!el) return;
+  el.textContent = '';
+  el.dataset.type = '';
+  el.classList.remove('loading', 'visible');
+  if (actionStatusTimer) {
+    clearTimeout(actionStatusTimer);
+    actionStatusTimer = null;
+  }
+}
+
+function setActionStatus(message, { type = 'info', loading = false, duration = 4000 } = {}) {
+  const el = getActionStatusEl();
+  if (!el) return;
+
+  if (actionStatusTimer) {
+    clearTimeout(actionStatusTimer);
+    actionStatusTimer = null;
+  }
+
+  if (!message) {
+    clearActionStatus();
+    return;
+  }
+
+  el.textContent = message;
+  el.dataset.type = type;
+  el.classList.toggle('loading', !!loading);
+  el.classList.add('visible');
+
+  if (duration > 0 && !loading) {
+    actionStatusTimer = setTimeout(() => {
+      const target = getActionStatusEl();
+      if (!target) return;
+      target.textContent = '';
+      target.dataset.type = '';
+      target.classList.remove('loading', 'visible');
+      actionStatusTimer = null;
+    }, duration);
+  }
+}
+
+function summarizeReasons(entries) {
+  if (!entries || !entries.length) return '';
+  const counts = new Map();
+  for (const entry of entries) {
+    const reason = entry && entry.reason ? entry.reason : 'other';
+    counts.set(reason, (counts.get(reason) || 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([reason, count]) => count > 1 ? `${reason} (${count})` : reason)
+    .join(', ');
+}
+
+function showUnloadSummary(result) {
+  if (!result || result.supported === false) {
+    setActionStatus('Native tab unload is not available in this version of Firefox.', {
+      type: 'error',
+      duration: 6000
+    });
+    return;
+  }
+
+  const unloadedCount = Array.isArray(result.unloaded) ? result.unloaded.length : 0;
+  const skippedCount = Array.isArray(result.skipped) ? result.skipped.length : 0;
+  const failedCount = Array.isArray(result.failed) ? result.failed.length : 0;
+  const alreadyCount = Array.isArray(result.already) ? result.already.length : 0;
+
+  const parts = [];
+  parts.push(`Unloaded: ${unloadedCount}`);
+  const skippedReasons = summarizeReasons(result.skipped);
+  parts.push(`Skipped: ${skippedCount}${skippedReasons ? ` (${skippedReasons})` : ''}`);
+  const failedReasons = summarizeReasons(result.failed);
+  parts.push(`Failed: ${failedCount}${failedReasons ? ` (${failedReasons})` : ''}`);
+  if (alreadyCount) {
+    parts.push(`Already: ${alreadyCount}`);
+  }
+
+  const type = failedCount ? 'error' : (unloadedCount ? 'success' : 'info');
+  setActionStatus(parts.join(' • '), { type, duration: 6000 });
+}
 
 function showEasterEgg() {
   if (!easterEgg || easterEgg.classList.contains('visible')) return;
@@ -1395,11 +1484,27 @@ function showContextMenu(e) {
     });
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
+      if (!browser.tabs || typeof browser.tabs.discard !== 'function') {
+        setActionStatus('Native tab unload is not available in this version of Firefox.', {
+          type: 'error',
+          duration: 6000
+        });
+        return;
+      }
+      setActionStatus('Unloading tab…', { type: 'info', loading: true, duration: 0 });
       try {
-        await browser.tabs.discard(id);
-        await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-      } catch (_) {}
-      scheduleUpdate();
+        const result = await browser.runtime.sendMessage({
+          type: 'unloadTabsNative',
+          tabIds: [id]
+        });
+        showUnloadSummary(result);
+      } catch (e) {
+        console.error('Failed to unload tab', e);
+        const message = e && e.message ? e.message : 'Failed to unload tab.';
+        setActionStatus(message, { type: 'error', duration: 6000 });
+      } finally {
+        scheduleUpdate();
+      }
     });
     // Direct move option removed in favor of flagged move workflow
   }
@@ -1466,25 +1571,74 @@ async function bulkActivate() {
 }
 
 async function bulkDiscard() {
-  const ids = getSelectedTabIds();
-  await Promise.all(ids.map(async id => {
+  if (!browser.tabs || typeof browser.tabs.discard !== 'function') {
+    setActionStatus('Native tab unload is not available in this version of Firefox.', {
+      type: 'error',
+      duration: 6000
+    });
+    return;
+  }
+
+  let ids = getSelectedTabIds();
+  if (!ids.length) {
     try {
-      await browser.tabs.discard(id);
-      await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
-    } catch (_) {}
-  }));
-  scheduleUpdate();
+      const activeTabs = await browser.tabs.query({ currentWindow: true, active: true });
+      if (activeTabs && activeTabs[0]) {
+        ids = [activeTabs[0].id];
+      }
+    } catch (e) {
+      console.error('Failed to resolve active tab for unload', e);
+    }
+  }
+
+  ids = Array.from(new Set(ids));
+  if (!ids.length) {
+    setActionStatus('No tabs available to unload.', { type: 'info', duration: 4000 });
+    return;
+  }
+
+  setActionStatus('Unloading selected tabs…', { type: 'info', loading: true, duration: 0 });
+
+  try {
+    const result = await browser.runtime.sendMessage({
+      type: 'unloadTabsNative',
+      tabIds: ids
+    });
+    showUnloadSummary(result);
+  } catch (e) {
+    console.error('Failed to unload selected tabs', e);
+    const message = e && e.message ? e.message : 'Failed to unload tabs.';
+    setActionStatus(message, { type: 'error', duration: 6000 });
+  } finally {
+    scheduleUpdate();
+  }
 }
 
 async function bulkUnloadAll() {
-  const tabs = await browser.tabs.query({});
-  await Promise.all(tabs.map(async t => {
-    try {
-      await browser.tabs.discard(t.id);
-    } catch (_) {}
-  }));
-  await browser.runtime.sendMessage({ type: 'clearVisitHistory' });
-  scheduleUpdate();
+  if (!browser.tabs || typeof browser.tabs.discard !== 'function') {
+    setActionStatus('Native tab unload is not available in this version of Firefox.', {
+      type: 'error',
+      duration: 6000
+    });
+    return;
+  }
+
+  setActionStatus('Unloading all tabs…', { type: 'info', loading: true, duration: 0 });
+
+  try {
+    const result = await browser.runtime.sendMessage({
+      type: 'unloadTabsNative',
+      scope: 'all',
+      options: { clearHistory: true }
+    });
+    showUnloadSummary(result);
+  } catch (e) {
+    console.error('Failed to unload all tabs', e);
+    const message = e && e.message ? e.message : 'Failed to unload tabs.';
+    setActionStatus(message, { type: 'error', duration: 6000 });
+  } finally {
+    scheduleUpdate();
+  }
 }
 
 async function bulkMove() {

--- a/mytabs/sidebar.html
+++ b/mytabs/sidebar.html
@@ -10,6 +10,7 @@
     <button id="search-clear" class="clear-btn hidden" type="button">&times;</button>
   </div>
   <div id="error"></div>
+  <div id="action-status" class="status-message" aria-live="polite"></div>
   <div id="tabs"></div>
 
   <script src="theme.js"></script>

--- a/mytabs/style.css
+++ b/mytabs/style.css
@@ -118,8 +118,56 @@ body[data-theme="dark"] #easter-egg {
 .count-icon {
   font-size: 1.2em;
 }
-#menu button {
+#menu button { 
   margin-right: 0.2em;
+}
+#action-status.status-message {
+  display: none;
+}
+
+.status-message {
+  min-height: 1.4em;
+  margin: 0.4em 0 0.6em;
+  font-size: 0.9em;
+  color: var(--color-muted);
+  display: none;
+  align-items: center;
+  gap: 0.4em;
+}
+
+.status-message.visible {
+  display: flex;
+}
+
+.status-message.loading::before {
+  content: '';
+  width: 0.9em;
+  height: 0.9em;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-text);
+  border-radius: 50%;
+  animation: status-spin 1s linear infinite;
+}
+
+.status-message[data-type="error"] {
+  color: #b00020;
+}
+
+.status-message[data-type="success"] {
+  color: #0b6b27;
+}
+
+body[data-theme="dark"] .status-message[data-type="error"] {
+  color: #ff7a7a;
+}
+
+body[data-theme="dark"] .status-message[data-type="success"] {
+  color: #66d48c;
+}
+
+@keyframes status-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }
 #menu button.active-view {
   background: linear-gradient(135deg, var(--color-selected), var(--color-active));


### PR DESCRIPTION
## Summary
- add a background helper that invokes Firefox's native discard API and returns structured unload results
- route popup and context menu unload actions through the helper with fallback selection logic and aggregated status reporting
- surface a reusable status indicator in the UI to present unload progress and outcomes across popup, full view, and sidebar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fc7993de708331aec45304478f449b