### PR TITLE
Remove legacy tab discard fallback

### DIFF
--- a/mytabs/background.js
+++ b/mytabs/background.js
@@ -8,6 +8,10 @@ let recentTimer = null;
 let autoUnload = false;
 let autoUnloadMinutes = 60;
 
+function unloadTab(tabId) {
+  return browser.tabs.unload(tabId);
+}
+
 async function applyAutoDiscardable() {
   try {
     const tabs = await browser.tabs.query({});
@@ -328,7 +332,7 @@ async function unloadAllTabs() {
   await Promise.all(tabs.filter(t => !t.discarded)
     .map(async t => {
       try {
-        await browser.tabs.discard(t.id);
+        await unloadTab(t.id);
       } catch (_) {}
     }));
   await browser.storage.local.remove(['visited', 'recent']).catch(() => {});
@@ -345,7 +349,7 @@ async function checkAutoUnload() {
     await Promise.all(tabs.map(async t => {
       if (!t.discarded && !t.active && t.lastAccessed && t.lastAccessed < threshold) {
         try {
-          await browser.tabs.discard(t.id);
+          await unloadTab(t.id);
           unmarkVisited(t.id);
         } catch (_) {}
       }

--- a/mytabs/popup.js
+++ b/mytabs/popup.js
@@ -38,6 +38,10 @@ let currentQuery = '';
 let searchOrder = null;
 // Scroll position to restore after certain operations
 let pendingScroll = null;
+
+function unloadTab(tabId) {
+  return browser.tabs.unload(tabId);
+}
 // Remember horizontal scroll for each view in full window
 const fullScrollPos = { all: 0, recent: 0, dups: 0 };
 // Remember vertical scroll for each view in popup window
@@ -1396,7 +1400,7 @@ function showContextMenu(e) {
     addItem('Activate', () => activateTab(id, win));
     addItem('Unload', async () => {
       try {
-        await browser.tabs.discard(id);
+        await unloadTab(id);
         await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
       } catch (_) {}
       scheduleUpdate();
@@ -1469,7 +1473,7 @@ async function bulkDiscard() {
   const ids = getSelectedTabIds();
   await Promise.all(ids.map(async id => {
     try {
-      await browser.tabs.discard(id);
+      await unloadTab(id);
       await browser.runtime.sendMessage({ type: 'unmarkVisited', tabId: id });
     } catch (_) {}
   }));
@@ -1480,7 +1484,7 @@ async function bulkUnloadAll() {
   const tabs = await browser.tabs.query({});
   await Promise.all(tabs.map(async t => {
     try {
-      await browser.tabs.discard(t.id);
+      await unloadTab(t.id);
     } catch (_) {}
   }));
   await browser.runtime.sendMessage({ type: 'clearVisitHistory' });


### PR DESCRIPTION
## Summary
- remove the discard fallback from the unload helper
- call the native browser.tabs.unload API from both background and popup scripts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690777a30bac83319c7e4455a3b324b2